### PR TITLE
Add Slack notification if PR validation job fails in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  slack: circleci/slack@4.4.4
 jobs:
   validate_code:
     macos:
@@ -41,6 +43,10 @@ jobs:
           path: output
       - store_test_results:
           path: output/scan
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          channel: team-mobile-bots
 workflows:
   version: 2
   pr_validation:
@@ -50,3 +56,5 @@ workflows:
             branches:
               ignore:
                 - main
+          context:
+            - Appcues


### PR DESCRIPTION
Added Slack app and updated CI settings as described here https://circleci.com/blog/circleci-slack-integration/

Also updated our project settings to only build PRs.

As other workflows/jobs are built and get mature to the level we don't expect failure, we can add similar Slack notify as desired.