### PR TITLE
Add floating debug view

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -17,6 +17,7 @@ public class Appcues {
 
     lazy var networking = Networking(config: config)
     lazy var flowRenderer = FlowRenderer(config: config, styleLoader: StyleLoader(networking: self.networking))
+    lazy var uiDebugger = UIDebugger(config: config)
 
     /// Creates an instance of Appcues analytics.
     /// - Parameter config: `Config` object for this instance.
@@ -118,5 +119,10 @@ public class Appcues {
         components.host = Bundle.main.bundleIdentifier
         components.path = "/" + screenName.asURLSlug
         return components.string
+    }
+
+    /// Launches the Appcues debugger over your app's UI.
+    public func debug() {
+        uiDebugger.show()
     }
 }

--- a/Sources/AppcuesKit/Debugger/FloatingView/DebugUIWindow.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DebugUIWindow.swift
@@ -1,0 +1,29 @@
+//
+//  DebugUIWindow.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal class DebugUIWindow: UIWindow {
+
+    init(windowScene: UIWindowScene, rootViewController: UIViewController) {
+        super.init(windowScene: windowScene)
+
+        self.rootViewController = rootViewController
+        windowLevel = .statusBar
+        isHidden = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        return rootViewController?.view.hitTest(point, with: event)
+    }
+}

--- a/Sources/AppcuesKit/Debugger/FloatingView/DebugView+GestureCalculator.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DebugView+GestureCalculator.swift
@@ -1,0 +1,117 @@
+//
+//  DebugView+GestureCalculator.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+
+// swiftlint:disable identifier_name
+
+extension DebugView {
+    struct GestureCalculator {
+        /// Calculate a scaled damping value from an initial magnitude.
+        func dynamicDamping(magnitude x: CGFloat) -> CGFloat {
+            let x = min(x, 5_000)
+            // Return scaled values between 0.4 and 0.85
+            return 1 - ((0.6 - 0.15) * (x - 100) / (5_000 - 100) + 0.15)
+        }
+
+        /// Distance traveled after decelerating to zero velocity at a constant rate.
+        func project(initialVelocity: CGFloat) -> CGFloat {
+            let decelerationRate = UIScrollView.DecelerationRate.normal.rawValue
+            return (initialVelocity / 1_000) * decelerationRate / (1 - decelerationRate)
+        }
+
+        /// Calculates the relative velocity needed for the initial velocity of the animation.
+        func relativeVelocity(forVelocity velocity: CGFloat, from currentValue: CGFloat, to targetValue: CGFloat) -> CGFloat {
+            guard currentValue - targetValue != 0 else { return 0 }
+            return velocity / (targetValue - currentValue)
+        }
+
+        /// Calculates an point on the provided rect based on the initial and projected points.
+        func restingPoint(from initial: CGPoint, to projected: CGPoint, within rect: CGRect) -> CGPoint {
+            var pt: CGPoint
+
+            if !rect.contains(initial) {
+                pt = restingPoint(outOfBounds: initial, within: rect)
+            } else if initial.distance(from: projected) < 500 {
+                pt = restingPoint(lowVelocity: initial, within: rect)
+            } else {
+                let angle = atan2(projected.y - initial.y, projected.x - initial.x)
+                let dx = cos(angle)
+                let dy = sin(angle)
+
+                // Add rect.min to each to account for CGRect where x,y != 0
+                var t1 = (rect.width + rect.minX - initial.x) / dx
+                var t2 = (rect.height + rect.minY - initial.y) / dy
+                var t3 = (rect.minX - initial.x) / dx
+                var t4 = (rect.minY - initial.y) / dy
+
+                if t1 <= 0 {
+                    t1 = CGFloat.greatestFiniteMagnitude
+                }
+                if t2 <= 0 {
+                    t2 = CGFloat.greatestFiniteMagnitude
+                }
+                if t3 <= 0 {
+                    t3 = CGFloat.greatestFiniteMagnitude
+                }
+                if t4 <= 0 {
+                    t4 = CGFloat.greatestFiniteMagnitude
+                }
+
+                let t = min(t1, t2, t3, t4)
+
+                pt = CGPoint(x: initial.x + t * dx, y: initial.y + t * dy)
+            }
+
+            // If we're intersecting along the top or the bottom, instead snap to the nearest vertical edge
+            if pt.y == rect.minY || pt.y == rect.maxY {
+                if pt.x < rect.midX {
+                    pt.x = rect.minX
+                } else {
+                    pt.x = rect.maxX
+                }
+            }
+
+            return pt
+        }
+
+        private func restingPoint(outOfBounds initial: CGPoint, within rect: CGRect) -> CGPoint {
+            var pt = CGPoint(x: initial.x, y: initial.y)
+
+            // Handle initial point outside of the bound rect
+            // Just snap the out-of-bounds value(s) to the rect edges
+            if initial.x < rect.minX {
+                pt.x = rect.minX
+            }
+            if initial.x > rect.maxX {
+                pt.x = rect.maxX
+            }
+            if initial.y < rect.minY {
+                pt.y = rect.minY
+            }
+            if initial.y > rect.maxY {
+                pt.y = rect.maxY
+            }
+
+            return pt
+        }
+
+        private func restingPoint(lowVelocity initial: CGPoint, within rect: CGRect) -> CGPoint {
+            var pt = CGPoint(x: initial.x, y: initial.y)
+
+            // If there's not enough velocity, snap straight to nearest edge
+            if initial.x < rect.midX {
+                pt.x = rect.minX
+            } else {
+                pt.x = rect.maxX
+            }
+
+            return pt
+        }
+    }
+}

--- a/Sources/AppcuesKit/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DebugViewController.swift
@@ -1,0 +1,58 @@
+//
+//  DebugViewController.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal class DebugViewController: UIViewController {
+
+    private var debugView = DebugView()
+
+    private let panelViewController: UIViewController
+
+    init(wrapping panelViewController: UIViewController, dismissHandler: @escaping () -> Void) {
+        self.panelViewController = panelViewController
+        super.init(nibName: nil, bundle: nil)
+
+        debugView.didDismiss = dismissHandler
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = debugView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addChild(panelViewController)
+        debugView.panelWrapperView.addSubview(panelViewController.view)
+        panelViewController.didMove(toParent: self)
+
+        panelViewController.view.pin(to: debugView.panelWrapperView)
+    }
+
+    func show(animated: Bool) {
+        debugView.setFloatingView(visible: true, animated: animated, programmatically: true)
+    }
+
+    func hide(animated: Bool) {
+        debugView.setFloatingView(visible: false, animated: animated, programmatically: true)
+    }
+
+    func open(animated: Bool) {
+        debugView.setPanelInterface(open: true, animated: animated, programatically: true)
+    }
+
+    func close(animated: Bool) {
+        debugView.setPanelInterface(open: false, animated: animated, programatically: true)
+    }
+}

--- a/Sources/AppcuesKit/Debugger/FloatingView/DismissDropZoneView.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DismissDropZoneView.swift
@@ -1,0 +1,92 @@
+//
+//  DismissDropZoneView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal class DismissDropZoneView: UIView {
+
+    /// Distance from the snapPoint at which the floating view locks to the snapPoint.
+    let snapRange: CGFloat = 100
+
+    var snapPoint: CGPoint { convert(imageView.center, to: superview) }
+
+    lazy var imageView: UIImageView = {
+        let image = UIImage(systemName: "xmark.circle", withConfiguration: UIImage.SymbolConfiguration(pointSize: 64))
+        let imageView = UIImageView(image: image)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = .white
+        return imageView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = .clear
+
+        addSubview(imageView)
+
+        let nonSafeAreaHeight: CGFloat = 100
+
+        NSLayoutConstraint.activate([
+            imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            // vertically centered in the non-safe-area space
+            imageView.centerYAnchor.constraint(equalTo: topAnchor, constant: nonSafeAreaHeight / 2),
+            // set the height from the safe area
+            topAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -nonSafeAreaHeight)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+
+        guard let ctx = UIGraphicsGetCurrentContext() else { return }
+
+        let space = CGColorSpaceCreateDeviceRGB()
+        let colors: [CGColor] = [
+            UIColor(white: 0.1, alpha: 1.0).cgColor,
+            UIColor(white: 0.0, alpha: 0.0).cgColor
+        ]
+        let locations: [CGFloat] = [0, 1]
+
+        guard let gradient = CGGradient(colorsSpace: space, colors: colors as CFArray, locations: locations) else { return }
+
+        let width = rect.width
+
+        ctx.drawRadialGradient(
+            gradient,
+            startCenter: CGPoint(x: width / 2, y: width),
+            startRadius: width / 2,
+            endCenter: CGPoint(x: width / 2, y: width * 2),
+            endRadius: width * 2,
+            options: []
+        )
+    }
+
+    func animateVisibility(visible isVisible: Bool, animated: Bool) {
+        let animations: () -> Void = {
+            self.alpha = isVisible ? 1 : 0
+            self.imageView.transform = isVisible ? CGAffineTransform(scaleX: 1, y: 1) : CGAffineTransform(scaleX: 0.001, y: 0.001)
+        }
+
+        if animated {
+            UIView.animate(
+                withDuration: 0.3,
+                animations: animations,
+                completion: nil
+            )
+        } else {
+            animations()
+        }
+    }
+}

--- a/Sources/AppcuesKit/Debugger/FloatingView/FloatingView.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/FloatingView.swift
@@ -1,0 +1,135 @@
+//
+//  FloatingView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal class FloatingView: UIView {
+
+    private let tapRecognizer = UITapGestureRecognizer()
+
+    var onViewActivated: (() -> Void)?
+
+    lazy var imageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "command.circle.fill"))
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.backgroundColor = .secondarySystemBackground
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        accessibilityLabel = "Appcues Debug Panel"
+
+        addSubview(imageView)
+        imageView.pin(to: self)
+
+        addGestureRecognizer(tapRecognizer)
+        tapRecognizer.addTarget(self, action: #selector(viewTapped))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // Round the self corners for a nice automatic accessibility path,
+        // but don't clip since that would obscure the unread indicator.
+        layer.cornerRadius = frame.width / 2
+        // Clipping the imageView is ok though.
+        imageView.layer.cornerRadius = frame.width / 2
+    }
+
+    @objc
+    private func viewTapped(recognizer: UITapGestureRecognizer) {
+        onViewActivated?()
+    }
+
+    func animatePosition(to point: CGPoint, animated: Bool = true, haptics: Bool = true) {
+        let animations: () -> Void = {
+            self.center = point
+        }
+
+        if haptics {
+            let generator = UIImpactFeedbackGenerator(style: .medium)
+            generator.impactOccurred()
+        }
+
+        if animated {
+            UIView.animate(
+                withDuration: 0.7,
+                delay: 0,
+                usingSpringWithDamping: 0.8,
+                initialSpringVelocity: 0,
+                animations: animations,
+                completion: nil
+            )
+        } else {
+            animations()
+        }
+    }
+
+    func animateSnap(to point: CGPoint, animated: Bool = true, haptics: Bool = true) {
+        let animations: () -> Void = {
+            self.center = point
+        }
+
+        if haptics {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+        }
+
+        if animated {
+            let timing = UISpringTimingParameters(
+                damping: 0.6,
+                response: 0.25,
+                initialVelocity: CGVector.zero
+            )
+            let animator = UIViewPropertyAnimator(duration: 0, timingParameters: timing)
+            animator.addAnimations(animations)
+            animator.startAnimation()
+        } else {
+            animations()
+        }
+    }
+
+    func animateVisibility(visible isVisible: Bool, animated: Bool, haptics: Bool, completion: (() -> Void)? = nil) {
+        let animations: () -> Void = {
+            self.alpha = isVisible ? 1 : 0
+            self.transform = isVisible ? CGAffineTransform(scaleX: 1, y: 1) : CGAffineTransform(scaleX: 0.001, y: 0.001)
+        }
+
+        let completion: (Bool) -> Void = { _ in
+            completion?()
+        }
+
+        if animated {
+            UIView.animate(
+                withDuration: 0.4,
+                animations: animations,
+                completion: completion
+            )
+        } else {
+            animations()
+            completion(true)
+        }
+    }
+
+    // MARK: Accessibility
+
+    override func accessibilityActivate() -> Bool {
+        onViewActivated?()
+        return onViewActivated != nil
+    }
+}

--- a/Sources/AppcuesKit/Debugger/FloatingView/UISpringTimingParameters+Custom.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/UISpringTimingParameters+Custom.swift
@@ -1,0 +1,33 @@
+//
+//  UISpringTimingParameters+Custom.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+import CoreGraphics
+
+extension UISpringTimingParameters {
+
+    /// A design-friendly way to create a spring timing curve.
+    ///
+    /// - Parameters:
+    ///   - damping: The 'bounciness' of the animation. Value must be between 0 and 1.
+    ///   - response: The 'speed' of the animation.
+    ///   - initialVelocity: The vector describing the starting motion of the property. Optional, default is `.zero`.
+    convenience init(damping: CGFloat, response: CGFloat, initialVelocity: CGVector = .zero) {
+        let stiffness = pow(2 * .pi / response, 2)
+        let damp = 4 * .pi * damping / response
+        self.init(mass: 1, stiffness: stiffness, damping: damp, initialVelocity: initialVelocity)
+    }
+}
+
+extension CGPoint {
+    func distance(from pt2: CGPoint) -> CGFloat {
+        let xDist: CGFloat = pt2.x - x
+        let yDist: CGFloat = pt2.y - y
+        return sqrt((xDist * xDist) + (yDist * yDist))
+    }
+}

--- a/Sources/AppcuesKit/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Debugger/UIDebugger.swift
@@ -1,0 +1,38 @@
+//
+//  UIDebugger.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal class UIDebugger {
+    private var debugWindow: UIWindow?
+
+    let config: Appcues.Config
+
+    init(config: Appcues.Config) {
+        self.config = config
+    }
+
+    func show() {
+        guard debugWindow == nil else { return }
+        guard let windowScene = UIApplication.shared.activeWindowScenes.first else {
+            config.logger.error("Could not open debugger")
+            return
+        }
+
+        let panelViewController = UIViewController()
+        panelViewController.view.backgroundColor = .secondarySystemBackground
+
+        let rootViewController = DebugViewController(wrapping: panelViewController, dismissHandler: hide)
+        debugWindow = DebugUIWindow(windowScene: windowScene, rootViewController: rootViewController)
+    }
+
+    func hide() {
+        debugWindow?.isHidden = true
+        debugWindow = nil
+    }
+}

--- a/Sources/AppcuesKit/UI/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/UI/Extensions/UIApplication+TopViewController.swift
@@ -10,12 +10,17 @@ import UIKit
 
 extension UIApplication {
 
+    var activeWindowScenes: [UIWindowScene] {
+        self.connectedScenes
+            .filter { $0.activationState == .foregroundActive }
+            .compactMap { $0 as? UIWindowScene }
+    }
+
     // Note: multitasking with two instances of the same app side by side will have both designated as `.foregroundActive`,
     // and as a result the returned window may not be the one expected.
     private var activeKeyWindow: UIWindow? {
-        self.connectedScenes
-            .filter { $0.activationState == .foregroundActive }
-            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+        self.activeWindowScenes
+            .flatMap { $0.windows }
             .first { $0.isKeyWindow }
     }
 

--- a/Sources/AppcuesKit/UI/Extensions/UIView+Constrain.swift
+++ b/Sources/AppcuesKit/UI/Extensions/UIView+Constrain.swift
@@ -1,0 +1,23 @@
+//
+//  DebugView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-10-25.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+     func pin(to view: UIView) {
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            self.topAnchor.constraint(equalTo: view.topAnchor),
+            self.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            self.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            self.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}


### PR DESCRIPTION
### Overview

So this is a lot of code all at once because it's based off a personal project from a couple years ago. At a high level, we can now call `appcues.debug()` which will add a window with the floating button shown below.

`UIDebugger` owns all the debugging functionality (including the window), and is lazily initialized to avoid unnecessary overhead.

`UIDebugger` creates a `DebugUIWindow` which covers other windows and ignores touches that aren't specifically in it's subviews, allowing them to pass through to the main window.

`DebugUIWindow` has a root view controller of `DebugViewController` which has a `DebugView` where all the magic happens. `DebugViewController` is a container view controller for some other controller which I didn't build as part of this PR, so right now the debug panel opens to an empty screen.

`DebugView` owns the `FloatingView` which is the icon you can drag around the screen. There's also `DismissDropZoneView` which the `FloatingView` can interact with when dragging.

The vast majority of the code in this PR is to handle the pan gesture and related animations. There's lots of magic numbers scattered throughout because of the nature of getting animations to "feel right" but where values are related, I've tried to link them.

### Interactions

The interactions are fine-tuned to prioritize feeling fun and lightweight. Haptic feedback adds a bit of tangibility to the experience.

1. Tap the floating view top open/close the debug panel
1. Drag the floating view around the screen and "dock" it along the left or right edge.
1. Fling the floating view and have it bounce into place.
1. Drag the floating view near the dismiss zone (which appears after a brief wait) and have it snap to the dismiss view. Drag away from the dismiss zone and have the floating view snap back to following the drag gesture.
1. End the drag gesture in the dismiss zone and have the whole debug interface disappear.
1. Drag the floating view while the debug panel is open to close the debug panel.
1. Trigger the floating view with VoiceOver (and ensure focus gets locked in the debug panel.

### Preview

https://user-images.githubusercontent.com/845681/139112470-609c5c59-ebfc-41fd-a1b0-f7b1449bc301.mp4

### Next

1. Set up a proper resource bundle to load an Appcues icon instead of the ⌘ symbol.
1. Show some debug content in the empty panel (will build using SwiftUI).
1. Add a button into the example app to trigger the debugger.
1. URL scheme deep link to trigger the debugger.