### PR TITLE
Update file comments to use AppcuesKit package name

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -1,6 +1,6 @@
 //
 //  Appcues+Config.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -1,6 +1,6 @@
 //
 //  Appcues.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-06.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Extensions/HTTPURLResponse+Custom.swift
+++ b/Sources/AppcuesKit/Extensions/HTTPURLResponse+Custom.swift
@@ -1,6 +1,6 @@
 //
 //  HTTPURLResponse+Custom.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-12.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Extensions/String+Format.swift
+++ b/Sources/AppcuesKit/Extensions/String+Format.swift
@@ -1,6 +1,6 @@
 //
 //  String+Format.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-12.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Logging/OSLog+Convenience.swift
+++ b/Sources/AppcuesKit/Logging/OSLog+Convenience.swift
@@ -1,6 +1,6 @@
 //
 //  OSLog+Convenience.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Activity.swift
+++ b/Sources/AppcuesKit/Models/Activity.swift
@@ -1,6 +1,6 @@
 //
 //  Activity.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-07.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Event.swift
+++ b/Sources/AppcuesKit/Models/Event.swift
@@ -1,6 +1,6 @@
 //
 //  Event.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-07.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Flow.swift
+++ b/Sources/AppcuesKit/Models/Flow.swift
@@ -1,6 +1,6 @@
 //
 //  Flow.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Flow/ActionGroup.swift
+++ b/Sources/AppcuesKit/Models/Flow/ActionGroup.swift
@@ -1,6 +1,6 @@
 //
 //  ActionGroup.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Flow/HotspotGroup.swift
+++ b/Sources/AppcuesKit/Models/Flow/HotspotGroup.swift
@@ -1,6 +1,6 @@
 //
 //  HotspotGroup.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Flow/ModalGroup.Pattern+UI.swift
+++ b/Sources/AppcuesKit/Models/Flow/ModalGroup.Pattern+UI.swift
@@ -1,6 +1,6 @@
 //
 //  ModalGroup.Pattern+UI.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Flow/ModalGroup.swift
+++ b/Sources/AppcuesKit/Models/Flow/ModalGroup.swift
@@ -1,6 +1,6 @@
 //
 //  ModalGroup.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Flow/StepGroup.swift
+++ b/Sources/AppcuesKit/Models/Flow/StepGroup.swift
@@ -1,6 +1,6 @@
 //
 //  StepGroup.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Models/Taco.swift
+++ b/Sources/AppcuesKit/Models/Taco.swift
@@ -1,6 +1,6 @@
 //
 //  Taco.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Networking/JSONCodingKeys.swift
+++ b/Sources/AppcuesKit/Networking/JSONCodingKeys.swift
@@ -1,6 +1,6 @@
 //
 //  JSONCodingKeys.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Networking/Networking+Endpoint.swift
+++ b/Sources/AppcuesKit/Networking/Networking+Endpoint.swift
@@ -1,6 +1,6 @@
 //
 //  Networking+Endpoint.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Networking/Networking.swift
+++ b/Sources/AppcuesKit/Networking/Networking.swift
@@ -1,6 +1,6 @@
 //
 //  Networking.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-07.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Networking/NetworkingError.swift
+++ b/Sources/AppcuesKit/Networking/NetworkingError.swift
@@ -1,6 +1,6 @@
 //
 //  NetworkingError.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/Networking/StyleLoader.swift
+++ b/Sources/AppcuesKit/Networking/StyleLoader.swift
@@ -1,6 +1,6 @@
 //
 //  StyleLoader.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/UI/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/UI/ExperienceRenderer.swift
@@ -1,6 +1,6 @@
 //
 //  ExperienceRenderer.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-20.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/UI/Extensions/NSCollectionLayoutSection+Factory.swift
+++ b/Sources/AppcuesKit/UI/Extensions/NSCollectionLayoutSection+Factory.swift
@@ -1,6 +1,6 @@
 //
 //  NSCollectionLayoutSection+Factory.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/UI/Extensions/ReusableView.swift
+++ b/Sources/AppcuesKit/UI/Extensions/ReusableView.swift
@@ -1,6 +1,6 @@
 //
 //  ReusableView.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/UI/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/UI/Extensions/UIApplication+TopViewController.swift
@@ -1,6 +1,6 @@
 //
 //  UIApplication+TopViewController.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-14.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/UI/Modals/ModalGroupView.swift
+++ b/Sources/AppcuesKit/UI/Modals/ModalGroupView.swift
@@ -1,6 +1,6 @@
 //
 //  ModalGroupView.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/UI/Modals/ModalGroupViewController.swift
+++ b/Sources/AppcuesKit/UI/Modals/ModalGroupViewController.swift
@@ -1,6 +1,6 @@
 //
 //  ModalGroupViewController.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.

--- a/Sources/AppcuesKit/UI/Modals/WebWrapperCell.swift
+++ b/Sources/AppcuesKit/UI/Modals/WebWrapperCell.swift
@@ -1,6 +1,6 @@
 //
 //  WebWrapperCell.swift
-//  Appcues
+//  AppcuesKit
 //
 //  Created by Matt on 2021-10-15.
 //  Copyright © 2021 Appcues. All rights reserved.


### PR DESCRIPTION
All new source files include our updated package name in the autogenerated header comment

```
// AppcuesKit
```

did a quick replace of any old ones before that transition to update to match.