### PR TITLE
Update experience model to flatten component structure

### DIFF
--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesButton.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesButton.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 internal struct AppcuesButton: View {
-    let id: UUID
     let model: ExperienceComponent.ButtonModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
@@ -25,7 +24,7 @@ internal struct AppcuesButton: View {
             // Otherwise the button tap target seems to small when there's padding/background? Need to investigate.
             Text(model.text)
         }
-        .setupActions(viewModel.groupedActionHandlers(for: id))
+        .setupActions(viewModel.groupedActionHandlers(for: model.id))
         .applyAppcues(layout, style)
     }
 }
@@ -34,7 +33,8 @@ internal struct AppcuesButton: View {
 internal struct AppcuesButtonPreview: PreviewProvider {
     static var previews: some View {
         Group {
-            AppcuesButton(id: UUID(), model: EC.ButtonModel(
+            AppcuesButton(model: EC.ButtonModel(
+                id: UUID(),
                 text: "Default Button",
                 layout: nil,
                 style: nil)
@@ -42,11 +42,11 @@ internal struct AppcuesButtonPreview: PreviewProvider {
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesButton(id: UUID(), model: EC.buttonPrimary)
+            AppcuesButton(model: EC.buttonPrimary)
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesButton(id: UUID(), model: EC.buttonSecondary)
+            AppcuesButton(model: EC.buttonSecondary)
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
         }

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesHStack.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesHStack.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 internal struct AppcuesHStack: View {
-    let id: UUID
     let model: ExperienceComponent.HStackModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
@@ -23,7 +22,7 @@ internal struct AppcuesHStack: View {
                 AnyView($0.view)
             }
         }
-        .setupActions(viewModel.groupedActionHandlers(for: id))
+        .setupActions(viewModel.groupedActionHandlers(for: model.id))
         .applyAppcues(layout, style)
     }
 }
@@ -33,10 +32,11 @@ internal struct AppcuesHStackPreview: PreviewProvider {
 
     static var previews: some View {
         Group {
-            AppcuesHStack(id: UUID(), model: EC.HStackModel(
+            AppcuesHStack(model: EC.HStackModel(
+                id: UUID(),
                 items: [
-                    EC(model: .image(EC.imageSymbol)),
-                    EC(model: .text(EC.textPlain))
+                    .image(EC.imageSymbol),
+                    .text(EC.textPlain)
                 ],
                 layout: nil,
                 style: EC.Style(backgroundColor: "#eee"))

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 internal struct AppcuesImage: View {
-    let id: UUID
     let model: ExperienceComponent.ImageModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
@@ -25,12 +24,12 @@ internal struct AppcuesImage: View {
             .ifLet(ContentMode(string: model.contentMode)) { view, val in
                 view.aspectRatio(contentMode: val)
             }
-            .setupActions(viewModel.groupedActionHandlers(for: id))
+            .setupActions(viewModel.groupedActionHandlers(for: model.id))
             .applyAppcues(layout, style)
             .clipped()
         } else {
             Image(systemName: model.symbolName ?? "")
-                .setupActions(viewModel.groupedActionHandlers(for: id))
+                .setupActions(viewModel.groupedActionHandlers(for: model.id))
                 .applyAppcues(layout, style)
                 .clipped()
         }
@@ -43,15 +42,15 @@ internal struct AppcuesImagePreview: PreviewProvider {
     static let imageURL = URL(string: "https://res.cloudinary.com/dnjrorsut/image/upload/v1513187203/crx-assets/modal-slideout-hero-image.png")!
     static var previews: some View {
         Group {
-            AppcuesImage(id: UUID(), model: EC.imageSymbol)
+            AppcuesImage(model: EC.imageSymbol)
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesImage(id: UUID(), model: EC.imageBanner)
+            AppcuesImage(model: EC.imageBanner)
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesImage(id: UUID(), model: EC.ImageModel(
+            AppcuesImage(model: EC.ImageModel(
                 imageUrl: imageURL,
                 contentMode: "fit",
                 layout: EC.Layout(height: 100, width: 100),

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesPager.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesPager.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 internal struct AppcuesPager: View {
-    let id: UUID
     let model: ExperienceComponent.PagerModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
@@ -24,7 +23,7 @@ internal struct AppcuesPager: View {
             }
         }
         .modifier(PagerViewModifier())
-        .setupActions(viewModel.groupedActionHandlers(for: id))
+        .setupActions(viewModel.groupedActionHandlers(for: model.id))
         .applyAppcues(layout, style)
     }
 
@@ -35,11 +34,12 @@ internal struct AppcuesPagerPreview: PreviewProvider {
 
     static var previews: some View {
         Group {
-            AppcuesPager(id: UUID(), model: EC.PagerModel(
+            AppcuesPager(model: EC.PagerModel(
+                id: UUID(),
                 items: [
-                    EC(model: .vstack(EC.vstackHero)),
-                    EC(model: .vstack(EC.vstackHero)),
-                    EC(model: .vstack(EC.vstackHero))
+                    .vstack(EC.vstackHero),
+                    .vstack(EC.vstackHero),
+                    .vstack(EC.vstackHero)
                 ],
                 layout: nil,
                 style: EC.Style(backgroundColor: "#333"))

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesText.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 internal struct AppcuesText: View {
-    let id: UUID
     let model: ExperienceComponent.TextModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
@@ -25,7 +24,7 @@ internal struct AppcuesText: View {
             .ifLet(style.textAlignment) { view, val in
                 view.multilineTextAlignment(val)
             }
-            .setupActions(viewModel.groupedActionHandlers(for: id))
+            .setupActions(viewModel.groupedActionHandlers(for: model.id))
             .applyAppcues(layout, style)
     }
 }
@@ -34,11 +33,12 @@ internal struct AppcuesText: View {
 internal struct AppcuesTextPreview: PreviewProvider {
     static var previews: some View {
         Group {
-            AppcuesText(id: UUID(), model: EC.textPlain)
+            AppcuesText(model: EC.textPlain)
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesText(id: UUID(), model: EC.TextModel(
+            AppcuesText(model: EC.TextModel(
+                id: UUID(),
                 text: "This is some text that wraps and is center aligned.",
                 layout: EC.Layout(width: 100),
                 style: EC.Style(textAlignment: "center"))
@@ -46,7 +46,8 @@ internal struct AppcuesTextPreview: PreviewProvider {
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesText(id: UUID(), model: EC.TextModel(
+            AppcuesText(model: EC.TextModel(
+                id: UUID(),
                 text: "Heading Sized Text",
                 layout: nil,
                 style: EC.Style(fontSize: 36, foregroundColor: "#f00"))

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesVStack.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesVStack.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 internal struct AppcuesVStack: View {
-    let id: UUID
     let model: ExperienceComponent.VStackModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
@@ -23,7 +22,7 @@ internal struct AppcuesVStack: View {
                 AnyView($0.view)
             }
         }
-        .setupActions(viewModel.groupedActionHandlers(for: id))
+        .setupActions(viewModel.groupedActionHandlers(for: model.id))
         .applyAppcues(layout, style)
     }
 }
@@ -33,11 +32,12 @@ internal struct AppcuesVStackPreview: PreviewProvider {
 
     static var previews: some View {
         Group {
-            AppcuesVStack(id: UUID(), model: EC.VStackModel(
+            AppcuesVStack(model: EC.VStackModel(
+                id: UUID(),
                 items: [
-                    EC(model: .text(EC.textTitle)),
-                    EC(model: .text(EC.textSubtitle)),
-                    EC(model: .button(EC.buttonPrimary))
+                    .text(EC.textTitle),
+                    .text(EC.textSubtitle),
+                    .button(EC.buttonPrimary)
                 ],
                 layout: nil,
                 style: EC.Style(backgroundColor: "#333"))
@@ -45,11 +45,12 @@ internal struct AppcuesVStackPreview: PreviewProvider {
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesVStack(id: UUID(), model: EC.VStackModel(
+            AppcuesVStack(model: EC.VStackModel(
+                id: UUID(),
                 items: [
-                    EC(model: .text(EC.textTitle)),
-                    EC(model: .text(EC.textSubtitle)),
-                    EC(model: .button(EC.buttonPrimary))
+                    .text(EC.textTitle),
+                    .text(EC.textSubtitle),
+                    .button(EC.buttonPrimary)
                 ],
                 layout: EC.Layout(spacing: 48, horizontalAlignment: "leading", paddingTop: 8, paddingLeading: 8, paddingBottom: 8, paddingTrailing: 8),
                 style: EC.Style(backgroundColor: "#333"))

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesZStack.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesZStack.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 internal struct AppcuesZStack: View {
-    let id: UUID
     let model: ExperienceComponent.ZStackModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
@@ -23,7 +22,7 @@ internal struct AppcuesZStack: View {
                 AnyView($0.view)
             }
         }
-        .setupActions(viewModel.groupedActionHandlers(for: id))
+        .setupActions(viewModel.groupedActionHandlers(for: model.id))
         .applyAppcues(layout, style)
     }
 }
@@ -33,14 +32,15 @@ internal struct AppcuesZStackPreview: PreviewProvider {
 
     static var previews: some View {
         Group {
-            AppcuesZStack(id: UUID(), model: EC.zstackHero)
+            AppcuesZStack(model: EC.zstackHero)
                 .previewLayout(PreviewLayout.sizeThatFits)
                 .padding()
 
-            AppcuesZStack(id: UUID(), model: EC.ZStackModel(
+            AppcuesZStack(model: EC.ZStackModel(
+                id: UUID(),
                 items: [
-                    EC(model: .image(EC.imageBanner)),
-                    EC(model: .text(EC.textTitle))
+                    .image(EC.imageBanner),
+                    .text(EC.textTitle)
                 ],
                 layout: EC.Layout(verticalAlignment: "top", horizontalAlignment: "leading"),
                 style: nil)

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+PreviewProvider.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+PreviewProvider.swift
@@ -16,31 +16,37 @@ internal typealias EC = ExperienceComponent
 
 extension ExperienceComponent {
     static let textPlain = EC.TextModel(
+        id: UUID(),
         text: "This is some text with no style provided.",
         layout: nil,
         style: nil)
 
     static let textTitle = EC.TextModel(
+        id: UUID(),
         text: "Hero Title 🚀",
         layout: nil,
         style: EC.Style(fontSize: 36, foregroundColor: "#fff"))
 
     static let textSubtitle = EC.TextModel(
+        id: UUID(),
         text: "To infinity, and beyond!",
         layout: nil,
         style: EC.Style(foregroundColor: "#fff"))
 
     static let buttonPrimary = EC.ButtonModel(
+        id: UUID(),
         text: "Primary Button",
         layout: EC.Layout.button,
         style: EC.Style.primaryButton)
 
     static let buttonSecondary = EC.ButtonModel(
+        id: UUID(),
         text: "Secondary Button",
         layout: EC.Layout.button,
         style: EC.Style.secondaryButton)
 
     static let buttonCallToAction = EC.ButtonModel(
+        id: UUID(),
         text: "Call to Action",
         layout: EC.Layout(paddingTop: 12, paddingLeading: 24, paddingBottom: 12, paddingTrailing: 24, marginTop: 30),
         style: EC.Style.primaryButton)
@@ -57,18 +63,20 @@ extension ExperienceComponent {
         style: nil)
 
     static let vstackHero = EC.VStackModel(
+        id: UUID(),
         items: [
-            EC(model: .text(EC.textTitle)),
-            EC(model: .text(EC.textSubtitle)),
-            EC(model: .button(EC.buttonCallToAction))
+            .text(EC.textTitle),
+            .text(EC.textSubtitle),
+            .button(EC.buttonCallToAction)
         ],
         layout: EC.Layout(spacing: 12),
         style: nil)
 
     static let zstackHero = EC.ZStackModel(
+        id: UUID(),
         items: [
-            EC(model: .image(EC.imageBanner)),
-            EC(model: .vstack(EC.vstackHero))
+            .image(EC.imageBanner),
+            .vstack(EC.vstackHero)
         ],
         layout: nil,
         style: nil)

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+View.swift
@@ -11,21 +11,21 @@ import SwiftUI
 extension ExperienceComponent {
 
     @ViewBuilder var view: some View {
-        switch model {
+        switch self {
         case .pager(let model):
-            AppcuesPager(id: id, model: model)
+            AppcuesPager(model: model)
         case .vstack(let model):
-            AppcuesVStack(id: id, model: model)
+            AppcuesVStack(model: model)
         case .hstack(let model):
-            AppcuesHStack(id: id, model: model)
+            AppcuesHStack(model: model)
         case .zstack(let model):
-            AppcuesZStack(id: id, model: model)
+            AppcuesZStack(model: model)
         case .text(let model):
-            AppcuesText(id: id, model: model)
+            AppcuesText(model: model)
         case .button(let model):
-            AppcuesButton(id: id, model: model)
+            AppcuesButton(model: model)
         case .image(let model):
-            AppcuesImage(id: id, model: model)
+            AppcuesImage(model: model)
         case .spacer(let model):
             Spacer(minLength: CGFloat(model.layout?.spacing))
         }


### PR DESCRIPTION
Implement model changes described in https://github.com/appcues/mobile-experiments/pull/13

One of the nice wins is that we don't have to specifically pass an `id` into every SwiftUI view.