### PR TITLE
Update lifecycle tracking API and examples to initiate lifecycle tracking at startup

### DIFF
--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -15,6 +15,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
+        // to opt-in for standard application lifecycle events, the SDK must be
+        // initialzed and have its trackLifecycle() function called during app startup here
+        Appcues.shared.trackLifecycle()
+
         return true
     }
 

--- a/Examples/DeveloperSPMExample/SPMExample/AppDelegate.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/AppDelegate.swift
@@ -15,6 +15,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
+        // to opt-in for standard application lifecycle events, the SDK must be
+        // initialzed and have its trackLifecycle() function called during app startup here
+        Appcues.shared.trackLifecycle()
+
         return true
     }
 

--- a/Sources/AppcuesKit/Analytics/LifecycleTracking.swift
+++ b/Sources/AppcuesKit/Analytics/LifecycleTracking.swift
@@ -12,10 +12,10 @@ import UIKit
 internal class LifecycleTracking {
 
     enum LifecycleEvents: String {
-        case applicationInstalled = "Application Installed"
-        case applicationOpened = "Application Opened"
-        case applicationUpdated = "Application Updated"
-        case applicationBackgrounded = "Application Backgrounded"
+        case applicationInstalled = "appcues:application_installed"
+        case applicationOpened = "appcues:application_opened"
+        case applicationUpdated = "appcues:application_updated"
+        case applicationBackgrounded = "appcues:application_backgrounded"
     }
 
     private let publisher: AnalyticsPublisher

--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -26,10 +26,6 @@ public extension Appcues {
 
         var logger: OSLog = .disabled
 
-        var trackScreens = false
-
-        var trackLifecycle = false
-
         var anonymousIDFactory: () -> String = {
             UIDevice.identifier
         }
@@ -75,24 +71,6 @@ public extension Appcues {
         @discardableResult
         public func anonymousIDFactory(_ anonymousIDFactory: @escaping () -> String) -> Self {
             self.anonymousIDFactory = anonymousIDFactory
-            return self
-        }
-
-        /// Set the automatic screen tracking status for the configuration.
-        /// - Parameter enabled: Whether automatic screen tracking is enabled.
-        /// - Returns: The `Configuration` object.
-        @discardableResult
-        public func trackScreens(_ enabled: Bool) -> Self {
-            self.trackScreens = enabled
-            return self
-        }
-
-        /// Set the automatic lifecycle tracking status for the configuration.
-        /// - Parameter enabled: Whether automatic lifecycle tracking is enabled.
-        /// - Returns: The `Configuration` object.
-        @discardableResult
-        public func trackLifecycle(_ enabled: Bool) -> Self {
-            self.trackLifecycle = enabled
             return self
         }
     }


### PR DESCRIPTION
Some small changes we discussed around setting up lifecycle tracking
* changed from config option to a function that the host app calls at startup (also related `trackScreens()` function)
* updated lifecycle event names to use `appcues:application_*` "internal" event naming convention.  still TBD how exactly these internal events will work out and, related, how we'll drive "session" based analytics from them.

next - update Segment integration to properly translate the Segment lifecycle events into our own lifecycle events, which should be a simple 1:1 mapping here