### PR TITLE
✨ Add shadow experience style property

### DIFF
--- a/Sources/AppcuesKit/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Models/Experience/ExperienceComponent.swift
@@ -239,6 +239,7 @@ extension ExperienceComponent {
         let foregroundColor: String?
         let backgroundColor: String?
         let backgroundGradient: RawGradient?
+        let shadow: RawShadow?
         let cornerRadius: Double?
         let borderColor: String?
         let borderWidth: Double?
@@ -253,6 +254,7 @@ extension ExperienceComponent {
             foregroundColor: String? = nil,
             backgroundColor: String? = nil,
             backgroundGradient: RawGradient? = nil,
+            shadow: RawShadow? = nil,
             cornerRadius: Double? = nil,
             borderColor: String? = nil,
             borderWidth: Double? = nil
@@ -266,6 +268,7 @@ extension ExperienceComponent {
             self.foregroundColor = foregroundColor
             self.backgroundColor = backgroundColor
             self.backgroundGradient = backgroundGradient
+            self.shadow = shadow
             self.cornerRadius = cornerRadius
             self.borderColor = borderColor
             self.borderWidth = borderWidth
@@ -279,5 +282,14 @@ extension ExperienceComponent.Style {
         let colors: [String]
         let startPoint: String
         let endPoint: String
+    }
+
+    struct RawShadow: Decodable {
+        let color: String
+        let radius: Double
+        // swiftlint:disable:next identifier_name
+        let x: Double
+        // swiftlint:disable:next identifier_name
+        let y: Double
     }
 }

--- a/Sources/AppcuesKit/UI/ExperienceModals/AppcuesStyle.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/AppcuesStyle.swift
@@ -16,6 +16,7 @@ internal struct AppcuesStyle {
     let foregroundColor: Color?
     let backgroundColor: Color?
     let backgroundGradient: LinearGradient?
+    let shadow: ExperienceComponent.Style.RawShadow?
     let cornerRadius: CGFloat?
     let borderColor: Color?
     let borderWidth: CGFloat?
@@ -28,6 +29,7 @@ internal struct AppcuesStyle {
         self.foregroundColor = Color(hex: model?.foregroundColor)
         self.backgroundColor = Color(hex: model?.backgroundColor)
         self.backgroundGradient = LinearGradient(rawGradient: model?.backgroundGradient)
+        self.shadow = model?.shadow
         self.cornerRadius = CGFloat(model?.cornerRadius)
         self.borderColor = Color(hex: model?.borderColor)
         self.borderWidth = CGFloat(model?.borderWidth)

--- a/Sources/AppcuesKit/UI/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/UI/Extensions/View+Appcues.swift
@@ -57,6 +57,13 @@ extension View {
             .ifLet(style.cornerRadius) { view, val in
                 view.cornerRadius(val)
             }
+            .ifLet(style.shadow) { view, val in
+                view.shadow(
+                    color: Color(hex: val.color) ?? Color(.sRGBLinear, white: 0, opacity: 0.33),
+                    radius: val.radius,
+                    x: val.x,
+                    y: val.y)
+            }
     }
 
     func applyBorderStyle(_ style: AppcuesStyle) -> some View {


### PR DESCRIPTION
Likely won't be included in builder v1, but adding support for shadows is easy and gives us backwards compatibility for if/when the builder does add it (or people who want to hack it into the JSON). Will also update the experience spec, but the definition is:

```json
"shadow": {
    "color": "#f00",
    "radius": 10,
    "x": 0,
    "y": 0 
}
```

![Simulator Screen Shot - iPhone 13 Pro - 2021-11-30 at 13 51 08](https://user-images.githubusercontent.com/845681/144109773-55aa2761-ab42-4d04-be9b-3150c66a5079.png)
