### PR TITLE
Rename session event "appcues:session_ended" to "appcues:session_reset"

### DIFF
--- a/Sources/AppcuesKit/Analytics/SessionMonitor.swift
+++ b/Sources/AppcuesKit/Analytics/SessionMonitor.swift
@@ -15,7 +15,7 @@ internal class SessionMonitor {
         case sessionStarted = "appcues:session_started"
         case sessionSuspended = "appcues:session_suspended"
         case sessionResumed = "appcues:session_resumed"
-        case sessionEnded = "appcues:session_ended"
+        case sessionReset = "appcues:session_reset"
     }
 
     private let storage: Storage
@@ -55,8 +55,8 @@ internal class SessionMonitor {
     }
 
     // called on reset(), user sign-out
-    func end() {
-        publisher.track(SessionEvents.sessionEnded)
+    func reset() {
+        publisher.track(SessionEvents.sessionReset)
         sessionID = nil
     }
 

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -67,7 +67,7 @@ public class Appcues {
     /// Clears out the current user in this session.  Can be used when the user logs out of your application.
     public func reset() {
         // call this first to close final analytics on the session
-        sessionMonitor.end()
+        sessionMonitor.reset()
 
         storage.userID = ""
         storage.isAnonymous = true

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -42,7 +42,7 @@ class AppcuesTests: XCTestCase {
         appcues.screen(title: "My test page", properties: ["my_key":"my_value", "another_key": 33])            //not tracked
         appcues.anonymous()                                                                                    //tracked - user (+1 session start)
         appcues.screen(title: "My test page", properties: ["my_key":"my_value", "another_key": 33])            //tracked - screen
-        appcues.reset()                                                                                        //reset (+1 session end)
+        appcues.reset()                                                                                        //reset (+1 session reset)
         appcues.screen(title: "My test page", properties: ["my_key":"my_value", "another_key": 33])            //not tracked
         appcues.identify(userID: "specific-user-id", properties: ["my_key":"my_value", "another_key": 33])     //tracked - user (+1 session start)
         appcues.screen(title: "My test page", properties: ["my_key":"my_value", "another_key": 33])            //tracked - screen


### PR DESCRIPTION
minor naming improvement suggested in tech proposal review