### PR TITLE
Add intrinsicSize to image placeholder sizing and fix image clipping

### DIFF
--- a/Sources/AppcuesKit/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Models/Experience/ExperienceComponent.swift
@@ -140,20 +140,28 @@ extension ExperienceComponent {
     }
 
     struct ImageModel: ComponentModel, Decodable {
+
+        struct IntrinsicSize: Decodable {
+            let width: Double
+            let height: Double
+        }
+
         let id: UUID
         let imageUrl: URL?
         // Not sure if we'd support this in the builder, but it's handy for previews
         let symbolName: String?
         let contentMode: String?
+        let intrinsicSize: IntrinsicSize?
 
         let style: Style?
 
         /// URL init
-        internal init(imageUrl: URL?, contentMode: String?, style: ExperienceComponent.Style?) {
+        internal init(imageUrl: URL?, contentMode: String?, intrinsicSize: IntrinsicSize?, style: ExperienceComponent.Style?) {
             self.id = UUID()
             self.imageUrl = imageUrl
             self.symbolName = nil
             self.contentMode = contentMode
+            self.intrinsicSize = intrinsicSize
             self.style = style
         }
 
@@ -163,6 +171,7 @@ extension ExperienceComponent {
             self.imageUrl = nil
             self.symbolName = symbolName
             self.contentMode = "fit"
+            self.intrinsicSize = nil
             self.style = style
         }
 

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
@@ -21,12 +21,18 @@ internal struct AppcuesImage: View {
             RemoteImage(url: url, cache: imageCache) {
                 style.backgroundColor ?? Color(UIColor.secondarySystemBackground)
             }
-            .ifLet(ContentMode(string: model.contentMode)) { view, val in
-                view.aspectRatio(contentMode: val)
-            }
-            .clipped()
             .setupActions(viewModel.groupedActionHandlers(for: model.id))
-            .applyAllAppcues(style)
+            .applyForegroundStyle(style)
+            // set the aspect ratio before applying frame sizing
+            .ifLet(ContentMode(string: model.contentMode)) { view, val in
+                view.aspectRatio(model.intrinsicSize?.aspectRatio, contentMode: val)
+            }
+            .applyInternalLayout(style)
+            // clip before adding shadows
+            .clipped()
+            .applyBackgroundStyle(style)
+            .applyBorderStyle(style)
+            .applyExternalLayout(style)
         } else {
             Image(systemName: model.symbolName ?? "")
                 .clipped()
@@ -53,6 +59,7 @@ internal struct AppcuesImagePreview: PreviewProvider {
             AppcuesImage(model: EC.ImageModel(
                 imageUrl: imageURL,
                 contentMode: "fit",
+                intrinsicSize: EC.ImageModel.IntrinsicSize(width: 1_920, height: 1_280),
                 style: EC.Style(height: 100, width: 100, backgroundColor: "#eee"))
             )
                 .previewLayout(PreviewLayout.sizeThatFits)

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/RemoteImage.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/RemoteImage.swift
@@ -60,18 +60,12 @@ internal struct RemoteImage<Placeholder: View>: View {
     private let placeholder: Placeholder
 
     var body: some View {
-        content
-            .onAppear(perform: loader.load)
-    }
-
-    private var content: some View {
-        Group {
-            if let image = loader.image {
-                Image(uiImage: image)
-                    .resizable()
-            } else {
-                placeholder
-            }
+        if let image = loader.image {
+            Image(uiImage: image)
+                .resizable()
+        } else {
+            placeholder
+                .onAppear(perform: loader.load)
         }
     }
 

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+PreviewProvider.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+PreviewProvider.swift
@@ -52,6 +52,7 @@ extension ExperienceComponent {
     static let imageBanner = ExperienceComponent.ImageModel(
         imageUrl: AppcuesImagePreview.imageURL,
         contentMode: "fill",
+        intrinsicSize: ImageModel.IntrinsicSize(width: 1_920, height: 1_280),
         style: ExperienceComponent.Style(height: 300, width: 370))
 
     static let vstackHero = EC.StackModel(

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+View.swift
@@ -29,3 +29,9 @@ extension ExperienceComponent {
         }
     }
 }
+
+extension ExperienceComponent.ImageModel.IntrinsicSize {
+    var aspectRatio: CGFloat {
+        width / height
+    }
+}


### PR DESCRIPTION
Continuing to make image sizing better... Intrinsic size is used when provided to size the placeholder until the image is loaded which lets us avoid the layout jumping.

I fiddled with the order of modifiers for image frames and clipping to get it to properly crop images. Here's an example from one of the chaos specs:

|Before|After|
|-|-|
|![reference_1_FADB79BF-7A03-492A-A450-FF50272873AD](https://user-images.githubusercontent.com/845681/145462171-d1cefbbe-53d3-4735-8ed7-c225d17e7a64.png)|![failure_2_FADB79BF-7A03-492A-A450-FF50272873AD](https://user-images.githubusercontent.com/845681/145462179-96d9efbf-cc5c-4ff6-964f-8e76107f0d66.png)|

Snapshot tests for the contentMode changes are here:
- https://github.com/appcues/appcues-mobile-experience-spec/pull/9