### PR TITLE
Reset stored Group when User changes

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -210,6 +210,9 @@ public class Appcues {
         if userChanged {
             // when the idenfied use changes from last known value, we must start a new session
             sessionMonitor.start()
+
+            // and clear any stored group information - will have to be reset as needed
+            storage.groupID = nil
         }
         publish(TrackingUpdate(type: .profile, properties: properties))
     }


### PR DESCRIPTION
One-liner, but this came to mind and I think is a more technically correct approach to handling groups when the user changes.  We already handle clearing the group in the `reset()` call.