### PR TITLE
Add support for animated gifs as mp4s

### DIFF
--- a/Sources/AppcuesKit/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Models/Experience/ExperienceComponent.swift
@@ -148,6 +148,9 @@ extension ExperienceComponent {
 
         let id: UUID
         let imageUrl: URL?
+        // Used to flag an animated gif
+        // swiftlint:disable:next discouraged_optional_boolean
+        let animated: Bool?
         // Not sure if we'd support this in the builder, but it's handy for previews
         let symbolName: String?
         let contentMode: String?
@@ -159,6 +162,7 @@ extension ExperienceComponent {
         internal init(imageUrl: URL?, contentMode: String?, intrinsicSize: IntrinsicSize?, style: ExperienceComponent.Style?) {
             self.id = UUID()
             self.imageUrl = imageUrl
+            self.animated = nil
             self.symbolName = nil
             self.contentMode = contentMode
             self.intrinsicSize = intrinsicSize
@@ -169,6 +173,7 @@ extension ExperienceComponent {
         internal init(symbolName: String?, style: ExperienceComponent.Style?) {
             self.id = UUID()
             self.imageUrl = nil
+            self.animated = nil
             self.symbolName = symbolName
             self.contentMode = "fit"
             self.intrinsicSize = nil

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
@@ -17,10 +17,7 @@ internal struct AppcuesImage: View {
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 
-        if let url = model.imageUrl {
-            RemoteImage(url: url, cache: imageCache) {
-                style.backgroundColor ?? Color(UIColor.secondarySystemBackground)
-            }
+        content(placeholder: style.backgroundColor)
             .setupActions(viewModel.groupedActionHandlers(for: model.id))
             .applyForegroundStyle(style)
             // set the aspect ratio before applying frame sizing
@@ -33,11 +30,18 @@ internal struct AppcuesImage: View {
             .applyBackgroundStyle(style)
             .applyBorderStyle(style)
             .applyExternalLayout(style)
+    }
+
+    @ViewBuilder
+    private func content(placeholder: Color?) -> some View {
+        if let url = model.imageUrl {
+            if model.animated == true, let videoURL = url.toMP4() {
+                LoopingVideoPlayer(url: videoURL)
+            } else {
+                RemoteImage(url: url, cache: imageCache) { placeholder ?? Color(UIColor.secondarySystemBackground) }
+            }
         } else {
             Image(systemName: model.symbolName ?? "")
-                .clipped()
-                .setupActions(viewModel.groupedActionHandlers(for: model.id))
-                .applyAllAppcues(style)
         }
     }
 }

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/LoopingVideoPlayer.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/LoopingVideoPlayer.swift
@@ -1,0 +1,65 @@
+//
+//  LoopingVideoPlayer.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-12-14.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import SwiftUI
+import AVKit
+
+internal struct LoopingVideoPlayer {
+    let url: URL
+}
+
+extension LoopingVideoPlayer: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> LoopingVideoView {
+        LoopingVideoView(url: url)
+    }
+
+    func updateUIView(_ uiView: LoopingVideoView, context: Context) {
+        // nothing to update, the content is constant
+    }
+}
+
+extension LoopingVideoPlayer {
+    class LoopingVideoView: UIView {
+
+        private static let key = "playable"
+        // Using AVPlayerLayer as our standard layer makes this a AVPlayer compatible view
+        override static var layerClass: AnyClass { AVPlayerLayer.self }
+
+        private var playerLayer: AVPlayerLayer? { layer as? AVPlayerLayer }
+        // need to retain a reference
+        private var looper: AVPlayerLooper?
+
+        init(url: URL) {
+            super.init(frame: .zero)
+
+            let asset = AVAsset(url: url)
+            asset.loadValuesAsynchronously(forKeys: [LoopingVideoView.key]) { [weak self] in
+                var error: NSError?
+                let status = asset.statusOfValue(forKey: LoopingVideoView.key, error: &error)
+                if case .loaded = status {
+                    self?.playLoopingAsset(with: asset)
+                }
+            }
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        private func playLoopingAsset(with asset: AVAsset) {
+            DispatchQueue.main.async { [weak self] in
+                let queuePlayer = AVQueuePlayer()
+                self?.playerLayer?.player = queuePlayer
+                self?.looper = AVPlayerLooper(player: queuePlayer, templateItem: AVPlayerItem(asset: asset))
+                queuePlayer.play()
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/UI/Extensions/URL+Cloudinary.swift
+++ b/Sources/AppcuesKit/UI/Extensions/URL+Cloudinary.swift
@@ -1,0 +1,26 @@
+//
+//  URL+Cloudinary.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2021-12-14.
+//  Copyright © 2021 Appcues. All rights reserved.
+//
+
+import Foundation
+
+extension URL {
+    /// Map a url with any file extension to one with a `.mp4` file extension.
+    ///
+    /// This supports a behaviour that's specific to Cloudinary.
+    func toMP4() -> URL? {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }
+
+        // Find and replace the last occurance of ".ext" in the path
+        let options: String.CompareOptions = [.backwards, .caseInsensitive]
+        if let range = components.path.range(of: ".\(pathExtension)", options: options, range: nil, locale: nil) {
+            components.path = components.path.replacingCharacters(in: range, with: ".mp4")
+        }
+
+        return components.url
+    }
+}


### PR DESCRIPTION
Turns out to be pretty simple. The AppcuesImage component has a few changes to reduce the repetition of applying the styling. The `URL` extension converts the file extension to mp4 (while trying as best as possible to avoid inadvertently modifying other parts of the url, say, in if the file name or domain happened to have `gif` in it.

And there's another optional Bool with `let animated: Bool?` 😬. This is the second one for mapping from the experience JSON. Starting to lean towards custom decoders even if they mean a ton of boilerplate...