### PR TITLE
Update example apps to indicate they don't use encryption

### DIFF
--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/Info.plist
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/Info.plist
@@ -33,6 +33,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>3</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Examples/DeveloperSPMExample/SPMExample/Info.plist
+++ b/Examples/DeveloperSPMExample/SPMExample/Info.plist
@@ -33,6 +33,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
quality of life update so we don't have to go manually check this box each time we submit to TestFlight