### PR TITLE
Fix potential duplicate IDs in debugger detail table

### DIFF
--- a/Sources/AppcuesKit/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Debugger/Panel/DebugUI.swift
@@ -54,7 +54,7 @@ internal enum DebugUI {
                 if let propertyGroups = event.eventProperties {
                     ForEach(propertyGroups, id: \.title) { title, items in
                         Section(header: Text(title)) {
-                            ForEach(items, id: \.value) { title, value in
+                            ForEach(items, id: \.title) { title, value in
                                 EventDetailRowView(title: title, value: value)
                             }
                         }


### PR DESCRIPTION
I noticed this error, which meant different debug event detail data rows were being rendered the same despite being different.

```
ForEach<Array<(title: String, value: Optional<String>)>, Optional<String>, EventDetailRowView>: the ID Optional("3") occurs multiple times within the collection, this will give undefined results!
```

The unique value should be the `title` which is an object key. The `value` may not be unique (eg the value `_sessionPageviews` and `_appBuild` were both `3`.