### PR TITLE
Update API access levels

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -158,7 +158,7 @@ public class Appcues {
     /// guard !<#appcuesInstance#>.didHandleURL(url) else { return true }
     /// ```
     @discardableResult
-    func didHandleURL(_ url: URL) -> Bool {
+    public func didHandleURL(_ url: URL) -> Bool {
         return container.resolve(DeeplinkHandler.self).didHandleURL(url)
     }
 


### PR DESCRIPTION
This function needs to be public (it's already documented as such!)

Non SceneDelegate apps and full SwiftUI need this to be able to handle appcues debug/preview deep links.