### PR TITLE
Improved testing support - part 2 - allow override of container init

### DIFF
--- a/Sources/AppcuesKit/Analytics/AnalyticsSubscribing.swift
+++ b/Sources/AppcuesKit/Analytics/AnalyticsSubscribing.swift
@@ -11,9 +11,3 @@ import Foundation
 internal protocol AnalyticsSubscribing: AnyObject {
     func track(update: TrackingUpdate)
 }
-
-extension AnalyticsSubscribing {
-    func registerForAnalyticsUpdates(_ container: DIContainer) {
-        container.resolve(AnalyticsPublishing.self).register(subscriber: self)
-    }
-}

--- a/Sources/AppcuesKit/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Analytics/AnalyticsTracker.swift
@@ -21,9 +21,8 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
 
     private lazy var storage = container.resolve(DataStoring.self)
     private lazy var config = container.resolve(Appcues.Config.self)
-    private lazy var networking = container.resolve(Networking.self)
     private lazy var experienceRenderer = container.resolve(ExperienceRendering.self)
-    private lazy var activityStorage = container.resolve(ActivityProcessing.self)
+    private lazy var activityProcessor = container.resolve(ActivityProcessing.self)
 
     // maintain a batch of asynchronous events that are waiting to be flushed to network
     private let syncQueue = DispatchQueue(label: "appcues-analytics")
@@ -32,7 +31,6 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
 
     init(container: DIContainer) {
         self.container = container
-        registerForAnalyticsUpdates(container)
     }
 
     func track(update: TrackingUpdate) {
@@ -83,7 +81,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
     }
 
     private func flush(_ activity: Activity?, sync: Bool) {
-        activityStorage.process(activity, sync: sync) { [weak self] result in
+        activityProcessor.process(activity, sync: sync) { [weak self] result in
             guard sync, let experienceRenderer = self?.experienceRenderer else { return }
             if case let .success(taco) = result {
                 // This prioritizes experiencess over legacy web flows and assumes that the returned flows are ordered by priority.

--- a/Sources/AppcuesKit/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Analytics/AutoPropertyDecorator.swift
@@ -28,7 +28,6 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
         self.sessionMonitor = container.resolve(SessionMonitoring.self)
         self.config = container.resolve(Appcues.Config.self)
         configureApplicationProperties()
-        container.resolve(AnalyticsPublishing.self).register(decorator: self)
     }
 
     func decorate(_ tracking: TrackingUpdate) -> TrackingUpdate {

--- a/Sources/AppcuesKit/Utilities/Storage.swift
+++ b/Sources/AppcuesKit/Utilities/Storage.swift
@@ -90,6 +90,7 @@ internal class Storage: DataStoring {
 
     init(container: DIContainer) {
         self.config = container.resolve(Appcues.Config.self)
+        self.deviceID = UIDevice.identifier
     }
 
     private func read<T>(_ key: Key, defaultValue: T) -> T {

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -1,0 +1,26 @@
+//
+//  MockAppcues.swift
+//  AppcuesKitTests
+//
+//  Created by James Ellis on 1/7/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+@testable import AppcuesKit
+
+class MockAppcues: Appcues {
+    override init(config: Config) {
+        super.init(config: config)
+    }
+
+    override func initializeContainer() {
+
+        container.register(Appcues.self, value: self)
+        container.register(Appcues.Config.self, value: config)
+        container.register(AnalyticsPublishing.self, value: self)
+
+        // TODO: build out the service mocks and registration
+
+    }
+}


### PR DESCRIPTION
The key change here is allowing a subclass of Appcues, for testing, to override the `initializeContainer` function and supply mock dependencies.

some other misc cleanup/simplification along the way