### PR TITLE
Update ExperiencePagingViewController to work with the sticky content trait

### DIFF
--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
@@ -43,6 +43,11 @@ internal class ExperienceStepViewController: UIViewController {
             contentViewController.view.widthAnchor.constraint(equalTo: stepView.scrollView.widthAnchor)
         ])
     }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        preferredContentSize = contentViewController.view.frame.size
+    }
 }
 
 extension ExperienceStepViewController {
@@ -53,10 +58,6 @@ extension ExperienceStepViewController {
             view.contentInsetAdjustmentBehavior = .always
             return view
         }()
-
-        var contentHeight: CGFloat {
-            scrollView.contentSize.height
-        }
 
         init() {
             super.init(frame: .zero)


### PR DESCRIPTION
Moved the scrollview from the collectionview cell to the `ExperienceStepViewController`.

The slightly irritating part is that `StepPageCell.contentHeight` now needs a special case that knows about `ExperienceStepViewController.ExperienceStepView`. It could be "generalized" to `if let scrollView = contentView.subviews.first?.subviews.first as? UIScrollView`, but that seems decidedly worse.

One minor benefit of this is that the scroll position of a step is remembered: if I scroll to the bottom of the page for step one and page through the carousel and back, the scroll position will still be at the bottom.

https://user-images.githubusercontent.com/845681/149974341-81dbeea5-2e74-42e2-bf33-7c131f145eb2.mp4

