### PR TITLE
Update the handling of preferred content size in the ExperienceStepViewController

### DIFF
--- a/Sources/AppcuesKit/UI/ExperienceModals/AppcuesHostingController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/AppcuesHostingController.swift
@@ -15,5 +15,6 @@ internal class AppcuesHostingController<Content: View>: UIHostingController<Cont
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         view.setNeedsUpdateConstraints()
+        preferredContentSize = view.frame.size
     }
 }

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
@@ -44,10 +44,12 @@ internal class ExperienceStepViewController: UIViewController {
         ])
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
+    override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+        super.preferredContentSizeDidChange(forChildContentContainer: container)
+
         preferredContentSize = contentViewController.view.frame.size
     }
+
 }
 
 extension ExperienceStepViewController {


### PR DESCRIPTION
I believe there was a potential race condition here in the layout timing, at least it seemed that way in my local environment.  The image below shows the symptom I was seeing - effectively a tiny height being allocated to the dialog container VC.

The `ExperienceStepViewController.viewDidLayoutSubviews` could be called before the child VC `AppcuesHostingController` had fully laid out and gotten its frame size.  With this change, now the `AppcuesHostingController` will communicate its preferredContentSize up to its parent `ExperienceStepViewController`, which will then communicate back up to its parent `ExperiencePagingViewController`.

**before**
![Screen Shot 2022-01-21 at 3 46 47 PM](https://user-images.githubusercontent.com/19266448/150794962-635d8709-bac1-4a55-afa5-72b18aab90ad.png)


**after**
![Screen Shot 2022-01-21 at 3 48 02 PM](https://user-images.githubusercontent.com/19266448/150794975-4da5d776-c089-46d3-875f-55a8c7f2b7a2.png)
