### PR TITLE
Add context property to our Event payloads on /activity requests

### DIFF
--- a/Sources/AppcuesKit/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Analytics/AnalyticsTracker.swift
@@ -101,7 +101,7 @@ extension Activity {
         case let .event(name, _):
             self.init(accountID: config.accountID,
                       userID: storage.userID,
-                      events: [Event(name: name, attributes: update.properties)],
+                      events: [Event(name: name, attributes: update.properties, context: update.context)],
                       groupID: storage.groupID)
 
         case let .screen(title):
@@ -111,7 +111,7 @@ extension Activity {
             }
             self.init(accountID: config.accountID,
                       userID: storage.userID,
-                      events: [Event(pageView: urlString, attributes: update.properties)],
+                      events: [Event(pageView: urlString, attributes: update.properties, context: update.context)],
                       groupID: storage.groupID)
 
         case .profile:
@@ -157,7 +157,7 @@ private extension Array where Element == Activity {
     }
 }
 
-// Temporary solution to piggyback on the web page views. A proper mobile screen solution is still needed.
+// TODO: Temporary solution to piggyback on the web page views. A proper mobile screen solution is still needed.
 private func generatePseudoURL(screenName: String) -> String? {
     var components = URLComponents()
     components.scheme = "https"

--- a/Sources/AppcuesKit/Analytics/TrackingUpdate.swift
+++ b/Sources/AppcuesKit/Analytics/TrackingUpdate.swift
@@ -33,6 +33,7 @@ internal struct TrackingUpdate {
 
     let type: TrackingType
     var properties: [String: Any]?
+    var context: [String: Any]?
     let timestamp = Date()
 
     var policy: Policy {

--- a/Sources/AppcuesKit/Models/Event.swift
+++ b/Sources/AppcuesKit/Models/Event.swift
@@ -13,20 +13,23 @@ internal struct Event {
     let name: String
     let timestamp: Date
     let attributes: [String: Any]?
+    let context: [String: Any]?
 
-    init(name: String, timestamp: Date = Date(), attributes: [String: Any]? = nil) {
+    init(name: String, timestamp: Date = Date(), attributes: [String: Any]? = nil, context: [String: Any]? = nil) {
         self.name = name
         self.timestamp = timestamp
         self.attributes = attributes
+        self.context = context
     }
 
-    init(pageView url: String, attributes: [String: Any]? = nil) {
+    init(pageView url: String, attributes: [String: Any]? = nil, context: [String: Any]? = nil) {
         name = "appcues:page_view"
         timestamp = Date()
 
         var extendedAttributes = attributes ?? [:]
         extendedAttributes["url"] = url
         self.attributes = extendedAttributes
+        self.context = context
     }
 }
 
@@ -35,6 +38,7 @@ extension Event: Encodable {
         case name
         case timestamp
         case attributes
+        case context
     }
 
     func encode(to encoder: Encoder) throws {
@@ -45,6 +49,11 @@ extension Event: Encodable {
         if let attributes = attributes {
             var attributesContainer = container.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: .attributes)
             try attributesContainer.encodeSkippingInvalid(attributes)
+        }
+
+        if let context = context {
+            var attributesContainer = container.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: .context)
+            try attributesContainer.encodeSkippingInvalid(context)
         }
     }
 }


### PR DESCRIPTION
This is sort of a one-off addition, but satisfying a request from platform-side about the data that is sent to assist with qualification.