### PR TITLE
Add support for padding from the modal trait

### DIFF
--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesModalTrait.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal struct AppcuesModalTrait: WrapperCreatingTrait, PresentingTrait {
+internal struct AppcuesModalTrait: StepDecoratingTrait, WrapperCreatingTrait, PresentingTrait {
     static let type = "@appcues/modal"
 
     let groupID: String?
@@ -27,6 +27,16 @@ internal struct AppcuesModalTrait: WrapperCreatingTrait, PresentingTrait {
 
         self.backdropColor = UIColor(dynamicColor: config?["backdropColor", decodedAs: ExperienceComponent.Style.DynamicColor.self])
         self.modalStyle = config?["style", decodedAs: ExperienceComponent.Style.self]
+    }
+
+    func decorate(stepController: UIViewController) throws {
+        // Need to cast for access to the padding property.
+        guard let stepController = stepController as? ExperienceStepViewController else { return }
+        stepController.padding = NSDirectionalEdgeInsets(
+            top: modalStyle?.paddingTop ?? 0,
+            leading: modalStyle?.paddingLeading ?? 0,
+            bottom: modalStyle?.paddingBottom ?? 0,
+            trailing: modalStyle?.paddingTrailing ?? 0)
     }
 
     func createWrapper(around containerController: ExperienceContainerViewController) -> UIViewController {

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
@@ -13,6 +13,10 @@ internal class ExperienceStepViewController: UIViewController {
     let viewModel: ExperienceStepViewModel
 
     lazy var stepView = ExperienceStepView()
+    var padding: NSDirectionalEdgeInsets {
+        get { stepView.contentView.directionalLayoutMargins }
+        set { stepView.contentView.directionalLayoutMargins = newValue }
+    }
 
     private let contentViewController: UIViewController
 
@@ -38,16 +42,16 @@ internal class ExperienceStepViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        embedChildViewController(contentViewController, inSuperview: stepView.scrollView)
-        NSLayoutConstraint.activate([
-            contentViewController.view.widthAnchor.constraint(equalTo: stepView.scrollView.widthAnchor)
-        ])
+        addChild(contentViewController)
+        stepView.contentView.addSubview(contentViewController.view)
+        contentViewController.view.pin(to: stepView.contentView.layoutMarginsGuide)
+        contentViewController.didMove(toParent: self)
     }
 
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
 
-        preferredContentSize = contentViewController.view.frame.size
+        preferredContentSize = stepView.contentView.frame.size
     }
 
 }
@@ -61,11 +65,22 @@ extension ExperienceStepViewController {
             return view
         }()
 
+        lazy var contentView: UIView = {
+            let view = UIView()
+            view.directionalLayoutMargins = .zero
+            return view
+        }()
+
         init() {
             super.init(frame: .zero)
 
             addSubview(scrollView)
+            scrollView.addSubview(contentView)
             scrollView.pin(to: self)
+            contentView.pin(to: scrollView)
+            NSLayoutConstraint.activate([
+                contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+            ])
         }
 
         @available(*, unavailable)

--- a/Sources/AppcuesKit/UI/Extensions/UIView+Constrain.swift
+++ b/Sources/AppcuesKit/UI/Extensions/UIView+Constrain.swift
@@ -21,6 +21,17 @@ extension UIView {
         ])
     }
 
+    func pin(to guide: UILayoutGuide) {
+       self.translatesAutoresizingMaskIntoConstraints = false
+
+       NSLayoutConstraint.activate([
+           self.topAnchor.constraint(equalTo: guide.topAnchor),
+           self.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
+           self.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
+           self.bottomAnchor.constraint(equalTo: guide.bottomAnchor)
+       ])
+   }
+
     func center(in view: UIView) {
        self.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
Pretty basic, but you can add padding to a modal now.

Builder ref: https://www.figma.com/file/M7Tm2SznjVkhGJ7cNsysYT/Mobile?node-id=3344%3A153468

Example for leading/trailing:

![Simulator Screen Shot - iPhone 13 Pro - 2022-02-07 at 15 10 35](https://user-images.githubusercontent.com/845681/152863958-0387aadd-6948-476f-982d-60934e6ae96f.png)
