### PR TITLE
Update trait inits

### DIFF
--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -16,7 +16,12 @@ internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
 
     required init?(config: [String: Any]?) {
         self.groupID = config?["groupID"] as? String
-        self.backgroundColor = UIColor(dynamicColor: config?["backgroundColor", decodedAs: ExperienceComponent.Style.DynamicColor.self])
+
+        if let dynamicColor = config?["backgroundColor", decodedAs: ExperienceComponent.Style.DynamicColor.self] {
+            self.backgroundColor = UIColor(dynamicColor: dynamicColor)
+        } else {
+            return nil
+        }
     }
 
     func decorate(backdropView: UIView) throws {

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesGroupTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesGroupTrait.swift
@@ -14,7 +14,11 @@ internal class AppcuesGroupTrait: GroupingTrait {
     let groupID: String?
 
     required init?(config: [String: Any]?) {
-        self.groupID = config?["groupID"] as? String
+        if let groupID = config?["groupID"] as? String {
+            self.groupID = groupID
+        } else {
+            return nil
+        }
     }
 
     func group(initialStep stepIndex: Int, in experience: Experience) -> [Experience.Step] {

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesModalTrait.swift
@@ -13,7 +13,6 @@ internal struct AppcuesModalTrait: WrapperCreatingTrait, PresentingTrait {
 
     let groupID: String?
     let presentationStyle: PresentationStyle
-    let backdropColor: UIColor?
     let modalStyle: ExperienceComponent.Style?
 
     init?(config: [String: Any]?) {
@@ -25,7 +24,6 @@ internal struct AppcuesModalTrait: WrapperCreatingTrait, PresentingTrait {
             return nil
         }
 
-        self.backdropColor = UIColor(dynamicColor: config?["backdropColor", decodedAs: ExperienceComponent.Style.DynamicColor.self])
         self.modalStyle = config?["style", decodedAs: ExperienceComponent.Style.self]
     }
 


### PR DESCRIPTION
As part of https://github.com/appcues/appcues-mobile-experience-spec/pull/21, I realized a few of the trait inits should be more selecting. There's no benefit to allowing a backdrop trait instance with no color or a group trait with no group ID, so failing the inits means if those cases occur in the JSON model, they'll be ignored when applying traits.

I also removed an unused backdrop reference from the modal trait which should have been removed when I added the backdrop trait.