### PR TITLE
Fix infinite loop in experience layouts

### DIFF
--- a/Sources/AppcuesKit/UI/ExperienceModals/AppcuesHostingController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/AppcuesHostingController.swift
@@ -15,6 +15,6 @@ internal class AppcuesHostingController<Content: View>: UIHostingController<Cont
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         view.setNeedsUpdateConstraints()
-        preferredContentSize = view.frame.size
+        preferredContentSize = view.intrinsicContentSize
     }
 }


### PR DESCRIPTION
When the SwiftUI view is _just_ the right size, the frame calculation would vary by a single pt. `preferredContentSize` is propagated up the VC hierarchy until the dialog modal controller sets a height constraint, triggering another layout pass. `intrinsicContentSize` is more stable size calculation.