### PR TITLE
Update Config.apiHost to be more flexible

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -22,7 +22,7 @@ public extension Appcues {
 
         let applicationID: String
 
-        var apiHost: URLComponents = NetworkClient.defaultAPIHost
+        var apiHost: URL = NetworkClient.defaultAPIHost
 
         var urlSession: URLSession = NetworkClient.defaultURLSession
 
@@ -59,8 +59,10 @@ public extension Appcues {
         /// Set the API host for the configuration.
         /// - Parameter apiHost: Domain of the API host.
         /// - Returns: The `Configuration` object.
+        ///
+        /// Any path values in the provided `URL` will be discarded.
         @discardableResult
-        public func apiHost(_ apiHost: URLComponents) -> Self {
+        public func apiHost(_ apiHost: URL) -> Self {
             self.apiHost = apiHost
             return self
         }

--- a/Sources/AppcuesKit/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Networking/Endpoint.swift
@@ -16,8 +16,7 @@ internal enum APIEndpoint: Endpoint {
 
     /// URL fragments that that are appended to the `Config.apiHost` to make the URL for a network request.
     func url(config: Appcues.Config, storage: DataStoring) -> URL? {
-        var components = config.apiHost
-        components.scheme = components.scheme ?? "https"
+        guard var components = URLComponents(url: config.apiHost, resolvingAgainstBaseURL: false) else { return nil }
 
         switch self {
         case let .activity(userID, sync):

--- a/Sources/AppcuesKit/Networking/NetworkClient.swift
+++ b/Sources/AppcuesKit/Networking/NetworkClient.swift
@@ -87,12 +87,8 @@ internal class NetworkClient: Networking {
 }
 
 extension NetworkClient {
-    static let defaultAPIHost: URLComponents = {
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = "api.appcues.com"
-        return components
-    }()
+    // swiftlint:disable:next force_unwrapping
+    static let defaultAPIHost = URL(string: "https://api.appcues.com")!
 
     static var defaultURLSession: URLSession {
         let configuration = URLSessionConfiguration.ephemeral


### PR DESCRIPTION
I'm creating UI tests for experiences in the spec repo and connecting to the local server requires more flexibility that just providing the host value (need to set the `scheme` to `http` and set a `port` number. The simplest way to do this is to allow a `URLComponents` struct to be provided to the SDK.

I've left the config property called `apiHost` since  the name still seems reasonably appropriate.