### PR TITLE
Fix unexpected type in event properties

### DIFF
--- a/Sources/AppcuesKit/UI/ExperienceLifecycleEvent.swift
+++ b/Sources/AppcuesKit/UI/ExperienceLifecycleEvent.swift
@@ -97,7 +97,7 @@ internal enum ExperienceLifecycleEvent {
 
         if let error = error {
             properties["message"] = error.message
-            properties["errorId"] = error.id
+            properties["errorId"] = error.id.uuidString
         }
 
         return properties


### PR DESCRIPTION
#126 introduced the `errorId` value, but I forgot that our properties have to be string values until I got a helpful crash.