### PR TITLE
Update context attribute name for screen_title

### DIFF
--- a/Sources/AppcuesKit/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Analytics/AutoPropertyDecorator.swift
@@ -46,7 +46,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             previousScreen = currentScreen
             currentScreen = title
             sessionPageviews += 1
-            context["screen"] = title
+            context["screen_title"] = title
         case .event(SessionEvents.sessionStarted.rawValue, _):
             sessionPageviews = 0
             sessionRandomizer = Int.random(in: 1...100)


### PR DESCRIPTION
There was sort of a long discussion chain in this ticket that I think got lost in the shuffle https://app.shortcut.com/appcues/story/31692/implement-context-property-in-analytic-events , but was reviewing this with related android work.

to summarize: simple change, the context property name for screen views should be "screen_title" instead of "screen".