### PR TITLE
Update auto property names for current/last screen

### DIFF
--- a/Sources/AppcuesKit/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Analytics/AutoPropertyDecorator.swift
@@ -66,8 +66,8 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             "_localId": storage.deviceID,
             "_sessionPageviews": sessionPageviews,
             "_sessionRandomizer": sessionRandomizer,
-            "_currentPageTitle": currentScreen,
-            "_lastPageTitle": previousScreen,
+            "_currentScreenTitle": currentScreen,
+            "_lastScreenTitle": previousScreen,
             "_updatedAt": Date(),
             "_lastContentShownAt": storage.lastContentShownAt,
             "_sessionId": sessionMonitor.sessionID?.uuidString


### PR DESCRIPTION
One more small adjustment from convo in https://app.shortcut.com/appcues/story/31692/implement-context-property-in-analytic-events, getting iOS/Android on same page (er, screen) here.