### PR TITLE
Re-generate example project files

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -10,13 +10,13 @@
 		0384A2A89074FC193A107EE5 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663BEDD1883CC408AA4A302 /* SignInViewController.swift */; };
 		04F09F9C75FB66578541D199 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */; };
 		3EADA9762D050C3E2ED69514 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */; };
-		58A23039E332166D9880BBE2 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B79D3B870B6EEFE961AE7C0 /* Pods_AppcuesCocoapodsExample.framework */; };
 		64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB61619365785F4544ED13D /* GroupViewController.swift */; };
+		7BA5677FF9354017F47EB3E9 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5B67BE1F6371A71F749412B /* Pods_AppcuesCocoapodsExample.framework */; };
 		866AA363BEFB1A42C8C1D149 /* Lato-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 547A647EB6D311E97F592C7C /* Lato-Black.ttf */; };
 		9E6FF9F4B22B8874E5AA6544 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93D50517BBE18B336D130E13 /* LaunchScreen.storyboard */; };
 		A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C713E67205D9507CE2DC80 /* AppDelegate.swift */; };
 		A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */; };
-		C9945E7427D29DD200EE6216 /* DeeplinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9945E7327D29DD200EE6216 /* DeeplinkNavigator.swift */; };
+		CAFC2E38ACF9024AD211097D /* DeeplinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADB3815CE7FEA22224162CE /* DeeplinkNavigator.swift */; };
 		CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384497BA35A275E793B475C1 /* ProfileViewController.swift */; };
 		CD156254F042866368E77CC3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 024025AF9E2E0D38C368A6AC /* Main.storyboard */; };
 		DBE453F2B40A01B4818CB84E /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */; };
@@ -25,31 +25,31 @@
 
 /* Begin PBXFileReference section */
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		1B79D3B870B6EEFE961AE7C0 /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		2623C75FBEB40F35C89C0FEF /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		384497BA35A275E793B475C1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		547A647EB6D311E97F592C7C /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
+		5ADB3815CE7FEA22224162CE /* DeeplinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkNavigator.swift; sourceTree = "<group>"; };
 		5DC2B62290580560D162A8E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		82DED1437C1DA54F0C231566 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8663BEDD1883CC408AA4A302 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		9CB61619365785F4544ED13D /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		9D26E6136C6539597C9E50A9 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
 		AAD7ED9DCA5972361B3F5E67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B5B67BE1F6371A71F749412B /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
-		C9945E7327D29DD200EE6216 /* DeeplinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkNavigator.swift; sourceTree = "<group>"; };
+		D222BCDD1CC476586F0AF3A8 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		D2C0EC54920737EBD7E2961F /* AppcuesCocoapodsExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AppcuesCocoapodsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
-		DA2DFA781521FF4E4AFA3388 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
-		E80E6226A35D5C23E32D2A3E /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		44B39B89FCBBD422DDA2E821 /* Frameworks */ = {
+		1CF5B836E47122D5CEA128D1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				58A23039E332166D9880BBE2 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
+				7BA5677FF9354017F47EB3E9 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -66,12 +66,13 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
-		87A4B18861713E746752AA26 /* Pods */ = {
+		468D3835D37404BDD6139029 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E80E6226A35D5C23E32D2A3E /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
-				DA2DFA781521FF4E4AFA3388 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+				2623C75FBEB40F35C89C0FEF /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
+				D222BCDD1CC476586F0AF3A8 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
 			);
+			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -81,6 +82,7 @@
 				3271BCB89D21367EC1AA9069 /* Fonts */,
 				10C713E67205D9507CE2DC80 /* AppDelegate.swift */,
 				2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */,
+				5ADB3815CE7FEA22224162CE /* DeeplinkNavigator.swift */,
 				9D26E6136C6539597C9E50A9 /* EventsViewController.swift */,
 				9CB61619365785F4544ED13D /* GroupViewController.swift */,
 				AAD7ED9DCA5972361B3F5E67 /* Info.plist */,
@@ -89,17 +91,8 @@
 				384497BA35A275E793B475C1 /* ProfileViewController.swift */,
 				25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */,
 				8663BEDD1883CC408AA4A302 /* SignInViewController.swift */,
-				C9945E7327D29DD200EE6216 /* DeeplinkNavigator.swift */,
 			);
 			path = CocoapodsExample;
-			sourceTree = "<group>";
-		};
-		B27CAAE798BEA7DE21ACB536 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				1B79D3B870B6EEFE961AE7C0 /* Pods_AppcuesCocoapodsExample.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		C743E51709EACC21B03B3A23 /* Products */ = {
@@ -115,9 +108,17 @@
 			children = (
 				8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */,
 				C743E51709EACC21B03B3A23 /* Products */,
-				87A4B18861713E746752AA26 /* Pods */,
-				B27CAAE798BEA7DE21ACB536 /* Frameworks */,
+				468D3835D37404BDD6139029 /* Pods */,
+				F4C42B27863A6CAFB95BFD29 /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		F4C42B27863A6CAFB95BFD29 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B5B67BE1F6371A71F749412B /* Pods_AppcuesCocoapodsExample.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -127,12 +128,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7200554C7EB6F6E4E0D35C70 /* Build configuration list for PBXNativeTarget "AppcuesCocoapodsExample" */;
 			buildPhases = (
-				2B7FF01DBB6FBFF73B1DE793 /* [CP] Check Pods Manifest.lock */,
+				440A53EC6F4B31963C472BC3 /* [CP] Check Pods Manifest.lock */,
 				39C4F25C30C2C38F00378FED /* Sources */,
 				4B41B1A9E3D52747D92B7344 /* Resources */,
 				6D4DB9FBC4445D937FD94125 /* SwiftLint */,
-				44B39B89FCBBD422DDA2E821 /* Frameworks */,
-				690B8A61E13C01E64C65B1C7 /* [CP] Embed Pods Frameworks */,
+				1CF5B836E47122D5CEA128D1 /* Frameworks */,
+				222B0B3E312B5C4695AE98D2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -150,6 +151,8 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = 95033167E7E129F199208F61 /* Build configuration list for PBXProject "AppcuesCocoapodsExample" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -186,7 +189,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2B7FF01DBB6FBFF73B1DE793 /* [CP] Check Pods Manifest.lock */ = {
+		222B0B3E312B5C4695AE98D2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		440A53EC6F4B31963C472BC3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -206,23 +226,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		690B8A61E13C01E64C65B1C7 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6D4DB9FBC4445D937FD94125 /* SwiftLint */ = {
@@ -251,11 +254,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */,
+				CAFC2E38ACF9024AD211097D /* DeeplinkNavigator.swift in Sources */,
 				EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */,
 				64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */,
 				CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */,
 				A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */,
-				C9945E7427D29DD200EE6216 /* DeeplinkNavigator.swift in Sources */,
 				0384A2A89074FC193A107EE5 /* SignInViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -284,7 +287,7 @@
 /* Begin XCBuildConfiguration section */
 		015038143918E0C7F9D7E873 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E80E6226A35D5C23E32D2A3E /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
+			baseConfigurationReference = 2623C75FBEB40F35C89C0FEF /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -365,7 +368,7 @@
 		};
 		266E5C088CC8701B4117B193 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DA2DFA781521FF4E4AFA3388 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
+			baseConfigurationReference = D222BCDD1CC476586F0AF3A8 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
@@ -3,11 +3,10 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1A711F382767A58D0099D732 /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A711F372767A58D0099D732 /* GroupViewController.swift */; };
 		64EFAB6E2ED72F70B75B98F1 /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7C790690C785694C7F24F8 /* EventsViewController.swift */; };
 		7013CDD44A5E7E6056595498 /* Lato-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 05539DC01B30BEB3C8796C56 /* Lato-Black.ttf */; };
 		702B963B624B5F8BB19F2468 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8757BA449145145EAF8FE061 /* Main.storyboard */; };
@@ -17,17 +16,18 @@
 		AB4DA4AF52B5BC21308C439B /* AppcuesKit in Frameworks */ = {isa = PBXBuildFile; productRef = 781D0ABDB3436955E4EA34B9 /* AppcuesKit */; };
 		B3CE09A940E9DD0DF6CA96A4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED2A2106A39811D89703AE5F /* LaunchScreen.storyboard */; };
 		BF24A197BFEAF23D84AC3462 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6901798B6E99F34ACF2F707B /* SceneDelegate.swift */; };
-		C977C89B27D69B6A00C99D06 /* DeeplinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C977C89A27D69B6A00C99D06 /* DeeplinkNavigator.swift */; };
+		C23CDD1E1B80B881A21764F2 /* DeeplinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498D1B1BD74BE672485DB096 /* DeeplinkNavigator.swift */; };
 		DD6A303F8B4B0A8075C32454 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288554133C93206378D963AB /* SignInViewController.swift */; };
+		EE6124C9BB7FB8ACF18B1503 /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C55D469D39EFF3296C5387 /* GroupViewController.swift */; };
 		F897157F45696443B145C383 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723869D8744D77D8EC9B55F1 /* ProfileViewController.swift */; };
 		FAD74CCC7D11B9407A5162D7 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F46FEDAF7B878A4794848F30 /* Lato-Regular.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		05539DC01B30BEB3C8796C56 /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
-		1A711F372767A58D0099D732 /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		288554133C93206378D963AB /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		476767533B954304A7121A53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		498D1B1BD74BE672485DB096 /* DeeplinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkNavigator.swift; sourceTree = "<group>"; };
 		6901798B6E99F34ACF2F707B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		6FF4A6230C0803185A864738 /* AppcuesSPMExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AppcuesSPMExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7203E757C2C6EA5D37C5E443 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -35,10 +35,10 @@
 		7A2AD399FBBF5EB8AEBE70BF /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
 		7A540BC606C8E2160FB2B489 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7A931564B0DEB1FE780CD0A2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		87C55D469D39EFF3296C5387 /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		8F18BFFBC809004FCDB520DF /* appcues-ios-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "appcues-ios-sdk"; path = ../..; sourceTree = SOURCE_ROOT; };
 		AF7C790690C785694C7F24F8 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
 		C77616FC1B7BAE52C91F4FBD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		C977C89A27D69B6A00C99D06 /* DeeplinkNavigator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeeplinkNavigator.swift; sourceTree = "<group>"; };
 		F46FEDAF7B878A4794848F30 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -95,15 +95,15 @@
 				8C2264C89F22EF422DA5A775 /* Fonts */,
 				7A540BC606C8E2160FB2B489 /* AppDelegate.swift */,
 				7203E757C2C6EA5D37C5E443 /* Assets.xcassets */,
+				498D1B1BD74BE672485DB096 /* DeeplinkNavigator.swift */,
 				AF7C790690C785694C7F24F8 /* EventsViewController.swift */,
+				87C55D469D39EFF3296C5387 /* GroupViewController.swift */,
 				476767533B954304A7121A53 /* Info.plist */,
 				ED2A2106A39811D89703AE5F /* LaunchScreen.storyboard */,
 				8757BA449145145EAF8FE061 /* Main.storyboard */,
 				723869D8744D77D8EC9B55F1 /* ProfileViewController.swift */,
 				6901798B6E99F34ACF2F707B /* SceneDelegate.swift */,
 				288554133C93206378D963AB /* SignInViewController.swift */,
-				1A711F372767A58D0099D732 /* GroupViewController.swift */,
-				C977C89A27D69B6A00C99D06 /* DeeplinkNavigator.swift */,
 			);
 			path = SPMExample;
 			sourceTree = "<group>";
@@ -139,6 +139,8 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = 3307568C9084A060E694F2E4 /* Build configuration list for PBXProject "AppcuesSPMExample" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -199,12 +201,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A711F382767A58D0099D732 /* GroupViewController.swift in Sources */,
 				A23B377CAA8FFC989E6A9A73 /* AppDelegate.swift in Sources */,
+				C23CDD1E1B80B881A21764F2 /* DeeplinkNavigator.swift in Sources */,
 				64EFAB6E2ED72F70B75B98F1 /* EventsViewController.swift in Sources */,
+				EE6124C9BB7FB8ACF18B1503 /* GroupViewController.swift in Sources */,
 				F897157F45696443B145C383 /* ProfileViewController.swift in Sources */,
 				BF24A197BFEAF23D84AC3462 /* SceneDelegate.swift in Sources */,
-				C977C89B27D69B6A00C99D06 /* DeeplinkNavigator.swift in Sources */,
 				DD6A303F8B4B0A8075C32454 /* SignInViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Attempting to push to TestFlight failed with in the `update_code_signing_settings` step with
> Seems to be a very old project file format - please open your project file in a more recent version of Xcode

https://app.circleci.com/pipelines/github/appcues/appcues-ios-sdk/585/workflows/20bb4474-096b-41a9-8f1f-9ae9fe27c5a3/jobs/479/parallel-runs/0/steps/0-109

This has happened locally before, and regenerating the project file with `mint run xcodegen` has fixed it, so hopefully it fixes it this time 🤞 

I don't know why the error pops up, but I'm not interesting in sinking too much time into investigating until it happens more frequently.