### PR TITLE
Update url request timeout to 5 seconds

### DIFF
--- a/Sources/AppcuesKit/Networking/NetworkClient.swift
+++ b/Sources/AppcuesKit/Networking/NetworkClient.swift
@@ -92,7 +92,7 @@ extension NetworkClient {
 
     static var defaultURLSession: URLSession {
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForResource = 30
+        configuration.timeoutIntervalForResource = 5
         configuration.httpAdditionalHeaders = [
             "Content-Type": "application/json; charset=utf-8"
         ]


### PR DESCRIPTION
Making it a config property would've been trickier than it was worth because you can't modify the URLSessionConfiguration after it's inited into the URLSession and the existing `Appcues.Config.urlSession()` customization point would conflict with a timeout config point.

E2E tested in here:
- https://github.com/appcues/appcues-mobile-experience-spec/pull/31