### PR TITLE
Update SDK to support analytics back to iOS 11

### DIFF
--- a/Appcues.podspec
+++ b/Appcues.podspec
@@ -29,7 +29,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/appcues/appcues-ios-sdk.git', :tag => s.version.to_s }
 
   s.swift_version = '5.0'
-  s.ios.deployment_target = '13.0'
+  s.ios.deployment_target = '11.0'
 
   s.source_files = 'Sources/AppcuesKit/**/*.swift'
   s.resource_bundles = {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Appcues",
     platforms: [
-        .iOS("13.0")
+        .iOS(.v11)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/AppcuesKit/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Actions/ActionRegistry.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal class ActionRegistry {
     typealias Completion = () -> Void
 

--- a/Sources/AppcuesKit/Actions/Appcues/AppcuesCloseAction.swift
+++ b/Sources/AppcuesKit/Actions/Appcues/AppcuesCloseAction.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 
+@available(iOS 13.0, *)
 internal struct AppcuesCloseAction: ExperienceAction {
 
     static let type = "@appcues/close"

--- a/Sources/AppcuesKit/Actions/Appcues/AppcuesContinueAction.swift
+++ b/Sources/AppcuesKit/Actions/Appcues/AppcuesContinueAction.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal struct AppcuesContinueAction: ExperienceAction {
     static let type = "@appcues/continue"
 

--- a/Sources/AppcuesKit/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal struct AppcuesLaunchExperienceAction: ExperienceAction {
     static let type = "@appcues/launch-experience"
 

--- a/Sources/AppcuesKit/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Actions/Appcues/AppcuesLinkAction.swift
@@ -9,6 +9,7 @@
 import UIKit
 import SafariServices
 
+@available(iOS 13.0, *)
 internal struct AppcuesLinkAction: ExperienceAction {
     static let type = "@appcues/link"
 

--- a/Sources/AppcuesKit/Actions/Appcues/AppcuesTrackAction.swift
+++ b/Sources/AppcuesKit/Actions/Appcues/AppcuesTrackAction.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal struct AppcuesTrackAction: ExperienceAction {
     static let type = "@appcues/track"
 

--- a/Sources/AppcuesKit/Actions/Appcues/AppcuesUpdateProfileAction.swift
+++ b/Sources/AppcuesKit/Actions/Appcues/AppcuesUpdateProfileAction.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal struct AppcuesUpdateProfileAction: ExperienceAction {
     static let type = "@appcues/update-profile"
 

--- a/Sources/AppcuesKit/Debugger/FloatingView/DebugUIWindow.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DebugUIWindow.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class DebugUIWindow: UIWindow {
 
     init(windowScene: UIWindowScene, rootViewController: UIViewController) {

--- a/Sources/AppcuesKit/Debugger/FloatingView/DebugView+GestureCalculator.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DebugView+GestureCalculator.swift
@@ -10,6 +10,7 @@ import UIKit
 
 // swiftlint:disable identifier_name
 
+@available(iOS 13.0, *)
 extension DebugView {
     struct GestureCalculator {
         /// Calculate a scaled damping value from an initial magnitude.

--- a/Sources/AppcuesKit/Debugger/FloatingView/DebugView.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DebugView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class DebugView: UIView {
 
     private let gestureCalculator = GestureCalculator()

--- a/Sources/AppcuesKit/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DebugViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class DebugViewController: UIViewController {
 
     private var debugView = DebugView()

--- a/Sources/AppcuesKit/Debugger/FloatingView/DismissDropZoneView.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/DismissDropZoneView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class DismissDropZoneView: UIView {
 
     /// Distance from the snapPoint at which the floating view locks to the snapPoint.

--- a/Sources/AppcuesKit/Debugger/FloatingView/FloatingView.swift
+++ b/Sources/AppcuesKit/Debugger/FloatingView/FloatingView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class FloatingView: UIView {
 
     private let tapRecognizer = UITapGestureRecognizer()

--- a/Sources/AppcuesKit/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Debugger/Panel/DebugUI.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 /// Namespaced Views used in the debug panel.
+@available(iOS 13.0, *)
 internal enum DebugUI {
     struct MainPanelView: View {
 

--- a/Sources/AppcuesKit/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Debugger/Panel/DebugViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal class DebugViewModel: ObservableObject {
     let accountID: String
     let applicationID: String
@@ -61,6 +62,7 @@ internal class DebugViewModel: ObservableObject {
     }
 }
 
+@available(iOS 13.0, *)
 extension DebugViewModel {
     struct StatusItem: Identifiable {
         let id = UUID()
@@ -138,6 +140,7 @@ extension DebugViewModel {
     }
 }
 
+@available(iOS 13.0, *)
 extension DebugViewModel.LoggedEvent {
     enum EventType: CustomStringConvertible {
         case screen

--- a/Sources/AppcuesKit/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Debugger/UIDebugger.swift
@@ -9,10 +9,12 @@
 import UIKit
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal protocol UIDebugging {
     func show()
 }
 
+@available(iOS 13.0, *)
 internal class UIDebugger: UIDebugging {
     private var debugWindow: UIWindow?
 
@@ -63,6 +65,7 @@ internal class UIDebugger: UIDebugging {
     }
 }
 
+@available(iOS 13.0, *)
 extension UIDebugger: AnalyticsSubscribing {
     func track(update: TrackingUpdate) {
         // Publishing changes must from the main thread.

--- a/Sources/AppcuesKit/DeeplinkHandler.swift
+++ b/Sources/AppcuesKit/DeeplinkHandler.swift
@@ -8,10 +8,12 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal protocol DeeplinkHandling {
     func didHandleURL(_ url: URL) -> Bool
 }
 
+@available(iOS 13.0, *)
 internal class DeeplinkHandler: DeeplinkHandling {
 
     enum Action: Hashable {
@@ -111,6 +113,7 @@ public extension Appcues {
     /// ```swift
     /// guard !<#appcuesInstance#>.filterAndHandle(URLContexts) else { return }
     /// ```
+    @available(iOS 13.0, *)
     @discardableResult
     func filterAndHandle(_ URLContexts: Set<UIOpenURLContext>) -> Set<UIOpenURLContext> {
         URLContexts.filter { !didHandleURL($0.url) }

--- a/Sources/AppcuesKit/Models/AppcuesError.swift
+++ b/Sources/AppcuesKit/Models/AppcuesError.swift
@@ -9,5 +9,6 @@
 import Foundation
 
 internal enum AppcuesError: Error {
+    case unsupportedOSVersion
     case noActiveSession
 }

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
     static var type: String = "@appcues/backdrop"
 

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal struct AppcuesCarouselTrait: ContainerCreatingTrait {
     static let type = "@appcues/carousel"
 
@@ -19,6 +20,7 @@ internal struct AppcuesCarouselTrait: ContainerCreatingTrait {
     }
 }
 
+@available(iOS 13.0, *)
 extension AppcuesCarouselTrait {
 
     class CarouselContainerViewController: UIViewController, ExperienceContainerViewController,

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesModalTrait.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal struct AppcuesModalTrait: StepDecoratingTrait, WrapperCreatingTrait, PresentingTrait {
     static let type = "@appcues/modal"
 
@@ -76,6 +77,7 @@ internal struct AppcuesModalTrait: StepDecoratingTrait, WrapperCreatingTrait, Pr
     }
 }
 
+@available(iOS 13.0, *)
 extension AppcuesModalTrait {
     enum PresentationStyle: String {
         case full

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesPagingDotsTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesPagingDotsTrait.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class AppcuesPagingDotsTrait: ContainerDecoratingTrait {
     static let type = "@appcues/paging-dots"
 

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class AppcuesSkippableTrait: ContainerDecoratingTrait, BackdropDecoratingTrait {
     static var type: String = "@appcues/skippable"
 
@@ -35,6 +36,7 @@ internal class AppcuesSkippableTrait: ContainerDecoratingTrait, BackdropDecorati
     }
 }
 
+@available(iOS 13.0, *)
 private extension UIViewController {
     func addDismissButton() {
         let dismissButton = CloseButton()
@@ -55,6 +57,7 @@ private extension UIViewController {
     }
 }
 
+@available(iOS 13.0, *)
 private extension UIViewController {
     class CloseButton: UIButton {
         private static let size: CGFloat = 30

--- a/Sources/AppcuesKit/Traits/Appcues/AppcuesStickyContentTrait.swift
+++ b/Sources/AppcuesKit/Traits/Appcues/AppcuesStickyContentTrait.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesStickyContentTrait: StepDecoratingTrait {
     static let type = "@appcues/sticky-content"
 
@@ -83,6 +84,7 @@ internal struct AppcuesStickyContentTrait: StepDecoratingTrait {
     }
 }
 
+@available(iOS 13.0, *)
 extension AppcuesStickyContentTrait {
     /// HostingController that reports `frame` size changes.
     class StickyHostingController<Content: View>: AppcuesHostingController<Content> {

--- a/Sources/AppcuesKit/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Traits/TraitComposer.swift
@@ -8,10 +8,12 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal protocol TraitComposing: AnyObject {
     func package(experience: Experience, stepIndex: Experience.StepIndex) throws -> ExperiencePackage
 }
 
+@available(iOS 13.0, *)
 internal class TraitComposer: TraitComposing {
 
     private let traitRegistry: TraitRegistry
@@ -105,6 +107,7 @@ internal class TraitComposer: TraitComposing {
     }
 }
 
+@available(iOS 13.0, *)
 extension TraitComposer {
     struct DefaultContainerCreatingTrait: ContainerCreatingTrait {
         static var type: String = "_defaultContainerCreatingTrait"

--- a/Sources/AppcuesKit/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Traits/TraitRegistry.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class TraitRegistry {
     private var traits: [String: ExperienceTrait.Type] = [:]
 

--- a/Sources/AppcuesKit/UI/ExperienceLoader.swift
+++ b/Sources/AppcuesKit/UI/ExperienceLoader.swift
@@ -8,10 +8,12 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal protocol ExperienceLoading {
     func load(experienceID: String, published: Bool, completion: ((Result<Void, Error>) -> Void)?)
 }
 
+@available(iOS 13.0, *)
 internal class ExperienceLoader: ExperienceLoading {
 
     private let networking: Networking

--- a/Sources/AppcuesKit/UI/ExperienceModals/AppcuesHostingController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/AppcuesHostingController.swift
@@ -11,6 +11,7 @@ import SwiftUI
 /// A `UIHostingController` that properly handles content size changes and removes the extra spacing added in iOS 15.
 ///
 /// Reference: https://stackoverflow.com/a/69359296
+@available(iOS 13.0, *)
 internal class AppcuesHostingController<Content: View>: UIHostingController<Content> {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()

--- a/Sources/AppcuesKit/UI/ExperienceModals/AppcuesStyle.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/AppcuesStyle.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesStyle {
     let padding: EdgeInsets
     let margin: EdgeInsets

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesBox.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesBox.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesBox: View {
     let model: ExperienceComponent.BoxModel
 
@@ -27,6 +28,7 @@ internal struct AppcuesBox: View {
 }
 
 #if DEBUG
+@available(iOS 13.0, *)
 internal struct AppcuesBoxPreview: PreviewProvider {
 
     static var previews: some View {

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesButton.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesButton.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesButton: View {
     let model: ExperienceComponent.ButtonModel
 
@@ -33,6 +34,7 @@ internal struct AppcuesButton: View {
 }
 
 #if DEBUG
+@available(iOS 13.0, *)
 internal struct AppcuesButtonPreview: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesEmbed.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesEmbed.swift
@@ -9,6 +9,7 @@
 import Foundation
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesEmbed: View {
     let model: ExperienceComponent.EmbedModel
 
@@ -24,6 +25,7 @@ internal struct AppcuesEmbed: View {
 }
 
 #if DEBUG
+@available(iOS 13.0, *)
 internal struct AppcuesEmbedPreview: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesImage.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesImage: View {
     let model: ExperienceComponent.ImageModel
 
@@ -56,6 +57,7 @@ internal struct AppcuesImage: View {
 }
 
 #if DEBUG
+@available(iOS 13.0, *)
 internal struct AppcuesImagePreview: PreviewProvider {
     // swiftlint:disable:next force_unwrapping
     static let imageURL = URL(string: "https://res.cloudinary.com/dnjrorsut/image/upload/v1513187203/crx-assets/modal-slideout-hero-image.png")!

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesStack.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesStack.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesStack: View {
     let model: ExperienceComponent.StackModel
 
@@ -54,6 +55,7 @@ internal struct AppcuesStack: View {
 }
 
 #if DEBUG
+@available(iOS 13.0, *)
 internal struct AppcuesStackPreview: PreviewProvider {
 
     static var previews: some View {

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/AppcuesText.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct AppcuesText: View {
     let model: ExperienceComponent.TextModel
 
@@ -24,6 +25,7 @@ internal struct AppcuesText: View {
 }
 
 #if DEBUG
+@available(iOS 13.0, *)
 internal struct AppcuesTextPreview: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/EmbedWebView.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/EmbedWebView.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import WebKit
 
+@available(iOS 13.0, *)
 internal struct EmbedWebView: UIViewRepresentable {
     let embed: String
 

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/EnvironmentValues+ImageCache.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/EnvironmentValues+ImageCache.swift
@@ -8,10 +8,12 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct ImageCacheKey: EnvironmentKey {
     static let defaultValue = SessionImageCache()
 }
 
+@available(iOS 13.0, *)
 extension EnvironmentValues {
     var imageCache: SessionImageCache {
         get { self[ImageCacheKey.self] }

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/LoopingVideoPlayer.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/LoopingVideoPlayer.swift
@@ -13,6 +13,7 @@ internal struct LoopingVideoPlayer {
     let url: URL
 }
 
+@available(iOS 13.0, *)
 extension LoopingVideoPlayer: UIViewRepresentable {
 
     func makeUIView(context: Context) -> LoopingVideoView {

--- a/Sources/AppcuesKit/UI/ExperienceModals/Components/RemoteImage.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/Components/RemoteImage.swift
@@ -12,6 +12,7 @@ import Combine
 // AsyncImage is iOS 15+, so borrow this from
 // https://www.vadimbulavin.com/asynchronous-swiftui-image-loading-from-url-with-combine-and-swift/
 
+@available(iOS 13.0, *)
 internal class ImageLoader: ObservableObject {
     @Published var image: UIImage?
     private(set) var isLoading = false
@@ -55,6 +56,7 @@ internal class ImageLoader: ObservableObject {
     }
 }
 
+@available(iOS 13.0, *)
 internal struct RemoteImage<Placeholder: View>: View {
     @ObservedObject private var loader: ImageLoader
     private let placeholder: Placeholder

--- a/Sources/AppcuesKit/UI/ExperienceModals/DefaultContainerViewController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/DefaultContainerViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class DefaultContainerViewController: UIViewController, ExperienceContainerViewController {
 
     weak var lifecycleHandler: ExperienceContainerLifecycleHandler?

--- a/Sources/AppcuesKit/UI/ExperienceModals/DialogContainerView.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/DialogContainerView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class DialogContainerView: UIView {
 
     let dialogView: UIView = {

--- a/Sources/AppcuesKit/UI/ExperienceModals/DialogContainerViewController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/DialogContainerViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class DialogContainerViewController: UIViewController {
 
     lazy var containerView = DialogContainerView()

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+PreviewProvider.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+PreviewProvider.swift
@@ -14,6 +14,7 @@ import Foundation
 // swiftlint:disable:next type_name
 internal typealias EC = ExperienceComponent
 
+@available(iOS 13.0, *)
 extension ExperienceComponent {
     static let textPlain = TextModel(
         id: UUID(),

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceComponent+View.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension ExperienceComponent {
 
     @ViewBuilder var view: some View {

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepRootView.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepRootView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct ExperienceStepRootView<Content: View>: View {
     let rootView: Content
 

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class ExperienceStepViewController: UIViewController {
 
     let viewModel: ExperienceStepViewModel
@@ -56,6 +57,7 @@ internal class ExperienceStepViewController: UIViewController {
 
 }
 
+@available(iOS 13.0, *)
 extension ExperienceStepViewController {
     class ExperienceStepView: UIView {
         lazy var scrollView: UIScrollView = {

--- a/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/UI/ExperienceModals/ExperienceStepViewModel.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal class ExperienceStepViewModel: ObservableObject {
 
     enum ActionType: String {

--- a/Sources/AppcuesKit/UI/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/UI/ExperienceRenderer.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal protocol ExperienceRendering {
     func show(experience: Experience, published: Bool, completion: ((Result<Void, Error>) -> Void)?)
     func show(qualifiedExperiences: [Experience], completion: ((Result<Void, Error>) -> Void)?)
@@ -15,6 +16,7 @@ internal protocol ExperienceRendering {
     func dismissCurrentExperience(completion: (() -> Void)?)
 }
 
+@available(iOS 13.0, *)
 internal class ExperienceRenderer: ExperienceRendering {
 
     private let stateMachine: ExperienceStateMachine

--- a/Sources/AppcuesKit/UI/ExperienceStateMachine+Action.swift
+++ b/Sources/AppcuesKit/UI/ExperienceStateMachine+Action.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     enum Action {
         case startExperience(Experience)

--- a/Sources/AppcuesKit/UI/ExperienceStateMachine+ExperienceError.swift
+++ b/Sources/AppcuesKit/UI/ExperienceStateMachine+ExperienceError.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     enum ExperienceError: Error {
         case noTransition
@@ -17,6 +18,7 @@ extension ExperienceStateMachine {
     }
 }
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine.ExperienceError: Equatable {
     static func == (lhs: ExperienceStateMachine.ExperienceError, rhs: ExperienceStateMachine.ExperienceError) -> Bool {
         switch (lhs, rhs) {
@@ -34,6 +36,7 @@ extension ExperienceStateMachine.ExperienceError: Equatable {
     }
 }
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine.ExperienceError: CustomStringConvertible {
     var description: String {
         switch self {

--- a/Sources/AppcuesKit/UI/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/UI/ExperienceStateMachine+State.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     enum State {
         case idling
@@ -56,6 +57,7 @@ extension ExperienceStateMachine {
     }
 }
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine.State: Equatable {
     static func == (lhs: ExperienceStateMachine.State, rhs: ExperienceStateMachine.State) -> Bool {
         switch (lhs, rhs) {
@@ -77,6 +79,7 @@ extension ExperienceStateMachine.State: Equatable {
     }
 }
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine.State: CustomStringConvertible {
     var description: String {
         switch self {
@@ -98,6 +101,7 @@ extension ExperienceStateMachine.State: CustomStringConvertible {
 
 // MARK: - Complex Transitions
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine.Transition {
     static func fromIdlingToBeginningExperience(_ experience: Experience) -> Self {
         guard !experience.steps.isEmpty else {

--- a/Sources/AppcuesKit/UI/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/UI/ExperienceStateMachine.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class ExperienceStateMachine {
 
     private let config: Appcues.Config
@@ -76,6 +77,7 @@ internal class ExperienceStateMachine {
 
 // MARK: - ExperienceContainerLifecycleHandler
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine: ExperienceContainerLifecycleHandler {
     // MARK: Step Lifecycle
 
@@ -181,6 +183,7 @@ extension ExperienceStateMachine: ExperienceContainerLifecycleHandler {
 
 // MARK: - State Machine Types
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     struct Transition {
         let toState: State?
@@ -198,6 +201,7 @@ extension ExperienceStateMachine {
     }
 }
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     enum SideEffect {
         case continuation(Action)

--- a/Sources/AppcuesKit/UI/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/UI/ExperienceStateObserver.swift
@@ -8,11 +8,13 @@
 
 import Foundation
 
+@available(iOS 13.0, *)
 internal protocol ExperienceStateObserver: AnyObject {
     typealias StateResult = Result<ExperienceStateMachine.State, ExperienceStateMachine.ExperienceError>
     func evaluateIfSatisfied(result: StateResult) -> Bool
 }
 
+@available(iOS 13.0, *)
 extension Result where Success == ExperienceStateMachine.State, Failure == ExperienceStateMachine.ExperienceError {
     /// Check if the result pertains to a specific experience ID.
     func matches(instanceID: UUID?) -> Bool {
@@ -34,6 +36,7 @@ extension Result where Success == ExperienceStateMachine.State, Failure == Exper
     }
 }
 
+@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     typealias Callback = (ExperienceStateObserver.StateResult) -> Bool
 

--- a/Sources/AppcuesKit/UI/Extensions/Inits/Alignment+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/Alignment+String.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension Alignment {
 
     /// Init `Alignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/Axis+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/Axis+String.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension Axis {
 
     /// Init `Axis` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/CAShapeLayer+RawShadow.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/CAShapeLayer+RawShadow.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 extension CAShapeLayer {
 
     /// Init `CAShapeLayer` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/Color+DynamicColor.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/Color+DynamicColor.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension UIColor {
     convenience init?(dynamicColor: ExperienceComponent.Style.DynamicColor?) {
         guard let semanticColor = dynamicColor else { return nil }
@@ -22,6 +23,7 @@ extension UIColor {
     }
 }
 
+@available(iOS 13.0, *)
 extension Color {
     init?(dynamicColor: ExperienceComponent.Style.DynamicColor?) {
         guard let uiColor = UIColor(dynamicColor: dynamicColor) else { return nil }

--- a/Sources/AppcuesKit/UI/Extensions/Inits/ContentMode+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/ContentMode+String.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension ContentMode {
 
     /// Init `ContentMode` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/Edge+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/Edge+String.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension Edge {
     init?(_ string: String?) {
         switch string {

--- a/Sources/AppcuesKit/UI/Extensions/Inits/Font+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/Font+String.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension Font {
 
     /// Init `Font` from an experience JSON model values.
@@ -21,6 +22,7 @@ extension Font {
     }
 }
 
+@available(iOS 13.0, *)
 extension Font.Weight {
 
     /// Init `Font.Weight` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/HorizontalAlignment+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/HorizontalAlignment+String.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension HorizontalAlignment {
 
     /// Init `HorizontalAlignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/Image+BlurHash.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/Image+BlurHash.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension Image {
     init?(blurHash: String?, size: CGSize = CGSize(width: 16, height: 16)) {
         guard let blurHash = blurHash, let image = UIImage(blurHash: blurHash, size: size) else {

--- a/Sources/AppcuesKit/UI/Extensions/Inits/LinearGradient+Init.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/LinearGradient+Init.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension LinearGradient {
 
     /// Init `LinearGradient` from an experience JSON model value.
@@ -24,6 +25,7 @@ extension LinearGradient {
     }
 }
 
+@available(iOS 13.0, *)
 extension UnitPoint {
 
     /// Init `UnitPoint` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/TextAlignment+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/TextAlignment+String.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension TextAlignment {
 
     /// Init `TextAlignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/Inits/VerticalAlignment+String.swift
+++ b/Sources/AppcuesKit/UI/Extensions/Inits/VerticalAlignment+String.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension VerticalAlignment {
 
     /// Init `VerticalAlignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/UI/Extensions/NSCollectionLayoutSection+Factory.swift
+++ b/Sources/AppcuesKit/UI/Extensions/NSCollectionLayoutSection+Factory.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 extension NSCollectionLayoutSection {
     static func fullScreenCarousel() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(

--- a/Sources/AppcuesKit/UI/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/UI/Extensions/UIApplication+TopViewController.swift
@@ -17,6 +17,7 @@ internal protocol URLOpening {
 
 extension UIApplication: TopControllerGetting, URLOpening {
 
+    @available(iOS 13.0, *)
     var activeWindowScenes: [UIWindowScene] {
         self.connectedScenes
             .filter { $0.activationState == .foregroundActive }
@@ -26,9 +27,13 @@ extension UIApplication: TopControllerGetting, URLOpening {
     // Note: multitasking with two instances of the same app side by side will have both designated as `.foregroundActive`,
     // and as a result the returned window may not be the one expected.
     private var activeKeyWindow: UIWindow? {
-        self.activeWindowScenes
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow }
+        if #available(iOS 13.0, *) {
+            return self.activeWindowScenes
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }
+        } else {
+            return keyWindow
+        }
     }
 
     func topViewController() -> UIViewController? {

--- a/Sources/AppcuesKit/UI/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/UI/Extensions/View+Appcues.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension View {
     // Recursively work through the sequence of actions in series.
     private func process(_ actionHandlers: [(@escaping ActionRegistry.Completion) -> Void]) {
@@ -111,6 +112,7 @@ extension View {
     }
 }
 
+@available(iOS 13.0, *)
 extension Text {
     func applyTextStyle(_ style: AppcuesStyle) -> some View {
         self

--- a/Sources/AppcuesKit/UI/Extensions/View+Conditional.swift
+++ b/Sources/AppcuesKit/UI/Extensions/View+Conditional.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension View {
 
     // https://www.avanderlee.com/swiftui/conditional-view-modifier/

--- a/project.yml
+++ b/project.yml
@@ -4,7 +4,7 @@ attributes:
 options:
   defaultConfig: Release
   deploymentTarget:
-    iOS: 13.0
+    iOS: 11.0
   groupSortPosition: top
 configs:
   Debug: debug
@@ -60,6 +60,7 @@ targets:
     platform: iOS
     settings:
       base:
+        IPHONEOS_DEPLOYMENT_TARGET: 13.0
         MARKETING_VERSION: 1.0.0
         CURRENT_PROJECT_VERSION: '1'
         GENERATE_INFOPLIST_FILE: 'YES'


### PR DESCRIPTION
## Overview

This is how things are divvied up:
![Dependency Graph](https://user-images.githubusercontent.com/845681/161075690-e0ce08d6-7b69-42cf-b1a1-f4e1d642d66c.png)

Any arrow going into the orange box requires a version check. Fortunately there's only one that's not in the main `Appcues` instance.

## Callouts
1. The only change to the public `Appcues` API is that if I call `show(experienceID:)` on an old iOS version, I'll get an error in the completion block `AppcuesError.unsupportedOSVersion`.
2. Having the `@available(iOS 13.0, *)` annotation on protocols as well as implementations (eg `TraitComposing` and `TraitComposer` is really nice because it means anywhere we resolve that protocol from the `DIContainer` has to also be wrapped in the version check. If we didn't tag the protocol, everything would still work, but we'd run the risk of runtime crashes on old iOS versions where the dependency wasn't registered.
3. I've set the tests `IPHONEOS_DEPLOYMENT_TARGET` to 13.0 so we don't have to wrap tests in version checks. We can remove that and allow some tests to be done on older OS versions, which might be valuable, especially in conjunction with 3) below.

## Next Steps

1. Update the source directory hierarchy to be organized around the iOS 10/iOS 13 distinction. I'm thinking top level directories named `Data` and `Presentation` where `Data` has all the iOS 10 analytics/models/etc, and `Presentation` has all the UI related stuff that's iOS 13+.
2. I want to create an iOS 10 example app to test against. Will also be beneficial to have an older-style app that doesn't use the UIScene stuff from iOS 13.
3. Slightly unrelated, but create a CircleCI job that we can trigger as a one-off to build using different (older) Xcode versions. We'll need to establish a min supported Xcode version and have an automated way to be sure the SDK compiles without issue on those versions.

## Update

iOS 11 was selected as the min version because setting iOS 10 causes the following compile-time error:
```
[14:29:53]: $ set -o pipefail && xcodebuild -workspace Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcworkspace -scheme AppcuesCocoapodsExample -destination 'generic/platform=iOS' build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS='' CODE_SIGNING_ALLOWED=NO | tee /Users/distiller/Library/Logs/gym/AppcuesCocoapodsExample-AppcuesCocoapodsExample.log | xcpretty
[14:30:00]: ▸ Copying Appcues-umbrella.h
[14:30:00]: ▸ Compiling AppcuesLinkAction.swift
[14:30:22]: ▸ ❌  /Users/distiller/project/Sources/AppcuesKit/UI/ExperienceModals/Components/LoopingVideoPlayer.swift:10:8: no such module '_AVKit_SwiftUI'
[14:30:22]: ▸ import AVKit
```