### PR TITLE
Add tests for SessionMonitor

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -244,12 +244,18 @@ public class Appcues {
         }
         publish(TrackingUpdate(type: .profile, properties: properties))
     }
-}
 
-extension Appcues: AnalyticsPublishing {
+    // internal implementation of AnalyticsPublishing that allows for the additional option to specify
+    // whether the event is `interactive` -- used to determine if it can be batched and sent later (i.e. experience
+    // analytics) or must be sent immeidately.
+    //
+    // this is not in the extension below so that it can be overriden in unit test
     func track(name: String, properties: [String: Any]?, interactive: Bool) {
         publish(TrackingUpdate(type: .event(name: name, interactive: interactive), properties: properties))
     }
+}
+
+extension Appcues: AnalyticsPublishing {
 
     func register(subscriber: AnalyticsSubscribing) {
         subscribers.append(subscriber)

--- a/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
+++ b/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
@@ -29,7 +29,6 @@ internal class SessionMonitor: SessionMonitoring {
     private let storage: DataStoring
     private let publisher: AnalyticsPublishing
     private let tracker: AnalyticsTracking
-    private let processor: ActivityProcessing
 
     private let sessionTimeout: UInt
 
@@ -43,7 +42,6 @@ internal class SessionMonitor: SessionMonitoring {
     init(container: DIContainer) {
         self.publisher = container.resolve(AnalyticsPublishing.self)
         self.tracker = container.resolve(AnalyticsTracking.self)
-        self.processor = container.resolve(ActivityProcessing.self)
         self.storage = container.resolve(DataStoring.self)
         self.sessionTimeout = container.resolve(Appcues.Config.self).sessionTimeout
 

--- a/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
@@ -33,9 +33,10 @@ class AppcuesTrackActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var trackCount = 0
-        appcues.onTrack = { name, properties in
+        appcues.onTrack = { name, properties, interactive in
             XCTAssertEqual(name, "My Custom Event")
             XCTAssertNil(properties)
+            XCTAssertTrue(interactive)
             trackCount += 1
         }
         let action = AppcuesTrackAction(config: ["eventName": "My Custom Event"])

--- a/Tests/AppcuesKitTests/Analytics/SessionMonitorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/SessionMonitorTests.swift
@@ -1,0 +1,225 @@
+//
+//  SessionMonitorTests.swift
+//  AppcuesKitTests
+//
+//  Created by James Ellis on 4/1/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+class SessionMonitorTests: XCTestCase {
+
+    var sessionMonitor: SessionMonitor!
+    var appcues: MockAppcues!
+
+    override func setUp() {
+        let config = Appcues.Config(accountID: "00000", applicationID: "abc")
+        appcues = MockAppcues(config: config)
+        sessionMonitor = SessionMonitor(container: appcues.container)
+    }
+
+    override func tearDown() {
+        // SessionMonitor uses the shared NotificationCenter.default when listening to system
+        // foreground/background notifications - we need to unhook these listners after each test
+        // so that no instance lingers around and fulfills expectations more than once due to
+        // that shared resource triggering additional events to flow through the system on older
+        // Appcues instances from previous tests.
+        appcues.onTrack = nil
+        appcues.analyticsTracker.onFlush = nil
+    }
+
+    func testStart() throws {
+        // Arrange
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        appcues.storage.userID = "user123"
+        appcues.onTrack = { name, props, interactive in
+            if name == SessionEvents.sessionStarted.rawValue{
+                XCTAssertTrue(interactive)
+                XCTAssertNil(props)
+                onTrackExpectation.fulfill()
+            }
+        }
+
+        // Act
+        sessionMonitor.start()
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(sessionMonitor.isActive)
+    }
+
+    func testStartNoUser() throws {
+        // Arrange
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        onTrackExpectation.isInverted = true
+        appcues.storage.userID = ""
+        appcues.onTrack = { name, _, _ in
+            if name == SessionEvents.sessionStarted.rawValue {
+                onTrackExpectation.fulfill()
+            }
+        }
+
+        // Act
+        sessionMonitor.start()
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(sessionMonitor.isActive)
+    }
+
+    func testReset() throws {
+        // Arrange
+        appcues.storage.userID = "user123"
+        sessionMonitor.start()
+        appcues.storage.userID = ""
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        appcues.onTrack = { name, props, interactive in
+            if name == SessionEvents.sessionReset.rawValue {
+                XCTAssertFalse(interactive)
+                XCTAssertNil(props)
+                onTrackExpectation.fulfill()
+            }
+        }
+
+        // Act
+        sessionMonitor.reset()
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(sessionMonitor.isActive)
+    }
+
+    func testBackground() throws {
+        // Arrange
+        appcues.storage.userID = "user123"
+        sessionMonitor.start()
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        let onFlushExpectation = expectation(description: "analytics tracker flushed")
+        appcues.onTrack = { name, props, interactive in
+            if name == SessionEvents.sessionSuspended.rawValue {
+                XCTAssertFalse(interactive)
+                XCTAssertNil(props)
+                onTrackExpectation.fulfill()
+            }
+        }
+        appcues.analyticsTracker.onFlush = {
+            onFlushExpectation.fulfill()
+        }
+
+        // Act
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(sessionMonitor.isActive)
+    }
+
+    func testBackgroundNoSession() throws {
+        // Arrange
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        let onFlushExpectation = expectation(description: "analytics tracker flushed")
+        onTrackExpectation.isInverted = true
+        onFlushExpectation.isInverted = true
+        appcues.onTrack = { name, _, _ in
+            if name == SessionEvents.sessionSuspended.rawValue {
+                onTrackExpectation.fulfill()
+            }
+        }
+        appcues.analyticsTracker.onFlush = {
+            onFlushExpectation.fulfill()
+        }
+
+        // Act
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(sessionMonitor.isActive)
+    }
+
+    func testForegroundNoSession() throws {
+        // Arrange
+        appcues.storage.userID = "user123"
+        sessionMonitor.start()
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
+        sessionMonitor.reset()
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        onTrackExpectation.isInverted = true
+        appcues.onTrack = { name, _, _ in
+            if name == SessionEvents.sessionStarted.rawValue || name == SessionEvents.sessionResumed.rawValue {
+                onTrackExpectation.fulfill()
+            }
+        }
+
+        // Act
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(sessionMonitor.isActive)
+    }
+
+    func testForegroundNoBackground() throws {
+        // Arrange
+        appcues.storage.userID = "user123"
+        sessionMonitor.start()
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        onTrackExpectation.isInverted = true
+        appcues.onTrack = { name, _, _ in
+            if name == SessionEvents.sessionStarted.rawValue || name == SessionEvents.sessionResumed.rawValue {
+                onTrackExpectation.fulfill()
+            }
+        }
+
+        // Act
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(sessionMonitor.isActive)
+    }
+
+    func testForegroundResume() throws {
+        // Arrange
+        appcues = MockAppcues(config: Appcues.Config(accountID: "00000", applicationID: "abc").sessionTimeout(1_800))
+        sessionMonitor = SessionMonitor(container: appcues.container)
+        appcues.storage.userID = "user123"
+        sessionMonitor.start()
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        appcues.onTrack = { name, _, _ in
+            if name == SessionEvents.sessionResumed.rawValue {
+                onTrackExpectation.fulfill()
+            }
+        }
+
+        // Act
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    func testForegroundStartNewSession() throws {
+        // Arrange
+        appcues = MockAppcues(config: Appcues.Config(accountID: "00000", applicationID: "abc").sessionTimeout(0))
+        sessionMonitor = SessionMonitor(container: appcues.container)
+        appcues.storage.userID = "user123"
+        sessionMonitor.start()
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
+        let onTrackExpectation = expectation(description: "session analytics tracked")
+        appcues.onTrack = { name, _, _ in
+            if name == SessionEvents.sessionStarted.rawValue {
+                onTrackExpectation.fulfill()
+            }
+        }
+
+        // Act
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -37,6 +37,7 @@ class MockAppcues: Appcues {
         container.register(TraitComposing.self, value: traitComposer)
         container.register(ActivityProcessing.self, value: activityProcessor)
         container.register(ActivityStoring.self, value: activityStorage)
+        container.register(AnalyticsTracking.self, value: analyticsTracker)
 
 
         // dependencies that are not mocked
@@ -51,10 +52,10 @@ class MockAppcues: Appcues {
         super.identify(userID: userID, properties: properties)
     }
 
-    var onTrack: ((String, [String: Any]?) -> Void)?
-    override func track(name: String, properties: [String : Any]? = nil) {
-        onTrack?(name, properties)
-        super.track(name: name, properties: properties)
+    var onTrack: ((String, [String: Any]?, Bool) -> Void)?
+    override func track(name: String, properties: [String : Any]?, interactive: Bool) {
+        onTrack?(name, properties, interactive)
+        super.track(name: name, properties: properties, interactive: interactive)
     }
 
     var onScreen: ((String, [String: Any]?) -> Void)?
@@ -73,6 +74,7 @@ class MockAppcues: Appcues {
     var traitComposer = MockTraitComposer()
     var activityStorage = MockActivityStorage()
     var networking = MockNetworking()
+    var analyticsTracker = MockAnalyticsTracker()
 }
 
 class MockStorage: DataStoring {
@@ -132,14 +134,9 @@ class MockSessionMonitor: SessionMonitoring {
 class MockActivityProcessor: ActivityProcessing {
 
     var onProcess: ((Activity, (Result<QualifyResponse, Error>) -> Void) -> Void)?
-    var onFlush: (() -> Void)?
 
     func process(_ activity: Activity, completion: @escaping (Result<QualifyResponse, Error>) -> Void) {
         onProcess?(activity, completion)
-    }
-
-    func flush() {
-        onFlush?()
     }
 }
 
@@ -237,4 +234,11 @@ class MockNetworking: Networking {
     }
 
 
+}
+
+class MockAnalyticsTracker: AnalyticsTracking {
+    var onFlush: (() -> Void)?
+    func flush() {
+        onFlush?()
+    }
 }


### PR DESCRIPTION
Need a few small updates in related mocking logic.  The only part I found semi interesting here was the shared usage of the `NotificationCenter.default` which could cause expectations to be fulfilled multiple times due to multiple tests sending the same notifications.  I got around this by unsubscribing after each test.  We could potentially go a more explicit route to allow mocking of the system notifications there, but that would have been a more involved change and updates in the core SDK code.  Seemed like overkill for this.

![Screen Shot 2022-04-04 at 11 39 38 AM](https://user-images.githubusercontent.com/19266448/161580612-24d25540-5977-4893-9c62-3ad17e229897.png)
