### PR TITLE
Allow userID to be included on experience_preview endpoint

### DIFF
--- a/Sources/AppcuesKit/Data/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Data/Networking/Endpoint.swift
@@ -27,26 +27,12 @@ internal enum APIEndpoint: Endpoint {
         case let .content(experienceID):
             components.path = "/v1/accounts/\(config.accountID)/users/\(storage.userID)/experience_content/\(experienceID)"
         case let .preview(experienceID):
-            // note: preview does not contain the /users/{user_id} portion of the path
-            components.path = "/v1/accounts/\(config.accountID)/experience_preview/\(experienceID)"
-        }
-
-        return components.url
-    }
-}
-
-/// Endpoint in the Appcues CDN.
-internal enum CDNEndpoint: Endpoint {
-    case styles(styleID: String)
-
-    func url(config: Appcues.Config, storage: DataStoring) -> URL? {
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = "fast.appcues.com"
-
-        switch self {
-        case let .styles(styleID):
-            components.path = "/v1/accounts/\(config.accountID)/styles/\(styleID)"
+            // optionally include the userID, if one exists, to allow for a personalized preview capability
+            if storage.userID.isEmpty {
+                components.path = "/v1/accounts/\(config.accountID)/experience_preview/\(experienceID)"
+            } else {
+                components.path = "/v1/accounts/\(config.accountID)/users/\(storage.userID)/experience_preview/\(experienceID)"
+            }
         }
 
         return components.url


### PR DESCRIPTION
Also remove some dead code for `CDNEndpoint`.  Something similar may return in the future if/when Themes are built.