### PR TITLE
Update debugger to ping health endpoint to check connectivity

### DIFF
--- a/Sources/AppcuesKit/Data/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Data/Networking/Endpoint.swift
@@ -14,6 +14,7 @@ internal enum APIEndpoint: Endpoint {
     case qualify(userID: String)
     case content(experienceID: String)
     case preview(experienceID: String)
+    case health
 
     /// URL fragments that that are appended to the `Config.apiHost` to make the URL for a network request.
     func url(config: Appcues.Config, storage: DataStoring) -> URL? {
@@ -33,6 +34,8 @@ internal enum APIEndpoint: Endpoint {
             } else {
                 components.path = "/v1/accounts/\(config.accountID)/users/\(storage.userID)/experience_preview/\(experienceID)"
             }
+        case .health:
+            components.path = "/healthz"
         }
 
         return components.url

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -80,6 +80,16 @@ internal enum DebugUI {
                          Text(subtitle).font(.caption)
                      }
                  }
+                 if let action = item.action {
+                     Spacer()
+                     Button {
+                         action.block()
+                     } label: {
+                         Image(systemName: action.symbolName)
+                             .imageScale(.small)
+                     }
+                     .foregroundColor(.secondary)
+                 }
              }
              .ifLet(item.detailText) { view, detail in
                  view.contextMenu {

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -34,6 +34,7 @@ internal class UIDebugger: UIDebugging {
         self.notificationCenter = container.resolve(NotificationCenter.self)
 
         self.viewModel = DebugViewModel(
+            networking: container.resolve(Networking.self),
             accountID: config.accountID,
             applicationID: config.applicationID,
             currentUserID: storage.userID,


### PR DESCRIPTION
The health endpoint is automatically pinged when the debugger loads and then can be manually refreshed if the uses suspects there's an issue.

![Simulator Screen Shot - iPhone 13 Pro - 2022-04-07 at 11 15 19](https://user-images.githubusercontent.com/845681/162233123-9268e85b-cb3d-4636-b907-9562bba3f5c6.png)

A long press on the "Connected to Appcues" row will allow you to copy the full error if there is one. For example:

```
Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline." UserInfo={_kCFStreamErrorCodeKey=50, NSUnderlyingError=0x60000238a580 {Error Domain=kCFErrorDomainCFNetwork Code=-1009 "(null)" UserInfo={_NSURLErrorNWPathKey=unsatisfied (No network route), _kCFStreamErrorCodeKey=50, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <D32FC1AD-1D30-46DE-B33C-A6EE1D80EB8C>.<6>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <D32FC1AD-1D30-46DE-B33C-A6EE1D80EB8C>.<6>"
), NSLocalizedDescription=The Internet connection appears to be offline., NSErrorFailingURLStringKey=https://api.appcues.net/healthz, NSErrorFailingURLKey=https://api.appcues.net/healthz, _kCFStreamErrorDomainKey=1}
```