### PR TITLE
Fix broken environment variable reference

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -99,7 +99,7 @@ platform :ios do
       commits_count: 5,
       pretty: "- [%as] %s"
     )
-    changelog = "Latest commits on #{CIRCLE_BRANCH}:\n" + git_log + "\n\nCircleCI Build: #{ENV["CIRCLE_BUILD_NUM"]}"
+    changelog = "Latest commits on #{ENV["CIRCLE_BRANCH"]}:\n" + git_log + "\n\nCircleCI Build: #{ENV["CIRCLE_BUILD_NUM"]}"
     
     upload_to_testflight(
       api_key: ENV["APP_STORE_CONNECT_API_KEY"],


### PR DESCRIPTION
Tried to push a new example app to TestFlight and it failed referencing the `CIRCLE_BRANCH` env value for compiling the changelog.

```
Search query: uninitialized constant Fastlane::FastFile::CIRCLE_BRANCH
```

I'm fairly sure I was just referencing it wrong, but I can't test it again until it's merged to `main`.