### PR TITLE
Convert svg image urls to scaled png urls

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
@@ -11,6 +11,7 @@ import SwiftUI
 @available(iOS 13.0, *)
 internal struct AppcuesImage: View {
     let model: ExperienceComponent.ImageModel
+    private let transformedURL: URL
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
     @Environment(\.imageCache) var imageCache: SessionImageCache
@@ -36,12 +37,19 @@ internal struct AppcuesImage: View {
             .applyExternalLayout(style)
     }
 
+    internal init(model: ExperienceComponent.ImageModel) {
+        self.model = model
+
+        // Setting this in the init to avoid recomputing it more frequently than necessary.
+        self.transformedURL = model.imageUrl.transformImage(width: model.style?.width, height: model.style?.height)
+    }
+
     @ViewBuilder
     private func content(placeholder: Color?) -> some View {
         if model.imageUrl.scheme == "sf-symbol" {
             Image(systemName: model.imageUrl.host ?? "")
         } else {
-            RemoteImage(url: model.imageUrl, cache: imageCache) {
+            RemoteImage(url: transformedURL, cache: imageCache) {
                 if let blurImage = Image(blurHash: model.blurHash) {
                     blurImage.resizable()
                 } else {
@@ -49,6 +57,50 @@ internal struct AppcuesImage: View {
                 }
             }
         }
+    }
+}
+
+private extension URL {
+
+    /// Transforms an image URL to one with the best chance of rendering.
+    func transformImage(width: Double? = nil, height: Double? = nil) -> URL {
+        // Note: we're not specifically checking for Cloudinary in the URL because there's no functional
+        // difference between a non-renderable image and a 404 caused by transforming a non-Cloudinary URL.
+        if pathExtension == "svg" {
+            return transformSVG(components: URLComponents(url: self, resolvingAgainstBaseURL: false), width: width, height: height) ?? self
+        }
+
+        return self
+    }
+
+    /// Converts a URL like https://res.cloudinary.com/xyz/image/upload/v123/000/abc.svg to
+    /// https://res.cloudinary.com/xyz/image/upload/h_600,c_scale/v123/000/abc.png
+    private func transformSVG(components: URLComponents?, width: Double? = nil, height: Double? = nil) -> URL? {
+        guard var components = components else { return self }
+
+        // Replace .svg in the path extension with .png
+        let options: String.CompareOptions = [.backwards, .caseInsensitive]
+        guard let range = components.path.range(of: ".svg", options: options, range: nil, locale: nil) else { return self }
+        components.path = components.path.replacingCharacters(in: range, with: ".png")
+
+        // Scale the png to the right size so it appears crisp like a vector would.
+        let scale: CGFloat = UIScreen.main.scale
+        var parts = components.path.split(separator: "/")
+        if parts.count == 6, parts[2] == "upload" {
+            if let width = width {
+                // An integer scale value represents a fixed pixel size.
+                parts.insert("w_\(Int(width * scale)),c_scale", at: 3)
+            } else if let height = height {
+                parts.insert("h_\(Int(height * scale)),c_scale", at: 3)
+            } else {
+                // If no fixed size, scale the default SVG size by the screen density.
+                // A decimal scale value represents a percentage.
+                parts.insert("w_\(scale),c_scale", at: 3)
+            }
+        }
+        components.path = "/" + parts.joined(separator: "/")
+
+        return components.url
     }
 }
 


### PR DESCRIPTION
Like the comment says,
```
// Note: we're not specifically checking for Cloudinary in the URL because there's no functional
// difference between a non-renderable image and a 404 caused by transforming a non-Cloudinary URL.
```
I'm not worried about breaking a non-Cloudinary svg url since we can't render it anyways, and adding checks for our specific bucket or other url properties would make things more problematic if we ever were to move away from Cloudinary. Given how this is implemented, we could move to a new image provider and as long as we created a proxy interface compatible with what this transform is doing, images would continue to work as expected.

Also, this solution doesn't account for the size of the image in the modal if no explicit height/width is set since it scales the based on the svg source size. My though there is if someone does have issues with a small svg being scaled and burry because it's filling the modal width, there's always the option to resize and re-upload the svg source to be more comparable. Not an ideal option, but an easy enough escape hatch in a dire situation.