### PR TITLE
Fix the config key for opening a link action in external browser

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -21,7 +21,7 @@ internal class AppcuesLinkAction: ExperienceAction {
     required init?(config: [String: Any]?) {
         if let url = URL(string: config?["url"] as? String ?? "") {
             self.url = url
-            self.openExternally = (config?["external"] as? Bool) ?? false
+            self.openExternally = (config?["openExternally"] as? Bool) ?? false
         } else {
             return nil
         }

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -40,7 +40,7 @@ class AppcuesLinkActionTests: XCTestCase {
             XCTAssertTrue(vc is SFSafariViewController)
             presentCount += 1
         }
-        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "external": false])
+        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": false])
         action?.urlOpener = mockURLOpener
 
         // Act
@@ -60,7 +60,7 @@ class AppcuesLinkActionTests: XCTestCase {
             XCTAssertEqual(url.absoluteString, "https://appcues.com")
             openCount += 1
         }
-        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "external": true])
+        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": true])
         action?.urlOpener = mockURLOpener
 
         // Act
@@ -80,7 +80,7 @@ class AppcuesLinkActionTests: XCTestCase {
             XCTAssertEqual(url.absoluteString, "deeplink://test")
             openCount += 1
         }
-        let action = AppcuesLinkAction(config: ["url": "deeplink://test", "external": false])
+        let action = AppcuesLinkAction(config: ["url": "deeplink://test", "openExternally": false])
         action?.urlOpener = mockURLOpener
 
         // Act


### PR DESCRIPTION
Noticed while testing Android - we had a discrepancy in which config key was used "external" or "openExternally".  According to the [spec](https://github.com/appcues/appcues-mobile-experience-spec/blob/main/action-schemas/appcues-link-schema.json#L30), it should be "openExternally" - so updating iOS to match.