### PR TITLE
Fix unwanted scroll bouncing in dialog modals

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/AppcuesHostingController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesHostingController.swift
@@ -16,6 +16,6 @@ internal class AppcuesHostingController<Content: View>: UIHostingController<Cont
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         view.setNeedsUpdateConstraints()
-        preferredContentSize = view.intrinsicContentSize
+        preferredContentSize = view.frame.size
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -52,7 +52,7 @@ internal class ExperienceStepViewController: UIViewController {
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
 
-        preferredContentSize = stepView.contentView.frame.size
+        preferredContentSize = stepView.scrollView.contentSize
     }
 
 }


### PR DESCRIPTION
This (deceptively simple 🙃) PR is related to the fix in #110. That fixed the infinite loop by adding the scroll bouncing instead (baby steps!).

This time, by sizing according to the scrollview `contentSize`, we ensure there's no unnecessary bouncing. The `contentSize` calculation is rounded up to whole numbers, so the the fix from #110 can be reverted back to what it was which was a more intuitive value.

I'll check if I can create a UI test that tries to scroll the modal and make sure it doesn't bounce. Not sure if that'll work, but that's the only real way I can think to capture it in a test.

The rounding issue itself stems from SwiftUI, specifically the `.aspectRatio` modifier on an image. A reduced test case for the step content is
```json
{
    "type": "stack",
    "orientation": "vertical",
    "id": "2cf7dbf7-c6be-4130-b642-85861f9c6b6a",
    "style": {},
    "items": [
        {
            "type": "stack",
            "id": "8e46637d-071a-4405-a9dd-dec4a64e98b8",
            "orientation": "horizontal",
            "distribution": "equal",
            "items": [
                {
                    "type": "block",
                    "blockType": "image",
                    "id": "80bb63b2-2db2-44a4-b5fc-61c3d7f5c889",
                    "content": {
                        "type": "image",
                        "id": "f2affaaa-0883-42f8-a313-73a28cc2d0b4",
                        "imageUrl": "https://res.cloudinary.com/dnjrorsut/image/upload/v1644263971/34567/jurncsf68kllngmy0dsi.jpg",
                        "contentMode": "fill",
                        "intrinsicSize": {
                            "width": 360,
                            "height": 200
                        },
                        "accessibilityLabel": "Bengals game winning field goal"
                    }
                }
            ]
        }
    ]
}
```

For this example, if the modal has a width of `358`, and the aspect ratio of the image is `1.8`, then the `.aspectRatio` SwiftUI modifier sets the image height to `358 / 1.8 = 198.8888888889`. Something in the interplay between SwiftUI and UIKit causes issues with the sizing calculation, I'm not sure how to determine what exactly is happening there, but at least I've been able to track it back to the `.aspectRatio` modifier. 