### PR TITLE
Fix sticky content causing scrolling in dialog modals

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -52,7 +52,11 @@ internal class ExperienceStepViewController: UIViewController {
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
 
-        preferredContentSize = stepView.scrollView.contentSize
+        let contentSize = stepView.scrollView.contentSize
+        preferredContentSize = CGSize(
+            width: contentSize.width + additionalSafeAreaInsets.left + additionalSafeAreaInsets.right,
+            height: contentSize.height + additionalSafeAreaInsets.top + additionalSafeAreaInsets.bottom
+        )
     }
 
 }


### PR DESCRIPTION
This regressed at some point, which is a sure sign this needs tests (which are included in https://github.com/appcues/appcues-mobile-experience-spec/pull/43). 

|Now|Before|
|-|-|
|![after](https://user-images.githubusercontent.com/845681/167446439-c99f551d-c7b3-4be5-8338-220a7f0cff31.png)|![before](https://user-images.githubusercontent.com/845681/167446448-947f907b-1dee-410e-b04a-7ef3d046a8b5.png)|

(I put the "after" case first in the table because the slack integration takes the first image in #team-mobile-bots and I want it to be the fixed one 😅)