### PR TITLE
Add version checks to tests

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/Storage/ActivityFileStorage.swift
+++ b/Sources/AppcuesKit/Data/Analytics/Storage/ActivityFileStorage.swift
@@ -59,7 +59,7 @@ internal class ActivityFileStorage: ActivityStoring {
             .default.contentsOfDirectory(at: storageDirectory, includingPropertiesForKeys: [], options: .skipsHiddenFiles)) ?? []
 
         let activities: [ActivityStorage] = files.compactMap {
-            if let jsonData = try? String(contentsOf: $0, encoding: .utf8).data(using: .utf8) {
+            if let jsonData = (try? String(contentsOf: $0, encoding: .utf8))?.data(using: .utf8) {
                return try? decoder.decode(ActivityStorage.self, from: jsonData)
             }
             return nil

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -45,6 +45,8 @@ private extension UIViewController {
 
         view.addSubview(dismissButton)
 
+        dismissButton.accessibilityLabel = "Close"
+
         NSLayoutConstraint.activate([
             view.safeAreaLayoutGuide.trailingAnchor.constraint(equalToSystemSpacingAfter: dismissButton.trailingAnchor, multiplier: 1),
             dismissButton.topAnchor.constraint(equalToSystemSpacingBelow: view.safeAreaLayoutGuide.topAnchor, multiplier: 1)

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class ActionRegistryTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -86,6 +87,7 @@ class ActionRegistryTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, *)
 private extension ActionRegistryTests {
     class TestAction: ExperienceAction {
         static let type = "@test/action"

--- a/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class AppcuesCloseActionTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class AppcuesContinueActionTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class AppcuesLaunchExperienceActionTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import SafariServices
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class AppcuesLinkActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -92,6 +93,7 @@ class AppcuesLinkActionTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, *)
 extension AppcuesLinkActionTests {
     class MockURLOpener: TopControllerGetting, URLOpening {
         var onOpen: ((URL) -> Void)?

--- a/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class AppcuesTrackActionTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class AppcuesUpdateProfileActionTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/DeeplinkHandlerTests.swift
+++ b/Tests/AppcuesKitTests/DeeplinkHandlerTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class DeeplinkHandlerTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -128,6 +129,7 @@ class DeeplinkHandlerTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, *)
 extension DeeplinkHandlerTests {
     class MockTopControllerGetting: TopControllerGetting {
         func topViewController() -> UIViewController? {

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class ExperienceLoaderTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class ExperienceRendererTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -286,6 +287,7 @@ class ExperienceRendererTests: XCTestCase {
 }
 
 private extension Experience {
+    @available(iOS 13.0, *)
     func packageWithDelay(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
         let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()])
         return ExperiencePackage(

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class ExperienceStateMachineTests: XCTestCase {
 
     typealias State = ExperienceStateMachine.State

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -27,18 +27,20 @@ class MockAppcues: Appcues {
         // TODO: build out the service mocks and registration
         container.register(DataStoring.self, value: storage)
         container.register(Networking.self, value: networking)
-        container.register(ExperienceLoading.self, value: experienceLoader)
-        container.register(ExperienceRendering.self, value: experienceRenderer)
-        container.register(UIDebugging.self, value: debugger)
-        container.register(DeeplinkHandling.self, value: deeplinkHandler)
         container.register(SessionMonitoring.self, value: sessionMonitor)
-        container.registerLazy(TraitRegistry.self, initializer: TraitRegistry.init)
-        container.registerLazy(ActionRegistry.self, initializer: ActionRegistry.init)
-        container.register(TraitComposing.self, value: traitComposer)
         container.register(ActivityProcessing.self, value: activityProcessor)
         container.register(ActivityStoring.self, value: activityStorage)
         container.register(AnalyticsTracking.self, value: analyticsTracker)
 
+        if #available(iOS 13.0, *) {
+            container.register(DeeplinkHandling.self, value: deeplinkHandler)
+            container.register(UIDebugging.self, value: debugger)
+            container.register(ExperienceLoading.self, value: experienceLoader)
+            container.register(ExperienceRendering.self, value: experienceRenderer)
+            container.registerLazy(TraitRegistry.self, initializer: TraitRegistry.init)
+            container.registerLazy(ActionRegistry.self, initializer: ActionRegistry.init)
+            container.register(TraitComposing.self, value: traitComposer)
+        }
 
         // dependencies that are not mocked
         container.registerLazy(NotificationCenter.self, initializer: NotificationCenter.init)

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -42,6 +42,7 @@ enum Mocks {
         }
     }
 
+    @available(iOS 13.0, *)
     class ContainerViewController: DefaultContainerViewController {
         // ExperienceStateMachine checks these values to avoid unnecessary lifecycle events,
         // and so we need to mock them to trigger the correct events
@@ -81,6 +82,7 @@ extension Experience {
             ])
     }
 
+    @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
         let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()])
         return ExperiencePackage(

--- a/Tests/AppcuesKitTests/Networking/DynamicCodingKeysTests.swift
+++ b/Tests/AppcuesKitTests/Networking/DynamicCodingKeysTests.swift
@@ -13,7 +13,9 @@ class DynamicCodingKeysTests: XCTestCase {
 
     var encoder: JSONEncoder = {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
+        if #available(iOS 11.0, *) {
+            encoder.outputFormatting = .sortedKeys
+        }
         return encoder
     }()
 

--- a/Tests/AppcuesKitTests/Networking/PartialDictionaryDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/PartialDictionaryDecodeTests.swift
@@ -13,7 +13,9 @@ class PartialDictionaryDecodeTests: XCTestCase {
 
     var encoder: JSONEncoder = {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
+        if #available(iOS 11.0, *) {
+            encoder.outputFormatting = .sortedKeys
+        }
         return encoder
     }()
 

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class TraitComposerTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -275,7 +276,7 @@ private extension Experience.Step.Child {
     }
 }
 
-
+@available(iOS 13.0, *)
 extension TraitComposerTests {
     class TestTrait: StepDecoratingTrait, ContainerCreatingTrait, ContainerDecoratingTrait, WrapperCreatingTrait, BackdropDecoratingTrait {
         static let type = "@test/trait"

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class TraitRegistryTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -58,6 +59,7 @@ class TraitRegistryTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, *)
 private extension TraitRegistryTests {
     class TestTrait: ExperienceTrait {
         static let type = "@test/trait"


### PR DESCRIPTION
Swift Package Index builds [failed](https://swiftpackageindex.com/builds/DA22ED22-09EA-4C08-A500-805CCBA2A37F) because of missing version checks in the tests. Add those checks so that things will compile properly.

Also made the one line change to ActivityFileStorage that makes it compile for Swift 4.2, because why not, and added the accessibility label to the skip button that the UI tests look for.