### PR TITLE
Misc touchups

### DIFF
--- a/Appcues.podspec
+++ b/Appcues.podspec
@@ -1,29 +1,16 @@
-#
-# Be sure to run `pod lib lint Appcues.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
-#
+# To validate: `$ pod lib lint Appcues.podspec
 
 Pod::Spec.new do |s|
   s.name             = 'Appcues'
   s.module_name      = 'AppcuesKit'
   s.version          = '1.0.0-beta.1'
-  s.summary          = 'SDK for integrating with Appcues'
-
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.summary          = 'Appcues iOS SDK allows you to integrate Appcues experiences into your native iOS apps'
 
   s.description      = <<-DESC
-TODO: Add long description of the pod here.
+A Swift library for sending user properties and events to the Appcues API and retrieving and rendering Appcues content based on those properties and events.
                        DESC
 
   s.homepage         = 'https://github.com/appcues/appcues-ios-sdk'
-  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Appcues' => 'mobile@appcues.com' }
   s.source           = { :git => 'https://github.com/appcues/appcues-ios-sdk.git', :tag => s.version.to_s }
@@ -35,12 +22,4 @@ TODO: Add long description of the pod here.
   s.resource_bundles = {
       'Appcues' => ['Sources/AppcuesKit/**/*.xcassets']
   }
-
-  # s.resource_bundles = {
-  #   'Appcues' => ['Appcues/Assets/*.png']
-  # }
-
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The SDK is a Swift library for sending user properties and events to the Appcues
       - [Segment](#segment)
       - [Swift Package Manager](#swift-package-manager)
       - [Cocoapods](#cocoapods)
+      - [XCFramework](#xcframework)
     - [One Time Setup](#one-time-setup)
       - [Initializing the SDK](#initializing-the-sdk)
       - [Supporting Debugging and Experience Previewing](#supporting-debugging-and-experience-previewing)
@@ -67,6 +68,17 @@ dependencies: [
    ```sh
    pod install
    ```
+
+#### XCFramework
+
+An XCFramework is attached with each [release](https://github.com/appcues/appcues-ios-sdk/releases).
+
+1. Download `AppcuesKit.xcframework.zip` attached to the [latest release](https://github.com/appcues/appcues-ios-sdk/releases) and unzip.
+2. In Xcode, open your project and navigate to **File** → **Add Files to "\<Project\>"…**
+3. Find the XCFramework in the file navigator and select it
+4. Ensure the option to "Copy items if needed" is checked and that your app's target is selected
+5. Click **Add**
+6. Select your project in the **Project navigator**, select your app target and then the **General** tab. Under **Frameworks, Libraries, and Embedded Content**, set AppcuesKit.xcframework to **Embed & Sign**
 
 ### One Time Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![AppcuesKit](/Sources/AppcuesKit/AppcuesKit.docc/banner%402x.png)
+![AppcuesKit](https://raw.githubusercontent.com/appcues/appcues-ios-sdk/main/Sources/AppcuesKit/AppcuesKit.docc/banner%402x.png)
 
 # Appcues iOS SDK
 

--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -109,7 +109,7 @@ public extension Appcues {
         }
 
         /// Set the `URLSession` instance used by the configuration.
-        /// - Parameter apiHost: Domain of the API host.
+        /// - Parameter urlSession: `URLSession` object.
         /// - Returns: The `Configuration` object.
         ///
         /// Injecting a custom `URLSession` may be useful for testing in combination with `URLSessionConfiguration.protocolClasses`.

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
@@ -22,6 +22,6 @@ internal class AppcuesCloseAction: ExperienceAction {
 
     func execute(inContext appcues: Appcues, completion: @escaping ActionRegistry.Completion) {
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
-        experienceRenderer.dismissCurrentExperience(markComplete: markComplete, completion: { _ in completion() })
+        experienceRenderer.dismissCurrentExperience(markComplete: markComplete) { _ in completion() }
     }
 }

--- a/Sources/AppcuesKit/Presentation/DeeplinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeeplinkHandler.swift
@@ -119,6 +119,7 @@ public extension Appcues {
     /// ```
     @available(iOS 13.0, *)
     @discardableResult
+    @objc
     func filterAndHandle(_ URLContexts: Set<UIOpenURLContext>) -> Set<UIOpenURLContext> {
         URLContexts.filter { !didHandleURL($0.url) }
     }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -53,7 +53,8 @@ internal class ExperienceStateMachine {
         do {
             try transition(action)
         } catch {
-            let observerIsSatisfiedByFailure = observer.evaluateIfSatisfied(result: .failure(ExperienceError.noTransition(currentState: state)))
+            let error = ExperienceError.noTransition(currentState: state)
+            let observerIsSatisfiedByFailure = observer.evaluateIfSatisfied(result: .failure(error))
             if observerIsSatisfiedByFailure {
                 stateObservers = stateObservers.filter { $0 !== observer }
             }

--- a/Sources/AppcuesKit/Presentation/Generated/Appcues+ResourceBundle.swift
+++ b/Sources/AppcuesKit/Presentation/Generated/Appcues+ResourceBundle.swift
@@ -13,13 +13,18 @@ extension Appcues {
     /// Reference: https://github.com/SwiftGen/SwiftGen/blob/stable/Documentation/Articles/Customize-loading-of-resources.md
     static let resourceBundle: Bundle = {
         #if SWIFT_PACKAGE
+        // 1. Swift Package Manager
         return Bundle.module
         #else
-        guard let url = Bundle(for: Appcues.self).url(forResource: "Appcues", withExtension: "bundle"),
-              let bundle = Bundle(url: url) else {
+        if let url = Bundle(for: Appcues.self).url(forResource: "Appcues", withExtension: "bundle"), let bundle = Bundle(url: url) {
+            // 2. Cocoapods
+            return bundle
+        } else if let bundle = Bundle(identifier: "com.appcues.sdk") {
+            // 3. XCFramework
+            return bundle
+        } else {
             fatalError("Can't find 'Appcues' resource bundle")
         }
-        return bundle
         #endif
     }()
 }


### PR DESCRIPTION
- 🚨 Fix lint warnings
- 📝 Fix documentation error
  - Helpfully enough, the objc interface flagged the wrong param name
- 📝 Add XCFramework installation instructions
- 🍏 Clean up podspec
- 🍏 Update swift tools version
  - This shouldn't matter at all, but a bit more backwards compatibility can't hurt
- 🐛 Fix bundle referencing from XCFramework
  - The `1.0.0-beta.1` XCFramework couldn't find the debug icon
- 📝 Update README image path to fix display outside of github
  - This should fix the broken image on the [CocoaPods listing](https://cocoapods.org/pods/Appcues)