### PR TITLE
Update AnalyticsPublisher to weakly reference decorators and subscribers

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -38,7 +38,7 @@ internal class UIDebugger: UIDebugging {
     private let config: Appcues.Config
     private let storage: DataStoring
     private let notificationCenter: NotificationCenter
-    private weak var analyticsPublisher: AnalyticsPublishing?
+    private let analyticsPublisher: AnalyticsPublishing
 
     init(container: DIContainer) {
         self.config = container.resolve(Appcues.Config.self)
@@ -72,7 +72,7 @@ internal class UIDebugger: UIDebugging {
             return
         }
 
-        analyticsPublisher?.register(subscriber: self)
+        analyticsPublisher.register(subscriber: self)
         let panelViewController = UIHostingController(rootView: DebugUI.MainPanelView(viewModel: viewModel))
         let rootViewController = DebugViewController(wrapping: panelViewController)
         rootViewController.delegate = self
@@ -86,7 +86,7 @@ internal class UIDebugger: UIDebugging {
     }
 
     func hide() {
-        analyticsPublisher?.remove(subscriber: self)
+        analyticsPublisher.remove(subscriber: self)
         debugWindow?.isHidden = true
         debugWindow = nil
         cancellable = nil

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsPublisherTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsPublisherTests.swift
@@ -48,6 +48,19 @@ class AnalyticsPublisherTests: XCTestCase {
         XCTAssertEqual(1, decorator.decorations)
     }
 
+    func testWeakDecorator() throws {
+        // Arrange
+        var decorator: Mocks.TestDecorator? = Mocks.TestDecorator()
+        weak var weakDecorator: Mocks.TestDecorator? = decorator
+        analyticsPublisher.register(decorator: decorator!)
+
+        // Act
+        decorator = nil
+
+        // Assert
+        XCTAssertNil(weakDecorator)
+    }
+
     func testRegisterSubscriber() throws {
         // Arrange
         let subscriber = Mocks.TestSubscriber()
@@ -73,4 +86,18 @@ class AnalyticsPublisherTests: XCTestCase {
         // Assert
         XCTAssertEqual(1, subscriber.trackedUpdates)
     }
+
+    func testWeakSubscriber() throws {
+        // Arrange
+        var subscriber: Mocks.TestSubscriber? = Mocks.TestSubscriber()
+        weak var weakSubscriber: Mocks.TestSubscriber? = subscriber
+        analyticsPublisher.register(subscriber: subscriber!)
+
+        // Act
+        subscriber = nil
+
+        // Assert
+        XCTAssertNil(weakSubscriber)
+    }
+
 }


### PR DESCRIPTION
A follow up to https://github.com/appcues/appcues-ios-sdk/pull/203

Updated dependency graph changes to the lines in/out of `AnalyticsPublishing`:

|Now|Before|
|-|-|
|![dependency-graph](https://user-images.githubusercontent.com/845681/172225955-2db744b6-d564-4fa9-96fe-313b7d3042ef.png)|![depencency-graph-old](https://user-images.githubusercontent.com/845681/172225965-04e36173-4031-4165-84b0-d5af32c1622b.png)|
