### PR TITLE
Add support for Democues special case deeplinking logic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/AppcuesKit/Presentation/DeeplinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeeplinkHandler.swift
@@ -22,7 +22,8 @@ internal class DeeplinkHandler: DeeplinkHandling {
         case debugger(destination: DebugDestination?)
 
         init?(url: URL, isSessionActive: Bool, applicationID: String) {
-            guard url.scheme == "appcues-\(applicationID)", url.host == "sdk" else { return nil }
+            let isValidScheme = url.scheme == "appcues-\(applicationID)" || url.scheme == "appcues-democues"
+            guard isValidScheme, url.host == "sdk" else { return nil }
 
             // supported paths:
             // appcues-{app_id}://sdk/experience_preview/{experience_id}

--- a/Tests/AppcuesKitTests/DeeplinkHandlerTests.swift
+++ b/Tests/AppcuesKitTests/DeeplinkHandlerTests.swift
@@ -35,6 +35,8 @@ class DeeplinkHandlerTests: XCTestCase {
         XCTAssertNil(DeeplinkHandler.Action(url: URL(string: "scheme://sdk/debugger")!, isSessionActive: false, applicationID: "abc"))
 
         XCTAssertNil(DeeplinkHandler.Action(url: URL(string: "appcues-abc://sdk/different-appid")!, isSessionActive: false, applicationID: "xyz"))
+
+        XCTAssertNotNil(DeeplinkHandler.Action(url: URL(string: "appcues-democues://sdk/experience_preview/f0edab83-5257-47a5-81fc-80389d14905b")!, isSessionActive: true, applicationID: "abc"))
     }
 
     func testHandlePreviewURLWithActiveScene() throws {

--- a/release.sh
+++ b/release.sh
@@ -116,9 +116,8 @@ case "$response" in
 		;;
 esac
 
-# get the commits since the last release...
-# note: we do this here so the "Version x.x.x" commit doesn't show up in logs.
-changelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7)
+# get the commits since the last release, filtering ones that aren't relevant.
+changelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7 | sed '/[🔧🎬⬆️📸✅💡📝]/d')
 tempFile=$(mktemp)
 # write changelog to temp file.
 echo "$changelog" >> $tempFile


### PR DESCRIPTION
Also updating the release script to exclude some commits from the changelog and updating the `swift-tools-version` back to what it was prior to #204 because there actually is a [change](https://github.com/apple/swift-evolution/blob/main/proposals/0307-allow-interchangeable-use-of-double-cgfloat-types.md) that means the SDK doesn't currently compile pre-5.5. Could fix all those cases, but not going to worry about it.