### PR TITLE
Update SPI doc target

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,4 @@ version: 1
 builder:
   configs:
     - platform: ios
-      documentation_targets: [AppcuesKit]
+      documentation_targets: [Appcues]


### PR DESCRIPTION
Trying this before opening an issue for the [missing docs](https://swiftpackageindex.com/appcues/appcues-ios-sdk/main/documentation/appcueskit) on the Swift Package Index.

The xcodebuild command for docs requires the _scheme_ not a target, so perhaps that's what's wrong

```sh
$ xcodebuild docbuild -scheme Appcues -sdk iphoneos -destination generic/platform=iOS
```