### PR TITLE
Fix fullscreen landscape carousel

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -206,9 +206,10 @@ extension AppcuesCarouselTrait {
             let layout = UICollectionViewCompositionalLayout(section: section)
 
             let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
-            view.backgroundColor = .clear
+            view.translatesAutoresizingMaskIntoConstraints = false
             view.alwaysBounceVertical = false
             view.contentInsetAdjustmentBehavior = .never
+            view.backgroundColor = .clear
 
             return view
         }()
@@ -217,7 +218,12 @@ extension AppcuesCarouselTrait {
             super.init(frame: .zero)
 
             addSubview(collectionView)
-            collectionView.pin(to: self)
+            NSLayoutConstraint.activate([
+                collectionView.topAnchor.constraint(equalTo: topAnchor),
+                collectionView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+                collectionView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+                collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ])
         }
 
         @available(*, unavailable)

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -78,6 +78,12 @@ extension ExperienceStepViewController {
             return view
         }()
 
+        // When nested inside the carousel traits collection view, the left and right safe area insets get doubled applied.
+        // This zeros out those values to achieve the desired layout.
+        override var safeAreaInsets: UIEdgeInsets {
+            get { UIEdgeInsets(top: super.safeAreaInsets.top, left: 0, bottom: super.safeAreaInsets.bottom, right: 0) }
+        }
+
         init() {
             super.init(frame: .zero)
 


### PR DESCRIPTION
It was terribly broken. Now it's not. Not a whole lot more to say than that.

I will says overriding `safeAreaInsets` is hacky, but for the life of me I can't figure out why the safe area is double applied. The middle video shows what was happening: the first page looks fine, but as you scroll, the safe area gets doubled on one side. Which side gets the extra space depends which direction you're scrolling, which is extra weird. Because we're using the compositional collection view layout, there's not any visibility into how that's being calculated.

### Fixed

https://user-images.githubusercontent.com/845681/174891845-fb2483b6-75e1-4440-ac0b-fcbff9ed32ac.mp4

### Partially Fixed (first commit)

https://user-images.githubusercontent.com/845681/174892757-bdd9fa29-9ba2-45e1-afef-4f13f9ac94c5.mp4

### Originally

https://user-images.githubusercontent.com/845681/174891974-cf2361a7-4042-4fbc-ac0b-1fc3c7821138.mp4