### PR TITLE
Ensure the same carousel step is always shown on orientation changes

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/NSCollectionLayoutSection+Factory.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/NSCollectionLayoutSection+Factory.swift
@@ -22,7 +22,7 @@ extension NSCollectionLayoutSection {
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 
         let section = NSCollectionLayoutSection(group: group)
-        section.orthogonalScrollingBehavior = .paging
+        section.orthogonalScrollingBehavior = .groupPaging
         return section
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -106,6 +106,20 @@ extension AppcuesCarouselTrait {
             preferredContentSize = container.preferredContentSize
         }
 
+        override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+            // Use the currentPage value instead of collectionView.indexPathsForVisibleItems because
+            // that occasionally includes additional items.
+            let targetIndex = IndexPath(item: pageMonitor.currentPage, section: 0)
+
+            // Using `coordinator.animate` would be ideal, and it does work,
+            // but that animation is jankier when going from landscape to portrait.
+            DispatchQueue.main.async {
+                self.carouselView.collectionView.scrollToItem(at: targetIndex, at: .centeredHorizontally, animated: false)
+            }
+
+            super.viewWillTransition(to: size, with: coordinator)
+        }
+
         func navigate(to pageIndex: Int, animated: Bool) {
             carouselView.collectionView.scrollToItem(
                 at: IndexPath(row: pageIndex, section: 0),

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -81,7 +81,7 @@ extension ExperienceStepViewController {
         // When nested inside the carousel traits collection view, the left and right safe area insets get doubled applied.
         // This zeros out those values to achieve the desired layout.
         override var safeAreaInsets: UIEdgeInsets {
-            get { UIEdgeInsets(top: super.safeAreaInsets.top, left: 0, bottom: super.safeAreaInsets.bottom, right: 0) }
+            UIEdgeInsets(top: super.safeAreaInsets.top, left: 0, bottom: super.safeAreaInsets.bottom, right: 0)
         }
 
         init() {


### PR DESCRIPTION
In some cases a carousel modal would end up on a different page after rotating the device. This is a bug with `UICollectionViewCompositionalLayout`. Apple's example code for [Implementing Modern Collection Views](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/implementing_modern_collection_views) also includes this bug where the items in view when in portrait are lost and different items end up being visible. See this example where item 3,9 is visible in portrait, but 3,3 ends up visible after rotation (not to mention losing the vertical scroll position too)

https://user-images.githubusercontent.com/845681/175646186-a2868c81-e89a-448c-9633-9d5751d3911a.mp4

In theory fixing this should be done with [`UICollectionViewDelegate.collectionView(_:targetContentOffsetForProposedContentOffset:)`](https://developer.apple.com/documentation/uikit/uicollectionviewdelegate/1618007-collectionview), but the delegate method isn't called for compositional layouts. And [`NSCollectionViewLayout .targetContentOffset(forProposedContentOffset:)`](https://developer.apple.com/documentation/appkit/nscollectionviewlayout/1535608-targetcontentoffset) isn't called when I tried subclassing `NSCollectionViewCompositionalLayout`.

Striking out there, I needed to find a different place to force jumping to the correct item on rotation. `viewWillTransition(to:with:)` works. However using `collectionView.indexPathsForVisibleItems` to scroll to the same items does not work because that array occasionally contains extra items than the IndexPath we care about. Fortunately we have `pageMonitor.currentPage`.

The final gotcha is how we set the correct page. Obviously directly calling `scrollToItem` won't work since it;'ll execute too soon. Calling inside a `coordinator.animate` block does get us to the right page after the rotation, but the animation from landscape to portrait is janky because it'll show the wrong page before animating to the right one:

https://user-images.githubusercontent.com/845681/175647617-5362cfc5-2e70-47b7-9fa3-91406a40dda8.mp4

Interestingly enough, using `DispatchQueue.main.async` instead gets us closer to what we want. It's still not perfect, but it's better:

https://user-images.githubusercontent.com/845681/175647742-6b1d6e5a-e1df-4af3-8201-77f62ff55274.mp4

The animation from landscape to portrait still isn't perfect, but it's also not _bad_ now and at least we stay on the right carousel page. These compositional layout bugs are tempting me to go back and do this all with a flow layout 😬

I created a reduced test case example app to test the changes out, so attaching here for posterity: [carousel.zip](https://github.com/appcues/appcues-ios-sdk/files/8980040/carousel.zip)
