### PR TITLE
Fix memory leak in sticky content trait

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStickyContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStickyContentTrait.swift
@@ -39,8 +39,8 @@ internal class AppcuesStickyContentTrait: StepDecoratingTrait {
         stickyContentVC.didMove(toParent: viewController)
 
         // Pass sticky content size changes to the parent controller to update the insets.
-        stickyContentVC.onSizeChange = { [weak self] size, safeArea in
-            guard let self = self else { return }
+        stickyContentVC.onSizeChange = { [weak self, weak viewController] size, safeArea in
+            guard let self = self, let viewController = viewController else { return }
             switch self.edge {
             case .top:
                 viewController.additionalSafeAreaInsets.top = size.height - safeArea.top


### PR DESCRIPTION
When checking the debugger dismiss behaviour in Democues, I noticed that after the one modal displayed, the debugger wasn't dismissing properly, indicating a memory leak. Turns out it was the sticky content in that modal: the `onSizeChange` closure property of `StickyHostingController` was capturing the reference to the `ExperienceStepViewController` which in turn owned the `StickyHostingController` as a child controller.