### PR TITLE
🐛 Fix debugger clearing current user value

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
@@ -82,12 +82,10 @@ internal class DebugViewModel: ObservableObject {
     }
 
     func reset() {
-        currentUserID = ""
         filter = nil
         events.removeAll()
         latestEvent = nil
         trackingPages = false
-        isAnonymous = true
     }
 
     func addUpdate(_ update: TrackingUpdate) {


### PR DESCRIPTION
When launched, dismissed, relaunched, the current user would be empty