### PR TITLE
Ensure the completion block is called when continue from the last step

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -111,6 +111,14 @@ internal class ExperienceRenderer: ExperienceRendering {
             case .success(.renderingStep):
                 DispatchQueue.main.async { completion?() }
                 return true
+            case .success(.idling):
+                if stepRef == .offset(1) {
+                    // If the experience is dismissed and resets to the idling state,
+                    // then by definition the progression to the next step has completed.
+                    DispatchQueue.main.async { completion?() }
+                    return true
+                }
+                return false
             case .failure:
                 // Done observing, something went wrong
                 DispatchQueue.main.async { completion?() }

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -70,6 +70,23 @@ extension Experience {
             ])
     }
 
+    static var singleStepMock: Experience {
+        Experience(
+            id: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
+            name: "Single step experience",
+            type: "mobile",
+            publishedAt: 1632142800000,
+            traits: [],
+            steps: [
+                Experience.Step(
+                    fixedID: "fb529214-3c78-4d6d-ba93-b55d22497ca1",
+                    children: [
+                        Step.Child(fixedID: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
+                    ]
+                )
+            ])
+    }
+
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
         let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()])


### PR DESCRIPTION
From [sc-38212: iOS SDK doesn't update property from button action](https://app.shortcut.com/appcues/story/38212/mobile-ios-sdk-doesn-t-update-property-from-button-action):

> It appears that this is an issue only on the last step of an experience. The profile details are successfully updated if the action is on the first step of a two step experience.
> The issue stems from sc-37520. The first action on the button is `@appcues/continue` and that tells the SDK "go to the next step, and once we're there, continue on to any additional actions". However, if the experience dismisses, we never see another step so the `@appcues/continue` action doesn't complete and we just wait forever to get to the `@appcues/update-profile` action.
> To summarize, the issue is actually with `@appcues/continue`, because currently any action after that on the last step of an experience won't be executed.