### PR TITLE
Add support for accessibility actions on buttons

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -29,6 +29,9 @@ extension View {
                 view.simultaneousGesture(TapGesture().onEnded {
                     process(actionHandlers)
                 })
+                .accessibilityAction {
+                    process(actionHandlers)
+                }
             }
             .ifLet(actions[.longPress]) { view, actionHandlers in
                 view.simultaneousGesture(LongPressGesture().onEnded { _ in


### PR DESCRIPTION
I realized I overlooked ensuring buttons actions works with VoiceOver and Voice Control. No more!

(AFAIK SwiftUI automatically makes accessibility actions work with button actions, but since we have the `simultaneousGesture` workaround, we need to be explicit.)