### PR TITLE
Add centralized action queue and support for post-experience actions

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -60,13 +60,34 @@ internal struct Experience {
     let traits: [Trait]
     let steps: [Step]
 
+    // Post experience actions
+    let redirectURL: URL?
+    let nextContentID: String?
+
     /// Unique ID to disambiguate the same experience flowing through the system from different origins.
     let instanceID = UUID()
 }
 
 extension Experience: Decodable {
-    private enum CodingKeys: CodingKey {
-        case id, name, type, publishedAt, traits, steps
+    private enum CodingKeys: String, CodingKey {
+        case id, name, type, publishedAt, traits, steps, redirectURL = "redirectUrl", nextContentID = "nextContentId"
+    }
+}
+
+extension Experience {
+    @available(iOS 13.0, *)
+    var postExperienceActions: [ExperienceAction] {
+        var actions: [ExperienceAction] = []
+
+        if let redirectURL = redirectURL {
+            actions.append(AppcuesLinkAction(url: redirectURL))
+        }
+
+        if let nextContentID = nextContentID {
+            actions.append(AppcuesLaunchExperienceAction(experienceID: nextContentID))
+        }
+
+        return actions
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -22,6 +22,10 @@ internal class AppcuesLaunchExperienceAction: ExperienceAction {
         }
     }
 
+    init(experienceID: String) {
+        self.experienceID = experienceID
+    }
+
     func execute(inContext appcues: Appcues, completion: @escaping ActionRegistry.Completion) {
         appcues.show(experienceID: experienceID) { _, _  in completion() }
     }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -27,6 +27,11 @@ internal class AppcuesLinkAction: ExperienceAction {
         }
     }
 
+    init(url: URL, openExternally: Bool = false) {
+        self.url = url
+        self.openExternally = openExternally
+    }
+
     func execute(inContext appcues: Appcues, completion: @escaping ActionRegistry.Completion) {
         // SFSafariViewController only supports HTTP and HTTPS URLs and crashes otherwise, so check to be safe.
         if !openExternally && ["http", "https"].contains(url.scheme?.lowercased()) {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -40,8 +40,12 @@ extension ExperienceStateMachine {
                 )
             case let (.endingStep(experience, currentIndex, _), .startStep(stepRef)):
                 return Transition.fromEndingStepToBeginningStep(experience, currentIndex, stepRef, traitComposer)
-            case (.endingExperience, .reset):
-                return Transition(toState: .idling)
+            case let (.endingExperience(experience, stepIndex, markComplete), .reset):
+                var sideEffect: SideEffect?
+                if markComplete || stepIndex == experience.stepIndices.last {
+                    sideEffect = .processActions(experience.postExperienceActions)
+                }
+                return Transition(toState: .idling, sideEffect: sideEffect)
 
             // Error cases
             case let (_, .startExperience(experience)):

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -40,9 +40,9 @@ extension ExperienceStateMachine {
                 )
             case let (.endingStep(experience, currentIndex, _), .startStep(stepRef)):
                 return Transition.fromEndingStepToBeginningStep(experience, currentIndex, stepRef, traitComposer)
-            case let (.endingExperience(experience, stepIndex, markComplete), .reset):
+            case let (.endingExperience(experience, _, _), .reset):
                 var sideEffect: SideEffect?
-                if markComplete || stepIndex == experience.stepIndices.last {
+                if self.isExperienceCompleted {
                     sideEffect = .processActions(experience.postExperienceActions)
                 }
                 return Transition(toState: .idling, sideEffect: sideEffect)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -13,6 +13,7 @@ internal class ExperienceStateMachine {
 
     private let config: Appcues.Config
     private let traitComposer: TraitComposing
+    private let actionRegistry: ActionRegistry
 
     private(set) var stateObservers: [ExperienceStateObserver] = []
 
@@ -33,6 +34,7 @@ internal class ExperienceStateMachine {
     init(container: DIContainer, initialState: State = .idling) {
         config = container.resolve(Appcues.Config.self)
         traitComposer = container.resolve(TraitComposing.self)
+        actionRegistry = container.resolve(ActionRegistry.self)
 
         state = initialState
     }
@@ -214,6 +216,7 @@ extension ExperienceStateMachine {
         case navigateInContainer(ExperiencePackage, pageIndex: Int)
         case dismissContainer(ExperiencePackage, continuation: Action)
         case error(ExperienceError, reset: Bool)
+        case processActions([ExperienceAction])
 
         func execute(in machine: ExperienceStateMachine) throws {
             switch self {
@@ -233,6 +236,8 @@ extension ExperienceStateMachine {
                 if reset {
                     machine.state = .idling
                 }
+            case let .processActions(actions):
+                machine.actionRegistry.enqueue(actionInstances: actions)
             }
         }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesBox.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesBox.swift
@@ -22,7 +22,7 @@ internal struct AppcuesBox: View {
                 AnyView($0.view)
             }
         }
-        .setupActions(viewModel.groupedActionHandlers(for: model.id))
+        .setupActions(on: viewModel, for: model.id)
         .applyAllAppcues(style)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
@@ -29,6 +29,6 @@ internal struct AppcuesButton: View {
         .applyBackgroundStyle(style)
         .applyBorderStyle(style)
         .applyExternalLayout(style)
-        .setupActions(viewModel.groupedActionHandlers(for: model.id))
+        .setupActions(on: viewModel, for: model.id)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
@@ -23,7 +23,7 @@ internal struct AppcuesImage: View {
             .ifLet(model.accessibilityLabel) { view, val in
                 view.accessibility(label: Text(val))
             }
-            .setupActions(viewModel.groupedActionHandlers(for: model.id))
+            .setupActions(on: viewModel, for: model.id)
             .applyForegroundStyle(style)
             // set the aspect ratio before applying frame sizing
             .ifLet(ContentMode(string: model.contentMode)) { view, val in

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
@@ -24,7 +24,7 @@ internal struct AppcuesStack: View {
                     AnyView($0.view)
                 }
             }
-            .setupActions(viewModel.groupedActionHandlers(for: model.id))
+            .setupActions(on: viewModel, for: model.id)
             .applyAllAppcues(style)
         case (.horizontal, .center),
             (.horizontal, .none):
@@ -33,7 +33,7 @@ internal struct AppcuesStack: View {
                     AnyView($0.view)
                 }
             }
-            .setupActions(viewModel.groupedActionHandlers(for: model.id))
+            .setupActions(on: viewModel, for: model.id)
             .applyAllAppcues(style)
         case (.horizontal, .equal):
             HStack(alignment: style.verticalAlignment, spacing: CGFloat(model.spacing ?? 0)) {
@@ -48,7 +48,7 @@ internal struct AppcuesStack: View {
                 }
             }
             .fixedSize(horizontal: false, vertical: true)
-            .setupActions(viewModel.groupedActionHandlers(for: model.id))
+            .setupActions(on: viewModel, for: model.id)
             .applyAllAppcues(style)
         }
     }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -19,7 +19,7 @@ internal struct AppcuesText: View {
 
         Text(model.text)
             .applyTextStyle(style)
-            .setupActions(viewModel.groupedActionHandlers(for: model.id))
+            .setupActions(on: viewModel, for: model.id)
             .applyAllAppcues(style)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -30,16 +30,12 @@ internal class ExperienceStepViewModel: ObservableObject {
         self.actionRegistry = actionRegistry
     }
 
-    /// Returns the actions for the specific component grouped by `ActionType`.
-    func groupedActionHandlers(for id: UUID) -> [ActionType: [(@escaping ActionRegistry.Completion) -> Void]] {
-        guard let componentActions = actions[id] else { return [:] }
+    func enqueueActions(_ actions: [Experience.Action]) {
+        actionRegistry.enqueue(actionModels: actions)
+    }
 
-        // (trailing closure in init would be less readable)
-        // swiftlint:disable:next trailing_closure
-        return Dictionary(grouping: componentActions, by: { $0.trigger })
-            .reduce(into: [:]) { dict, item in
-                guard let actionType = ActionType(rawValue: item.key) else { return }
-                dict[actionType] = actionRegistry.actionClosures(for: item.value)
-            }
+    func actions(for id: UUID) -> [ActionType?: [Experience.Action]] {
+        // An unknown trigger value will get lumped into Dictionary[nil] and be ignored.
+        Dictionary(grouping: actions[id] ?? [], by: { ActionType(rawValue: $0.trigger) })
     }
 }

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -326,7 +326,7 @@ class ActivityProcessorTests: XCTestCase {
         return Activity(accountID: "00000", userID: userID, events: [event], profileUpdate: nil, groupID: nil, groupUpdate: nil)
     }
 
-    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [])
+    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
 
 }
 

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -67,7 +67,9 @@ extension Experience {
                 .child(
                     Step.Child(fixedID: "03652bd5-f0cb-44f0-9274-e95b4441d857")
                 )
-            ])
+            ],
+            redirectURL: nil,
+            nextContentID: "abc")
     }
 
     static var singleStepMock: Experience {
@@ -84,7 +86,9 @@ extension Experience {
                         Step.Child(fixedID: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
                     ]
                 )
-            ])
+            ],
+            redirectURL: nil,
+            nextContentID: nil)
     }
 
     @available(iOS 13.0, *)

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -54,7 +54,9 @@ class TraitComposerTests: XCTestCase {
             ],
             steps: [
                 .child(Experience.Step.Child(traits: []))
-            ])
+            ],
+        redirectURL: nil,
+        nextContentID: nil)
 
         // Act
         _ = try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 0, item: 0))
@@ -153,7 +155,9 @@ class TraitComposerTests: XCTestCase {
             ],
             steps: [
                 .child(Experience.Step.Child(traits: []))
-            ])
+            ],
+            redirectURL: nil,
+            nextContentID: nil)
 
 
         // Act
@@ -188,7 +192,9 @@ class TraitComposerTests: XCTestCase {
                     traits: [],
                     actions: [:]
                 ))
-            ])
+            ],
+            redirectURL: nil,
+            nextContentID: nil)
 
         // Act
         XCTAssertThrowsError(try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 0, item: 0))) { error in
@@ -260,7 +266,9 @@ class TraitComposerTests: XCTestCase {
                             "backdropDecoratingExpectation": backdropDecoratingExpectation as Any
                         ])
                 ]))
-            ])
+            ],
+        redirectURL: nil,
+        nextContentID: nil)
     }
 }
 


### PR DESCRIPTION
This PR does two things:
1. Update `ActionRegistry` to be have a queue for all experience actions that need to be processed. By itself this changes nothing.
2. Experience actions are now mapped and handled by appending to the `ActionRegistry` queue.

The result of this is that an experience that's dismissed via a button will handle all the button actions in the queue and then the experience actions afterwards. See the example below.

## Implementation

Moving action handling to `ActionRegistry` cleaned up a bunch of messy closure passing that I was doing before and overall it's a substantially cleaner solution.

The experience actions then just need to add to the `ActionRegistry` queue. One approach was to create an `ExperienceStateObserver` and look for the `endingExperience` state, but introducing a new `processActions` side effect into the state machine proved simpler.

## Example

This is an experience that has a button set to trigger a flow and then the experience has a redirect and a content trigger. The button flow is briefly shown before the deep link is applied and the content from the experience settings is shown.

<img width="235" alt="Screen Shot 2022-07-20 at 11 46 22 AM" src="https://user-images.githubusercontent.com/845681/180026164-c62c666b-0fea-492f-84e3-b8d1344830da.png">
<img width="579" alt="Screen Shot 2022-07-20 at 11 46 30 AM" src="https://user-images.githubusercontent.com/845681/180026184-7bf17648-9d34-43fe-a0a0-1dac47a1c478.png">

https://user-images.githubusercontent.com/845681/180025949-68b12504-89dd-46e8-a780-04088da0c8c9.mp4

## Diagram Changes

The state machine has a new side effect (in orange)
![updated-state-machine](https://user-images.githubusercontent.com/845681/180025015-243ec3f7-ef0b-4482-a765-39127fe1dd08.png)

The dependency graph has a new dependency (in orange)
![updated-dependency-graph](https://user-images.githubusercontent.com/845681/180025020-016bbe34-4384-4ab7-beea-9125fa40f2b1.png)
