### PR TITLE
Add shake gesture detection to refresh experience previews

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -18,10 +18,12 @@ internal class TraitComposer: TraitComposing {
 
     private let traitRegistry: TraitRegistry
     private let actionRegistry: ActionRegistry
+    private let notificationCenter: NotificationCenter
 
     init(container: DIContainer) {
         traitRegistry = container.resolve(TraitRegistry.self)
         actionRegistry = container.resolve(ActionRegistry.self)
+        notificationCenter = container.resolve(NotificationCenter.self)
     }
 
     func package(experience: Experience, stepIndex: Experience.StepIndex) throws -> ExperiencePackage {
@@ -83,7 +85,7 @@ internal class TraitComposer: TraitComposing {
 
         let stepControllers: [ExperienceStepViewController] = try stepModelsWithDecorators.map { step, decorators in
             let viewModel = ExperienceStepViewModel(step: step, actionRegistry: actionRegistry)
-            let stepViewController = ExperienceStepViewController(viewModel: viewModel)
+            let stepViewController = ExperienceStepViewController(viewModel: viewModel, notificationCenter: notificationCenter)
             try decorators.forEach { try $0.decorate(stepController: stepViewController) }
             return stepViewController
         }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 internal class ExperienceStepViewController: UIViewController {
 
     let viewModel: ExperienceStepViewModel
+    let notificationCenter: NotificationCenter?
 
     lazy var stepView = ExperienceStepView()
     var padding: NSDirectionalEdgeInsets {
@@ -21,8 +22,9 @@ internal class ExperienceStepViewController: UIViewController {
 
     private let contentViewController: UIViewController
 
-    init(viewModel: ExperienceStepViewModel) {
+    init(viewModel: ExperienceStepViewModel, notificationCenter: NotificationCenter? = nil) {
         self.viewModel = viewModel
+        self.notificationCenter = notificationCenter
 
         let rootView = ExperienceStepRootView(rootView: viewModel.step.content.view, viewModel: viewModel)
         self.contentViewController = AppcuesHostingController(rootView: rootView)
@@ -59,6 +61,11 @@ internal class ExperienceStepViewController: UIViewController {
         )
     }
 
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            notificationCenter?.post(name: .shakeToRefresh, object: self)
+        }
+    }
 }
 
 @available(iOS 13.0, *)
@@ -105,4 +112,8 @@ extension ExperienceStepViewController {
             fatalError("init(coder:) has not been implemented")
         }
     }
+}
+
+extension Notification.Name {
+    internal static let shakeToRefresh = Notification.Name("shakeToRefresh")
 }


### PR DESCRIPTION
Went with the notification approach since coupling the ExperienceStepViewController to the ExperienceLoader seems like a bad idea.