### PR TITLE
Add ability to verify deeplink configuration from within the debugger

### DIFF
--- a/Sources/AppcuesKit/AppcuesKit.docc/Debugging.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/Debugging.md
@@ -34,6 +34,10 @@ Tap the row to re-check the connection status.
 
 > If there is a connection error, long-press the row to copy the detailed error information.
 
+### Deeplink Configuration Status
+
+Tap to check status. Shows a checkmark if the Appcues deeplink is properly configured. See <doc:URLSchemeConfiguring> for information about error messages.
+
 ### Screen Tracking Status
 
 Shows a checkmark if a screen event has been observed since the debugger was launched. You may need to navigate to another screen in your app for the debugger to observe a screen event.

--- a/Sources/AppcuesKit/AppcuesKit.docc/URLSchemeConfiguring.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/URLSchemeConfiguring.md
@@ -79,6 +79,17 @@ var body: some Scene {
 
 ## Verifying the Custom URL Scheme
 
-Test that the URL scheme handling is set up correctly by navigating to `appcues-APPCUES_APPLICATION_ID://sdk/debugger` in your browser on the device with the app installed.
+The Appcues debugger allows you to easily validate that the Appcues deeplink is properly configured.
+
+1. Launch the debugger in your app with a call to ``Appcues/debug()``.
+2. Expand the debugger by tapping the floating button.
+3. Tap the "Appcues Deeplink Configured" row to verify the status. If a checkmark appears, the Appcues deeplink is properly configured. 
+
+### Troubleshooting
+
+- `Error 0`: The Appcues debugger was unable to set up the verification test.
+- `Error 1`: The `CFBundleURLSchemes` value is missing. Refer to the "Register the Custom URL Scheme" section above.
+- `Error 2`: The URL scheme is registered, but the Appcues SDK did not receive the link from the host app. Refer to the "Handle the Custom URL Scheme" section above.
+- `Error 3`: The Appcues SDK received the link, but the verification token value was unexpected. Testing again should resolve the issue.
 
 See <doc:Debugging> for details on the functionality of the debugger.

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
@@ -34,12 +34,16 @@ internal class DebugViewModel: ObservableObject {
     }
     @Published var filter: DebugViewModel.LoggedEvent.EventType?
     @Published private(set) var connectedStatus = StatusItem(status: .pending, title: "Connected to Appcues")
+    @Published private(set) var deeplinkStatus = StatusItem(status: .pending, title: "Appcues Deeplink Configured")
     @Published private(set) var trackingPages = false
     @Published private(set) var userIdentified = false
     @Published var isAnonymous = false
 
     @Published var experienceStatuses: [StatusItem] = []
     private let syncQueue = DispatchQueue(label: "appcues-status-listing")
+
+    /// Unique value to pass through a deeplink to verify handling.
+    private var deeplinkVerificationToken: String?
 
     var statusItems: [StatusItem] {
         return [
@@ -51,6 +55,7 @@ internal class DebugViewModel: ObservableObject {
                 title: "Installed SDK \(Appcues.version())",
                 subtitle: "Account ID: \(accountID)\nApplication ID: \(applicationID)"),
             connectedStatus,
+            deeplinkStatus,
             StatusItem(
                 status: trackingPages ? .verified : .pending,
                 title: "Tracking Screens",
@@ -79,6 +84,7 @@ internal class DebugViewModel: ObservableObject {
         self.userIdentified = !currentUserID.isEmpty
 
         connectedStatus.action = Action(symbolName: "arrow.triangle.2.circlepath") { [weak self] in self?.ping() }
+        deeplinkStatus.action = Action(symbolName: "arrow.triangle.2.circlepath") { [weak self] in self?.verifyDeeplink() }
     }
 
     func reset() {
@@ -87,6 +93,8 @@ internal class DebugViewModel: ObservableObject {
         latestEvent = nil
         trackingPages = false
     }
+
+    // MARK: Event Handling
 
     func addUpdate(_ update: TrackingUpdate) {
         let event = LoggedEvent(from: update)
@@ -160,6 +168,8 @@ internal class DebugViewModel: ObservableObject {
         }
     }
 
+    // MARK: API Connection Status
+
     func ping() {
         connectedStatus.status = .pending
         connectedStatus.subtitle = nil
@@ -177,6 +187,61 @@ internal class DebugViewModel: ObservableObject {
                 }
             }
         }
+    }
+
+    // MARK: Deeplink Status
+
+    func verifyDeeplink() {
+        deeplinkStatus.status = .pending
+        deeplinkStatus.subtitle = nil
+
+        if !infoPlistContainsScheme() {
+            deeplinkStatus.status = .unverfied
+            deeplinkStatus.subtitle = "Error 1: CFBundleURLSchemes value missing"
+            return
+        }
+
+        verifyDeeplinkHandling(token: UUID().uuidString)
+    }
+
+    private func infoPlistContainsScheme() -> Bool {
+        guard let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else { return false }
+
+        return urlTypes
+            .flatMap { $0["CFBundleURLSchemes"] as? [String] ?? [] }
+            .contains { $0 == "appcues-\(applicationID)" }
+    }
+
+    private func verifyDeeplinkHandling(token: String) {
+        guard let url = URL(string: "appcues-\(applicationID)://sdk/verify/\(token)") else {
+            deeplinkStatus.status = .unverfied
+            deeplinkStatus.subtitle = "Error 0: Failed to set up verification"
+            return
+        }
+
+        deeplinkVerificationToken = token
+
+        UIApplication.shared.open(url, options: [:])
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            if self.deeplinkVerificationToken != nil {
+                self.deeplinkStatus.status = .unverfied
+                self.deeplinkStatus.subtitle = "Error 2: Appcues SDK not receiving links"
+                self.deeplinkVerificationToken = nil
+            }
+        }
+    }
+
+    func receivedVerification(token: String) {
+        if token == deeplinkVerificationToken {
+            deeplinkStatus.status = .verified
+            deeplinkStatus.subtitle = nil
+        } else {
+            deeplinkStatus.status = .unverfied
+            deeplinkStatus.subtitle = "Error 3: Unexpected result"
+        }
+
+        deeplinkVerificationToken = nil
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -12,6 +12,7 @@ import Combine
 
 @available(iOS 13.0, *)
 internal protocol UIDebugging: AnyObject {
+    func verifyInstall(token: String)
     func show(destination: DebugDestination?)
 }
 
@@ -54,6 +55,10 @@ internal class UIDebugger: UIDebugging {
             isAnonymous: storage.isAnonymous)
 
         notificationCenter.addObserver(self, selector: #selector(appcuesReset), name: .appcuesReset, object: nil)
+    }
+
+    func verifyInstall(token: String) {
+        viewModel.receivedVerification(token: token)
     }
 
     func show(destination: DebugDestination?) {

--- a/Sources/AppcuesKit/Presentation/DeeplinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeeplinkHandler.swift
@@ -20,6 +20,7 @@ internal class DeeplinkHandler: DeeplinkHandling {
         case preview(experienceID: String) // preview for draft content
         case show(experienceID: String)    // published content
         case debugger(destination: DebugDestination?)
+        case verifyInstall(id: String)
 
         init?(url: URL, isSessionActive: Bool, applicationID: String) {
             let isValidScheme = url.scheme == "appcues-\(applicationID)" || url.scheme == "appcues-democues"
@@ -30,6 +31,7 @@ internal class DeeplinkHandler: DeeplinkHandling {
             // appcues-{app_id}://sdk/experience_content/{experience_id}
             // appcues-{app_id}://sdk/debugger
             // appcues-{app_id}://sdk/debugger/fonts
+            // appcues-{app_id}://sdk/verify/{token}
 
             let pathTokens = url.path.split(separator: "/").map { String($0) }
 
@@ -40,6 +42,8 @@ internal class DeeplinkHandler: DeeplinkHandling {
                 self = .show(experienceID: pathTokens[1])
             } else if pathTokens.count >= 1, pathTokens[0] == "debugger" {
                 self = .debugger(destination: DebugDestination(pathToken: pathTokens[safe: 1]))
+            } else if pathTokens.count == 2, pathTokens[0] == "verify" {
+                self = .verifyInstall(id: pathTokens[1])
             } else {
                 return nil
             }
@@ -101,6 +105,8 @@ internal class DeeplinkHandler: DeeplinkHandling {
             container?.resolve(ExperienceLoading.self).load(experienceID: experienceID, published: true, completion: nil)
         case .debugger(let destination):
             container?.resolve(UIDebugging.self).show(destination: destination)
+        case .verifyInstall(let token):
+            container?.resolve(UIDebugging.self).verifyInstall(token: token)
         }
     }
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -36,6 +36,6 @@ internal class ExperienceStepViewModel: ObservableObject {
 
     func actions(for id: UUID) -> [ActionType?: [Experience.Action]] {
         // An unknown trigger value will get lumped into Dictionary[nil] and be ignored.
-        Dictionary(grouping: actions[id] ?? [], by: { ActionType(rawValue: $0.trigger) })
+        Dictionary(grouping: actions[id] ?? []) { ActionType(rawValue: $0.trigger) }
     }
 }

--- a/Tests/AppcuesKitTests/DeeplinkHandlerTests.swift
+++ b/Tests/AppcuesKitTests/DeeplinkHandlerTests.swift
@@ -119,6 +119,26 @@ class DeeplinkHandlerTests: XCTestCase {
         XCTAssertTrue(handled)
         XCTAssertTrue(debuggerShown)
     }
+
+    func testHandleDebugDeeplinkVerification() throws {
+        // Arrange
+        deeplinkHandler.topControllerGetting = MockTopControllerGetting()
+        let url = try XCTUnwrap(URL(string: "appcues-abc://sdk/verify/token-123"))
+
+        var debuggerVerificationCalled = false
+        appcues.debugger.onVerify = { token in
+            XCTAssertEqual(token, "token-123")
+            debuggerVerificationCalled = true
+        }
+
+        // Act
+        let handled = deeplinkHandler.didHandleURL(url)
+
+        // Assert
+        XCTAssertTrue(handled)
+        XCTAssertTrue(debuggerVerificationCalled)
+    }
+
     func testHandleNonAppcuesURL() throws {
         // Arrange
         deeplinkHandler.topControllerGetting = MockTopControllerGetting()

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -157,6 +157,11 @@ class MockActivityProcessor: ActivityProcessing {
 
 class MockDebugger: UIDebugging {
 
+    var onVerify: ((String) -> Void)?
+    func verifyInstall(token: String) {
+        onVerify?(token)
+    }
+
     var onShow: ((DebugDestination?) -> Void)?
     func show(destination: DebugDestination?) {
         onShow?(destination)


### PR DESCRIPTION
This was actually quite simple: for the first check we inspect the `Info.plist`, then we call a new deeplink url that doesn't do anything other than tell the debugger that the link was received. There's a unique token for each call just in case there's any weirdness with multiple SDK instances or something like that.

Video here: https://a.cl.ly/12uLZwxl