### PR TITLE
Improve support for dynamic content sizing with background content

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
@@ -19,7 +19,7 @@ extension UIViewController {
     func unembedChildViewController(_ childVC: UIViewController) {
         guard childVC.parent == self else { return }
         childVC.willMove(toParent: nil)
-        childVC.removeFromParent()
         childVC.view.removeFromSuperview()
+        childVC.removeFromParent()
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -47,6 +47,7 @@ internal class AppcuesBackgroundContentTrait: StepDecoratingTrait, ContainerDeco
         let backgroundContentVC = AppcuesHostingController(rootView: content.view
             .edgesIgnoringSafeArea(.all)
             .environmentObject(viewModel))
+        backgroundContentVC.updatesPreferredContentSize = false
         backgroundContentVC.view.backgroundColor = .clear
 
         // The background is strictly decoration.

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -101,6 +101,12 @@ extension AppcuesCarouselTrait {
         override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
             super.preferredContentSizeDidChange(forChildContentContainer: container)
 
+            // if this container has opted out of updating size, for example background content containers, do not update
+            // this view controller's preferredContentSize or height constraint
+            if let dynamicSizing = container as? DynamicContentSizing, !dynamicSizing.updatesPreferredContentSize {
+                return
+            }
+
             // If the current child controller changes it's preferred size, propagate that to the paging view.
             carouselView.preferredHeightConstraint.constant = container.preferredContentSize.height
             preferredContentSize = container.preferredContentSize

--- a/Sources/AppcuesKit/Presentation/Traits/DefaultContainerViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/DefaultContainerViewController.swift
@@ -84,7 +84,13 @@ internal class DefaultContainerViewController: ExperienceContainerViewController
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
 
-        // If the current child controller changes it's preferred size, propagate that to the paging view.
+        // if this container has opted out of updating size, for example background content containers, do not update
+        // this view controller's preferredContentSize or height constraint
+        if let dynamicSizing = container as? DynamicContentSizing, !dynamicSizing.updatesPreferredContentSize {
+            return
+        }
+
+        // If the current child controller changes it's preferred size, propagate that this controller's view.
         preferredHeightConstraint.constant = container.preferredContentSize.height
         preferredContentSize = container.preferredContentSize
     }

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesHostingController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesHostingController.swift
@@ -12,7 +12,13 @@ import SwiftUI
 ///
 /// Reference: https://stackoverflow.com/a/69359296
 @available(iOS 13.0, *)
-internal class AppcuesHostingController<Content: View>: UIHostingController<Content> {
+internal class AppcuesHostingController<Content: View>: UIHostingController<Content>, DynamicContentSizing {
+
+    // By default, changes in preferred content size from this hosting controller should be propagated up
+    // to any containers embedding it, to allow for dynamic sizing based on the content.
+    // This will be overriden to false for content that does not determine size, such as background content.
+    var updatesPreferredContentSize = true
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         view.setNeedsUpdateConstraints()

--- a/Sources/AppcuesKit/Presentation/UI/DynamicContentSizing.swift
+++ b/Sources/AppcuesKit/Presentation/UI/DynamicContentSizing.swift
@@ -1,0 +1,16 @@
+//
+//  DynamicContentSizing.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 8/17/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import UIKit
+
+/// Used to inform a container `UIViewController` whether it should update it's `preferredContentSize` based
+/// on the updated size of this `UIContentContainer`.
+@available(iOS 13.0, *)
+internal protocol DynamicContentSizing: UIContentContainer {
+    var updatesPreferredContentSize: Bool { get set }
+}


### PR DESCRIPTION
Fix up an issue noticed while testing out embedded content ideas - this should prevent any container sizing from being based upon the preferred size of a background content ViewController (which has height zero).