### PR TITLE
Add basic UI implementation for form components

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -22,6 +22,7 @@ internal indirect enum ExperienceComponent {
     case image(ImageModel)
     case spacer(SpacerModel)
     case embed(EmbedModel)
+    case textInput(TextInputModel)
 
     subscript<T>(dynamicMember keyPath: KeyPath<ComponentModel, T>) -> T {
         switch self {
@@ -32,6 +33,7 @@ internal indirect enum ExperienceComponent {
         case .image(let model): return model[keyPath: keyPath]
         case .spacer(let model): return model[keyPath: keyPath]
         case .embed(let model): return model[keyPath: keyPath]
+        case .textInput(let model): return model[keyPath: keyPath]
         }
     }
 }
@@ -69,6 +71,8 @@ extension ExperienceComponent: Decodable {
             self = .spacer(try modelContainer.decode(SpacerModel.self))
         case "embed":
             self = .embed(try modelContainer.decode(EmbedModel.self))
+        case "textInput":
+            self = .textInput(try modelContainer.decode(TextInputModel.self))
         default:
             let context = DecodingError.Context(codingPath: container.codingPath, debugDescription: "unknown type '\(type)'")
             throw DecodingError.valueNotFound(Self.self, context)
@@ -144,6 +148,27 @@ extension ExperienceComponent {
         let style: Style?
     }
 
+    struct TextInputModel: ComponentModel, Decodable {
+        enum DataType: String, Decodable {
+            case text, number, email, phone, name, address
+        }
+
+        let id: UUID
+
+        let label: TextModel
+        let placeholder: TextModel?
+        let defaultValue: String?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let required: Bool?
+        let numberOfLines: Int?
+        let maxLength: Int?
+        let dataType: DataType?
+        let textFieldStyle: Style?
+        let cursorColor: Style.DynamicColor?
+
+        let style: Style?
+    }
+    
     struct SpacerModel: ComponentModel, Decodable {
         let id: UUID
         let spacing: Double?

--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -22,6 +22,7 @@ internal indirect enum ExperienceComponent {
     case image(ImageModel)
     case spacer(SpacerModel)
     case embed(EmbedModel)
+    case optionSelect(OptionSelectModel)
     case textInput(TextInputModel)
 
     subscript<T>(dynamicMember keyPath: KeyPath<ComponentModel, T>) -> T {
@@ -33,6 +34,7 @@ internal indirect enum ExperienceComponent {
         case .image(let model): return model[keyPath: keyPath]
         case .spacer(let model): return model[keyPath: keyPath]
         case .embed(let model): return model[keyPath: keyPath]
+        case .optionSelect(let model): return model[keyPath: keyPath]
         case .textInput(let model): return model[keyPath: keyPath]
         }
     }
@@ -71,6 +73,8 @@ extension ExperienceComponent: Decodable {
             self = .spacer(try modelContainer.decode(SpacerModel.self))
         case "embed":
             self = .embed(try modelContainer.decode(EmbedModel.self))
+        case "optionSelect":
+            self = .optionSelect(try modelContainer.decode(OptionSelectModel.self))
         case "textInput":
             self = .textInput(try modelContainer.decode(TextInputModel.self))
         default:
@@ -168,7 +172,46 @@ extension ExperienceComponent {
 
         let style: Style?
     }
-    
+
+    struct FormOptionModel: Decodable, Identifiable {
+        var id: String { value }
+
+        let value: String
+        let content: ExperienceComponent
+        let selectedContent: ExperienceComponent?
+    }
+
+    struct OptionSelectModel: ComponentModel, Decodable {
+        enum SelectMode: String, Decodable {
+            case single, multi
+        }
+
+        enum ControlPosition: String, Decodable {
+            case leading, trailing, top, bottom, hidden
+        }
+
+        enum DisplayFormat: String, Decodable {
+            case verticalList, horizontalList, picker
+        }
+
+        let id: UUID
+
+        let label: TextModel
+        let selectMode: SelectMode
+        let options: [FormOptionModel]
+        let defaultValue: [String]?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let required: Bool?
+        let controlPosition: ControlPosition?
+        let displayFormat: DisplayFormat?
+        let selectedColor: Style.DynamicColor?
+        let unselectedColor: Style.DynamicColor?
+        let accentColor: Style.DynamicColor?
+        let pickerStyle: Style?
+
+        let style: Style?
+    }
+
     struct SpacerModel: ComponentModel, Decodable {
         let id: UUID
         let spacing: Double?

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/Font+Double.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/Font+Double.swift
@@ -71,3 +71,68 @@ extension Font.Design {
         }
     }
 }
+
+@available(iOS 13.0, *)
+extension UIFont {
+    static func matching(name: String?, size: Double?) -> UIFont? {
+        guard let size = CGFloat(size) else { return nil }
+        guard let name = name else {
+            return .systemFont(ofSize: size)
+        }
+
+        // A space is invalid for PostScript font names, and so we can safely avoid collisions with a custom font named "System".
+        if name.starts(with: "System ") {
+            // Expected format is `System $Design $Weight`.
+            let parts = name.split(separator: " ")
+            if parts.count == 3 {
+                let systemFont = UIFont.systemFont(ofSize: size, weight: UIFont.Weight(string: String(parts[2])) ?? .regular)
+                let design = UIFontDescriptor.SystemDesign(string: String(parts[1])) ?? .default
+
+                if let descriptor = systemFont.fontDescriptor.withDesign(design) {
+                    return UIFont(descriptor: descriptor, size: size)
+                } else {
+                    return systemFont
+                }
+            } else {
+                return .systemFont(ofSize: size)
+            }
+        } else {
+            return UIFont(name: name, size: size)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension UIFont.Weight {
+
+    /// Init `UIFont.Weight` from an experience JSON fontName keyword.
+    init?(string: String?) {
+        switch string {
+        case "Black": self = .black
+        case "Heavy": self = .heavy
+        case "Bold": self = .bold
+        case "Semibold": self = .semibold
+        case "Medium": self = .medium
+        case "Regular": self = .regular
+        case "Light": self = .light
+        case "Thin": self = .thin
+        case "Ultralight": self = .ultraLight
+        default: return nil
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension UIFontDescriptor.SystemDesign {
+
+    /// Init `UIFontDescriptor.SystemDesign` from an experience JSON fontName keyword.
+    init?(string: String?) {
+        switch string {
+        case "Default": self = .default
+        case "Monospaced": self = .monospaced
+        case "Rounded": self = .rounded
+        case "Serif": self = .serif
+        default: return nil
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -110,12 +110,15 @@ extension View {
     }
 
     func applyAllAppcues(_ style: AppcuesStyle) -> some View {
-        self
-            .applyForegroundStyle(style)
-            .applyInternalLayout(style)
-            .applyBackgroundStyle(style)
-            .applyBorderStyle(style)
-            .applyExternalLayout(style)
+        // Using `AnyView` here drastically improves memory and CPU usage
+        AnyView(
+            self
+                .applyForegroundStyle(style)
+                .applyInternalLayout(style)
+                .applyBackgroundStyle(style)
+                .applyBorderStyle(style)
+                .applyExternalLayout(style)
+        )
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -29,13 +29,13 @@ internal struct AppcuesOptionSelect: View {
                     }
                 }
             case (_, .horizontalList):
-                HStack(alignment: .center, spacing: 0) {
+                HStack(alignment: model.controlPosition?.verticalAlignment ?? .center, spacing: 0) {
                     items
                 }
             case (_, .verticalList),
                 // fallbacks
                 (_, .none), (.multi, .picker):
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: model.controlPosition?.horizontalAlignment ?? .center, spacing: 0) {
                     items
                 }
             }
@@ -57,6 +57,31 @@ internal struct AppcuesOptionSelect: View {
                     option.content.view
                 }
             }
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension ExperienceComponent.OptionSelectModel.ControlPosition {
+    var verticalAlignment: VerticalAlignment? {
+        switch self {
+        case .top:
+            return .top
+        case .bottom:
+            return .bottom
+        case .leading, .trailing, .hidden:
+            return nil
+        }
+    }
+
+    var horizontalAlignment: HorizontalAlignment? {
+        switch self {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
+        case .top, .bottom, .hidden:
+            return nil
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -1,0 +1,62 @@
+//
+//  AppcuesOptionSelect.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-08-11.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal struct AppcuesOptionSelect: View {
+    let model: ExperienceComponent.OptionSelectModel
+
+    @EnvironmentObject var viewModel: ExperienceStepViewModel
+
+    var body: some View {
+        let style = AppcuesStyle(from: model.style)
+
+        VStack(alignment: style.horizontalAlignment, spacing: 0) {
+            ExperienceComponent.text(model.label).view
+
+            switch (model.selectMode, model.displayFormat) {
+            case (.single, .picker):
+                Picker(model.label.text, selection: viewModel.formBinding(for: model.id)) {
+                    ForEach(model.options) { option in
+                        option.content.view
+                            .tag(option.value)
+                    }
+                }
+            case (_, .horizontalList):
+                HStack(alignment: .center, spacing: 0) {
+                    items
+                }
+            case (_, .verticalList),
+                // fallbacks
+                (_, .none), (.multi, .picker):
+                VStack(alignment: .leading, spacing: 0) {
+                    items
+                }
+            }
+        }
+        .setupActions(on: viewModel, for: model.id)
+        .applyAllAppcues(style)
+    }
+
+    @ViewBuilder var items: some View {
+        ForEach(model.options) { option in
+            let binding = viewModel.formBinding(for: model.id, value: option.value)
+            SelectToggleView(
+                selected: binding,
+                model: model
+            ) {
+                if binding.wrappedValue {
+                    (option.selectedContent ?? option.content).view
+                } else {
+                    option.content.view
+                }
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
@@ -1,0 +1,48 @@
+//
+//  AppcuesTextInput.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-08-15.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal struct AppcuesTextInput: View {
+    let model: ExperienceComponent.TextInputModel
+
+    var height: Double {
+        let lineHeight = (model.textFieldStyle?.fontSize ?? UIFont.labelFontSize) * 1.2
+        let padding = 16.0 * 2
+        return Double(model.numberOfLines ?? 1) * lineHeight + padding
+    }
+
+    @EnvironmentObject var viewModel: ExperienceStepViewModel
+
+    var body: some View {
+        let style = AppcuesStyle(from: model.style)
+        let textFieldStyle = AppcuesStyle(from: model.textFieldStyle)
+
+        VStack(alignment: style.horizontalAlignment, spacing: 0) {
+            ExperienceComponent.text(model.label).view
+
+            let binding = viewModel.formBinding(for: model.id)
+
+            MultilineTextView(text: binding, model: model)
+                .frame(height: height)
+                .overlay(placeholder(binding), alignment: .topLeading)
+                .applyAllAppcues(textFieldStyle)
+        }
+        .setupActions(on: viewModel, for: model.id)
+        .applyAllAppcues(style)
+    }
+
+    @ViewBuilder func placeholder(_ binding: Binding<String>) -> some View {
+        if let placeholder = model.placeholder, binding.wrappedValue.isEmpty {
+            ExperienceComponent.text(placeholder).view
+                .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                .allowsHitTesting(false)
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
@@ -27,6 +27,8 @@ extension ExperienceComponent {
             AppcuesEmbed(model: model)
         case .textInput(let model):
             AppcuesTextInput(model: model)
+        case .optionSelect(let model):
+            AppcuesOptionSelect(model: model)
         case .spacer(let model):
             Spacer(minLength: CGFloat(model.spacing))
         }

--- a/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
@@ -25,6 +25,8 @@ extension ExperienceComponent {
             AppcuesImage(model: model)
         case .embed(let model):
             AppcuesEmbed(model: model)
+        case .textInput(let model):
+            AppcuesTextInput(model: model)
         case .spacer(let model):
             Spacer(minLength: CGFloat(model.spacing))
         }

--- a/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
@@ -12,25 +12,26 @@ import SwiftUI
 extension ExperienceComponent {
 
     @ViewBuilder var view: some View {
+        // Using `AnyView` here drastically improves memory and CPU usage
         switch self {
         case .stack(let model):
-            AppcuesStack(model: model)
+            AnyView(AppcuesStack(model: model))
         case .box(let model):
-            AppcuesBox(model: model)
+            AnyView(AppcuesBox(model: model))
         case .text(let model):
-            AppcuesText(model: model)
+            AnyView(AppcuesText(model: model))
         case .button(let model):
-            AppcuesButton(model: model)
+            AnyView(AppcuesButton(model: model))
         case .image(let model):
-            AppcuesImage(model: model)
+            AnyView(AppcuesImage(model: model))
         case .embed(let model):
-            AppcuesEmbed(model: model)
+            AnyView(AppcuesEmbed(model: model))
         case .textInput(let model):
-            AppcuesTextInput(model: model)
+            AnyView(AppcuesTextInput(model: model))
         case .optionSelect(let model):
-            AppcuesOptionSelect(model: model)
+            AnyView(AppcuesOptionSelect(model: model))
         case .spacer(let model):
-            Spacer(minLength: CGFloat(model.spacing))
+            AnyView(Spacer(minLength: CGFloat(model.spacing)))
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
@@ -1,0 +1,169 @@
+//
+//  MultilineTextView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-09-12.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal struct MultilineTextView: UIViewRepresentable {
+    @Binding var text: String
+    let model: ExperienceComponent.TextInputModel
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        if (model.numberOfLines ?? 1) > 1 {
+            return makeTextView(context: context)
+        } else {
+            return makeTextField(context: context)
+        }
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        if let textView = uiView as? UITextView {
+            textView.text = text
+        } else if let textField = uiView as? UITextField {
+            textField.text = text
+        }
+    }
+
+    private func makeTextView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.delegate = context.coordinator
+        textView.backgroundColor = .clear
+        textView.textContainer.lineFragmentPadding = 0
+        textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+
+        let fontSize = model.textFieldStyle?.fontSize ?? UIFont.labelFontSize
+        textView.font = UIFont.matching(name: model.textFieldStyle?.fontName, size: fontSize)
+        textView.textColor = UIColor(dynamicColor: model.textFieldStyle?.foregroundColor)
+
+        textView.tintColor = UIColor(dynamicColor: model.cursorColor)
+        if let keyboardType = model.dataType?.keyboardType {
+            textView.keyboardType = keyboardType
+        }
+        textView.textContentType = model.dataType?.textContentType
+
+        return textView
+    }
+
+    private func makeTextField(context: Context) -> UITextField {
+        let textField = PaddedTextField(insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+        textField.delegate = context.coordinator
+        textField.addTarget(context.coordinator, action: #selector(Coordinator.textFieldDidChange(_:)), for: .editingChanged)
+        textField.backgroundColor = .clear
+
+        let fontSize = model.textFieldStyle?.fontSize ?? UIFont.labelFontSize
+        textField.font = UIFont.matching(name: model.textFieldStyle?.fontName, size: fontSize)
+        textField.textColor = UIColor(dynamicColor: model.textFieldStyle?.foregroundColor)
+
+        textField.tintColor = UIColor(dynamicColor: model.cursorColor)
+        if let keyboardType = model.dataType?.keyboardType {
+            textField.keyboardType = keyboardType
+        }
+        textField.textContentType = model.dataType?.textContentType
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        return textField
+    }
+}
+
+@available(iOS 13.0, *)
+extension MultilineTextView {
+    class Coordinator: NSObject, UITextViewDelegate, UITextFieldDelegate {
+        var parent: MultilineTextView
+
+        init(_ multilineTextView: MultilineTextView) {
+            self.parent = multilineTextView
+        }
+
+        // MARK: UITextViewDelegate
+
+        func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+            guard let maxLength = parent.model.maxLength else { return true }
+
+            let currentText = textView.text ?? ""
+            guard let stringRange = Range(range, in: currentText) else { return false }
+            let updatedText = currentText.replacingCharacters(in: stringRange, with: text)
+            return updatedText.count <= maxLength
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            self.parent.text = textView.text
+        }
+
+        // MARK: UITextFieldDelegate
+
+        func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            guard let maxLength = parent.model.maxLength else { return true }
+
+            let currentText = textField.text ?? ""
+            guard let stringRange = Range(range, in: currentText) else { return false }
+            let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+            return updatedText.count <= maxLength
+        }
+
+        @objc
+        func textFieldDidChange(_ textField: UITextField) {
+            self.parent.text = textField.text ?? ""
+        }
+    }
+
+    class PaddedTextField: UITextField {
+        let insets: UIEdgeInsets
+
+        init(insets: UIEdgeInsets) {
+            self.insets = insets
+            super.init(frame: .zero)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func textRect(forBounds bounds: CGRect) -> CGRect {
+            return bounds.inset(by: insets)
+        }
+
+        override func editingRect(forBounds bounds: CGRect) -> CGRect {
+            return self.textRect(forBounds: bounds)
+        }
+    }
+}
+
+extension ExperienceComponent.TextInputModel.DataType {
+    var keyboardType: UIKeyboardType? {
+        switch self {
+        case .text, .name, .address:
+            return nil
+        case .number:
+            return .numberPad
+        case .email:
+            return .emailAddress
+        case .phone:
+            return .phonePad
+        }
+    }
+
+    var textContentType: UITextContentType? {
+        switch self {
+        case .text, .number:
+            return nil
+        case .email:
+            return .emailAddress
+        case .phone:
+            return .telephoneNumber
+        case .name:
+            return .name
+        case .address:
+            return .fullStreetAddress
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/Components/SelectToggleView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/SelectToggleView.swift
@@ -1,0 +1,98 @@
+//
+//  SelectToggleView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-08-24.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal struct SelectToggleView<Content: View>: View {
+
+    enum Appearance {
+        case checkbox, radio
+    }
+
+    @Binding var selected: Bool
+    let model: ExperienceComponent.OptionSelectModel
+    @ViewBuilder var content: Content
+
+    @ViewBuilder var control: some View {
+        Appearance(model.selectMode).symbol(selected: selected, model: model)
+            .imageScale(.large)
+            // Ensure the minimum size leaves enough space to be an adequate touch target.
+            .frame(minWidth: 48, minHeight: 48)
+            // zIndex ensures the image is on top of the content the content can be styled to go under the image.
+            .zIndex(1)
+    }
+
+    var body: some View {
+        Group {
+            switch model.controlPosition {
+            case .leading:
+                HStack(spacing: 0) {
+                    control
+                    content
+                }
+            case .trailing:
+                HStack(spacing: 0) {
+                    content
+                    control
+                }
+            case .top:
+                VStack(spacing: 0) {
+                    control
+                    content
+                }
+            case .bottom:
+                VStack(spacing: 0) {
+                    content
+                    control
+                }
+            case .hidden, .none:
+                content
+            }
+        }
+        .onTapGesture { self.selected.toggle() }
+    }
+}
+
+@available(iOS 13.0, *)
+extension SelectToggleView.Appearance {
+    init(_ mode: ExperienceComponent.OptionSelectModel.SelectMode) {
+        switch mode {
+        case .single:
+            self = .radio
+        case .multi:
+            self = .checkbox
+        }
+    }
+
+    @ViewBuilder
+    func symbol(selected: Bool, model: ExperienceComponent.OptionSelectModel) -> some View {
+        let primaryColor = selected ? Color(dynamicColor: model.selectedColor) :  Color(dynamicColor: model.unselectedColor)
+
+        switch (self, selected) {
+        case (.checkbox, true):
+            if #available(iOS 15.0, *), let checkmarkColor = Color(dynamicColor: model.accentColor), let primaryColor = primaryColor {
+                Image(systemName: "checkmark.square.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(checkmarkColor, primaryColor)
+            } else {
+                Image(systemName: "checkmark.square.fill")
+                    .foregroundColor(primaryColor)
+            }
+        case (.checkbox, false):
+            Image(systemName: "square")
+                .foregroundColor(primaryColor)
+        case (.radio, true):
+            Image(systemName: "circle.inset.filled")
+                .foregroundColor(primaryColor)
+        case (.radio, false):
+            Image(systemName: "circle")
+                .foregroundColor(primaryColor)
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -163,6 +163,17 @@ extension ExperienceComponent {
             components[model.id] = .init(
                 value: .single(model.defaultValue ?? ""),
                 required: model.required ?? false)
+        case .optionSelect(let model):
+            switch model.selectMode {
+            case .single:
+                components[model.id] = .init(
+                    value: .single(model.defaultValue?.first ?? ""),
+                    required: model.required ?? false)
+            case .multi:
+                components[model.id] = .init(
+                    value: .multi(Set(model.defaultValue ?? [])),
+                    required: model.required ?? false)
+            }
         }
 
         return components

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -20,6 +20,12 @@ internal class ExperienceStepViewModel: ObservableObject {
     private let actions: [UUID: [Experience.Action]]
     private let actionRegistry: ActionRegistry?
 
+    @Published private var formComponents: [UUID: FormItem]
+
+    var formIsComplete: Bool {
+        !formComponents.contains { !$0.value.isSatisfied }
+    }
+
     init(step: Experience.Step.Child, actionRegistry: ActionRegistry) {
         self.step = step
         // Update the action list to be keyed by the UUID.
@@ -28,6 +34,8 @@ internal class ExperienceStepViewModel: ObservableObject {
             dict[uuidKey] = item.value
         }
         self.actionRegistry = actionRegistry
+
+        self.formComponents = step.content.formComponents
     }
 
     // Create an empty view model for contexts that require an `ExperienceStepViewModel` but aren't in a step context.
@@ -43,6 +51,7 @@ internal class ExperienceStepViewModel: ObservableObject {
             actions: [:])
         self.actions = [:]
         self.actionRegistry = nil
+        self.formComponents = [:]
     }
 
     func enqueueActions(_ actions: [Experience.Action]) {
@@ -52,5 +61,110 @@ internal class ExperienceStepViewModel: ObservableObject {
     func actions(for id: UUID) -> [ActionType?: [Experience.Action]] {
         // An unknown trigger value will get lumped into Dictionary[nil] and be ignored.
         Dictionary(grouping: actions[id] ?? []) { ActionType(rawValue: $0.trigger) }
+    }
+
+    // MARK: Bindings for SwiftUI form controls
+
+    func formBinding(for key: UUID) -> Binding<String> {
+        return .init(
+            get: { self.formComponents[key]?.getValue() ?? "" },
+            set: { self.formComponents[key]?.setValue($0) })
+    }
+
+    func formBinding(for key: UUID, value: String) -> Binding<Bool> {
+        return .init(
+            get: { self.formComponents[key]?.contains(searchValue: value) ?? false },
+            set: { _ in self.formComponents[key]?.setValue(value) })
+    }
+}
+
+@available(iOS 13.0, *)
+extension ExperienceStepViewModel {
+
+    struct FormItem {
+        enum ValueType {
+            case single(String)
+            case multi(Set<String>)
+
+            var isSet: Bool {
+                switch self {
+                case .single(let value):
+                    return !value.isEmpty
+                case .multi(let values):
+                    return !values.isEmpty
+                }
+            }
+
+            var value: String {
+                switch self {
+                case .single(let value):
+                    return value
+                case .multi(let values):
+                    return values.joined(separator: ",")
+                }
+            }
+        }
+
+        private var underlyingValue: ValueType
+        private let required: Bool
+
+        var isSatisfied: Bool {
+            return !required || underlyingValue.isSet
+        }
+
+        internal init(value: FormItem.ValueType, required: Bool) {
+            self.underlyingValue = value
+            self.required = required
+        }
+
+        func getValue() -> String {
+            underlyingValue.value
+        }
+
+        mutating func setValue(_ newValue: String) {
+            switch underlyingValue {
+            case .single:
+                underlyingValue = .single(newValue)
+            case .multi(let existingValues):
+                // Toggle the value to be included in the set.
+                underlyingValue = .multi(existingValues.symmetricDifference([newValue]))
+            }
+        }
+
+        func contains(searchValue: String) -> Bool {
+            switch underlyingValue {
+            case .single(let value):
+                return value == searchValue
+            case .multi(let existingValues):
+                return existingValues.contains(searchValue)
+            }
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension ExperienceComponent {
+    /// Recursively get all the form components in the `ExperienceContent`.
+    var formComponents: [UUID: ExperienceStepViewModel.FormItem] {
+        var components: [UUID: ExperienceStepViewModel.FormItem] = [:]
+
+        switch self {
+        case .text, .button, .image, .spacer, .embed:
+            break
+        case .stack(let model):
+            model.items.forEach {
+                components.merge($0.formComponents, uniquingKeysWith: { first, _ in first })
+            }
+        case .box(let model):
+            model.items.forEach {
+                components.merge($0.formComponents, uniquingKeysWith: { first, _ in first })
+            }
+        case .textInput(let model):
+            components[model.id] = .init(
+                value: .single(model.defaultValue ?? ""),
+                required: model.required ?? false)
+        }
+
+        return components
     }
 }


### PR DESCRIPTION
This PR maps the data models and implements _most_ of the UI functionality.

Currently unimplemented or rough around the edges:
- ~multiline text, max input length~
- keyboard safe area management for the text field
- ~checkbox/radio control styling (json model updates tbd)~

These additional primitives along with their complexity are creating some strange CPU and memory usage issues within SwiftUI. The update to `View+Appcues` wrapping `AnyView` fixes those and doesn't seem to have any other side effects despite `AnyView` generally being an anti-pattern. Definitely something to keep an eye on.

Otherwise, this is actually fairly simple for what it enables. All the form state is stored in the `ExperienceStepViewModel` and so we'll be able to grab the info out of there to send the necessary form interaction events in a future PR.

`ExperienceStepViewModel.FormItem` is how I'm generalizing the interface for selecting a single vs multiple values: The enum holds a `String` or `Set<String>` and then `get`, `set`, and `contains` functions manipulate those values. This will allow us to send a comma-separated list of values for the multi-select case. 