### PR TITLE
Add ExperienceData model to wrap Experience object and hold form state

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
@@ -26,7 +26,8 @@ internal enum StepReference: Equatable {
         }
     }
 
-    func resolve(experience: Experience, currentIndex: Experience.StepIndex) -> Experience.StepIndex? {
+    @available(iOS 13.0, *)
+    func resolve(experience: ExperienceData, currentIndex: Experience.StepIndex) -> Experience.StepIndex? {
         switch self {
         case .index(let index):
             return experience.stepIndices[safe: index]
@@ -61,29 +62,32 @@ extension Experience {
             self.item = parts[1]
         }
     }
+}
 
-    var stepIndices: [StepIndex] {
-        steps.enumerated().flatMap { groupOffset, element in
+@available(iOS 13.0, *)
+extension ExperienceData {
+    var stepIndices: [Experience.StepIndex] {
+        model.steps.enumerated().flatMap { groupOffset, element in
             element.items.enumerated().map { stepOffset, _ in
-                StepIndex(group: groupOffset, item: stepOffset)
+                Experience.StepIndex(group: groupOffset, item: stepOffset)
             }
         }
     }
 
-    func stepIndex(for id: UUID) -> StepIndex? {
-        for (groupOffset, element) in steps.enumerated() {
+    func stepIndex(for id: UUID) -> Experience.StepIndex? {
+        for (groupOffset, element) in model.steps.enumerated() {
             if element.id == id {
-                return StepIndex(group: groupOffset, item: 0)
+                return Experience.StepIndex(group: groupOffset, item: 0)
             }
 
             for (stepOffset, step) in element.items.enumerated() where step.id == id {
-                return StepIndex(group: groupOffset, item: stepOffset)
+                return Experience.StepIndex(group: groupOffset, item: stepOffset)
             }
         }
         return nil
     }
 
-    func step(at stepIndex: StepIndex) -> Step.Child? {
-        steps[safe: stepIndex.group]?.items[safe: stepIndex.item]
+    func step(at stepIndex: Experience.StepIndex) -> Experience.Step.Child? {
+        model.steps[safe: stepIndex.group]?.items[safe: stepIndex.item]
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -60,7 +60,7 @@ internal class ExperienceRenderer: ExperienceRendering {
             self.stateMachine.addObserver(analyticsObserver)
         }
         stateMachine.clientAppcuesDelegate = appcues?.experienceDelegate
-        stateMachine.transitionAndObserve(.startExperience(experience), filter: experience.instanceID) { result in
+        stateMachine.transitionAndObserve(.startExperience(ExperienceData(experience: experience)), filter: experience.instanceID) { result in
             switch result {
             case .success(.renderingStep):
                 DispatchQueue.main.async { completion?(.success(())) }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
@@ -11,7 +11,7 @@ import Foundation
 @available(iOS 13.0, *)
 extension ExperienceStateMachine {
     enum Action {
-        case startExperience(Experience)
+        case startExperience(ExperienceData)
         case startStep(StepReference)
         case renderStep
         case endExperience(markComplete: Bool)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
@@ -12,9 +12,9 @@ import Foundation
 extension ExperienceStateMachine {
     enum ExperienceError: Error {
         case noTransition(currentState: State)
-        case experienceAlreadyActive(ignoredExperience: Experience)
-        case experience(Experience, String)
-        case step(Experience, Experience.StepIndex, String)
+        case experienceAlreadyActive(ignoredExperience: ExperienceData)
+        case experience(ExperienceData, String)
+        case step(ExperienceData, Experience.StepIndex, String)
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -12,11 +12,11 @@ import Foundation
 extension ExperienceStateMachine {
     enum State {
         case idling
-        case beginningExperience(Experience)
-        case beginningStep(Experience, Experience.StepIndex, ExperiencePackage, isFirst: Bool)
-        case renderingStep(Experience, Experience.StepIndex, ExperiencePackage, isFirst: Bool)
-        case endingStep(Experience, Experience.StepIndex, ExperiencePackage)
-        case endingExperience(Experience, Experience.StepIndex, markComplete: Bool)
+        case beginningExperience(ExperienceData)
+        case beginningStep(ExperienceData, Experience.StepIndex, ExperiencePackage, isFirst: Bool)
+        case renderingStep(ExperienceData, Experience.StepIndex, ExperiencePackage, isFirst: Bool)
+        case endingStep(ExperienceData, Experience.StepIndex, ExperiencePackage)
+        case endingExperience(ExperienceData, Experience.StepIndex, markComplete: Bool)
 
         func transition(for action: Action, traitComposer: TraitComposing) -> Transition? {
             switch (self, action) {
@@ -107,7 +107,7 @@ extension ExperienceStateMachine.State: CustomStringConvertible {
 
 @available(iOS 13.0, *)
 extension ExperienceStateMachine.Transition {
-    static func fromIdlingToBeginningExperience(_ experience: Experience) -> Self {
+    static func fromIdlingToBeginningExperience(_ experience: ExperienceData) -> Self {
         guard !experience.steps.isEmpty else {
             return .init(toState: nil, sideEffect: .error(.experience(experience, "Experience has 0 steps"), reset: true))
         }
@@ -118,7 +118,7 @@ extension ExperienceStateMachine.Transition {
        )
     }
 
-    static func fromBeginningExperienceToBeginningStep(_ experience: Experience, _ traitComposer: TraitComposing) -> Self {
+    static func fromBeginningExperienceToBeginningStep(_ experience: ExperienceData, _ traitComposer: TraitComposing) -> Self {
         let stepIndex = Experience.StepIndex.initial
         do {
             let package = try traitComposer.package(experience: experience, stepIndex: stepIndex)
@@ -132,7 +132,7 @@ extension ExperienceStateMachine.Transition {
     }
 
     static func fromRenderingStepToEndingStep(
-        _ experience: Experience, _ stepIndex: Experience.StepIndex, _ package: ExperiencePackage, _ stepRef: StepReference
+        _ experience: ExperienceData, _ stepIndex: Experience.StepIndex, _ package: ExperiencePackage, _ stepRef: StepReference
     ) -> Self {
         guard let newStepIndex = stepRef.resolve(experience: experience, currentIndex: stepIndex) else {
             if stepRef == .offset(1) && experience.stepIndices.last == stepIndex {
@@ -158,7 +158,7 @@ extension ExperienceStateMachine.Transition {
     }
 
     static func fromEndingStepToBeginningStep(
-        _ experience: Experience, _ currentIndex: Experience.StepIndex, _ stepRef: StepReference, _ traitComposer: TraitComposing
+        _ experience: ExperienceData, _ currentIndex: Experience.StepIndex, _ stepRef: StepReference, _ traitComposer: TraitComposing
     ) -> Self {
         guard let stepIndex = stepRef.resolve(experience: experience, currentIndex: currentIndex) else {
             return .init(

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -212,7 +212,7 @@ extension ExperienceStateMachine {
 extension ExperienceStateMachine {
     enum SideEffect {
         case continuation(Action)
-        case presentContainer(Experience, Experience.StepIndex, ExperiencePackage)
+        case presentContainer(ExperienceData, Experience.StepIndex, ExperiencePackage)
         case navigateInContainer(ExperiencePackage, pageIndex: Int)
         case dismissContainer(ExperiencePackage, continuation: Action)
         case error(ExperienceError, reset: Bool)
@@ -242,10 +242,10 @@ extension ExperienceStateMachine {
         }
 
         private func executePresentContainer(
-            machine: ExperienceStateMachine, experience: Experience, stepIndex: Experience.StepIndex, package: ExperiencePackage
+            machine: ExperienceStateMachine, experience: ExperienceData, stepIndex: Experience.StepIndex, package: ExperiencePackage
         ) {
             machine.clientControllerDelegate = UIApplication.shared.topViewController() as? AppcuesExperienceDelegate
-            guard machine.canDisplay(experience: experience) else {
+            guard machine.canDisplay(experience: experience.model) else {
                 try? machine.transition(.reportError(.step(experience, stepIndex, "Step blocked by app"), fatal: true))
                 return
             }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
@@ -28,7 +28,8 @@ internal enum LifecycleEvent: String, CaseIterable {
     }
 
     /// Map experience model to a general property dictionary.
-    static func properties(_ experience: Experience, _ stepIndex: Experience.StepIndex? = nil, error: ErrorBody? = nil) -> [String: Any] {
+    @available(iOS 13.0, *)
+    static func properties(_ experience: ExperienceData, _ stepIndex: Experience.StepIndex? = nil, error: ErrorBody? = nil) -> [String: Any] {
         var properties: [String: Any] = [
             "experienceId": experience.id.uuidString.lowercased(),
             "experienceName": experience.name,

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -10,7 +10,7 @@ import UIKit
 
 @available(iOS 13.0, *)
 internal protocol TraitComposing: AnyObject {
-    func package(experience: Experience, stepIndex: Experience.StepIndex) throws -> ExperiencePackage
+    func package(experience: ExperienceData, stepIndex: Experience.StepIndex) throws -> ExperiencePackage
 }
 
 @available(iOS 13.0, *)
@@ -26,7 +26,7 @@ internal class TraitComposer: TraitComposing {
         notificationCenter = container.resolve(NotificationCenter.self)
     }
 
-    func package(experience: Experience, stepIndex: Experience.StepIndex) throws -> ExperiencePackage {
+    func package(experience: ExperienceData, stepIndex: Experience.StepIndex) throws -> ExperiencePackage {
         let stepModels: [Experience.Step.Child] = experience.steps[stepIndex.group].items
         let targetPageIndex = stepIndex.item
 
@@ -85,7 +85,10 @@ internal class TraitComposer: TraitComposing {
 
         let stepControllers: [ExperienceStepViewController] = try stepModelsWithDecorators.map { step, decorators in
             let viewModel = ExperienceStepViewModel(step: step, actionRegistry: actionRegistry)
-            let stepViewController = ExperienceStepViewController(viewModel: viewModel, notificationCenter: notificationCenter)
+            let stepViewController = ExperienceStepViewController(
+                viewModel: viewModel,
+                stepState: experience.state(for: experience.steps[stepIndex.group].items[stepIndex.item].id),
+                notificationCenter: notificationCenter)
             try decorators.forEach { try $0.decorate(stepController: stepViewController) }
             return stepViewController
         }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -13,6 +13,7 @@ internal struct AppcuesOptionSelect: View {
     let model: ExperienceComponent.OptionSelectModel
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
+    @EnvironmentObject var stepState: ExperienceData.StepState
 
     var body: some View {
         let style = AppcuesStyle(from: model.style)
@@ -22,7 +23,7 @@ internal struct AppcuesOptionSelect: View {
 
             switch (model.selectMode, model.displayFormat) {
             case (.single, .picker):
-                Picker(model.label.text, selection: viewModel.formBinding(for: model.id)) {
+                Picker(model.label.text, selection: stepState.formBinding(for: model.id)) {
                     ForEach(model.options) { option in
                         option.content.view
                             .tag(option.value)
@@ -46,7 +47,7 @@ internal struct AppcuesOptionSelect: View {
 
     @ViewBuilder var items: some View {
         ForEach(model.options) { option in
-            let binding = viewModel.formBinding(for: model.id, value: option.value)
+            let binding = stepState.formBinding(for: model.id, value: option.value)
             SelectToggleView(
                 selected: binding,
                 model: model

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
@@ -19,6 +19,7 @@ internal struct AppcuesTextInput: View {
     }
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
+    @EnvironmentObject var stepState: ExperienceData.StepState
 
     var body: some View {
         let style = AppcuesStyle(from: model.style)
@@ -27,7 +28,7 @@ internal struct AppcuesTextInput: View {
         VStack(alignment: style.horizontalAlignment, spacing: 0) {
             ExperienceComponent.text(model.label).view
 
-            let binding = viewModel.formBinding(for: model.id)
+            let binding = stepState.formBinding(for: model.id)
 
             MultilineTextView(text: binding, model: model)
                 .frame(height: height)

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -1,0 +1,139 @@
+//
+//  ExperienceData.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-09-12.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+@dynamicMemberLookup
+internal class ExperienceData {
+    let model: Experience
+    private let formState: FormState
+
+    internal init(experience: Experience) {
+        self.model = experience
+        self.formState = FormState(experience: experience)
+    }
+
+    func state(for stepID: UUID) -> StepState {
+        guard let stepState = formState.steps[stepID] else {
+            // This will never happen as long as we ask for a valid `stepID`, but to avoid a crash
+            // where there's no environmentObject set, return an empty state.
+            // If this does get into the UI, the result will be form controls that don't update.
+            return StepState(formItems: [:])
+        }
+
+        return stepState
+    }
+
+    subscript<T>(dynamicMember keyPath: KeyPath<Experience, T>) -> T {
+        return model[keyPath: keyPath]
+    }
+}
+
+@available(iOS 13.0, *)
+extension ExperienceData {
+    class FormState {
+        var steps: [UUID: StepState] = [:]
+
+        init(experience: Experience) {
+            experience.steps.forEach { step in
+                step.items.forEach { item in
+                    steps[item.id] = StepState(formItems: item.content.formComponents)
+                }
+            }
+        }
+    }
+
+    class StepState: ObservableObject {
+        @Published var formItems: [UUID: FormItem]
+
+        var stepFormIsComplete: Bool {
+            !formItems.contains { !$0.value.isSatisfied }
+        }
+
+        init(formItems: [UUID: FormItem]) {
+            self.formItems = formItems
+        }
+
+        func formBinding(for key: UUID) -> Binding<String> {
+            return .init(
+                get: { self.formItems[key]?.getValue() ?? "" },
+                set: {
+                    self.formItems[key]?.setValue($0)
+                })
+        }
+
+        func formBinding(for key: UUID, value: String) -> Binding<Bool> {
+            return .init(
+                get: { self.formItems[key]?.contains(searchValue: value) ?? false },
+                set: { _ in
+                    self.formItems[key]?.setValue(value)
+                })
+        }
+    }
+
+    struct FormItem {
+        enum ValueType {
+            case single(String)
+            case multi(Set<String>)
+
+            var isSet: Bool {
+                switch self {
+                case .single(let value):
+                    return !value.isEmpty
+                case .multi(let values):
+                    return !values.isEmpty
+                }
+            }
+
+            var value: String {
+                switch self {
+                case .single(let value):
+                    return value
+                case .multi(let values):
+                    return values.joined(separator: ",")
+                }
+            }
+        }
+
+        private var underlyingValue: ValueType
+        private let required: Bool
+
+        var isSatisfied: Bool {
+            return !required || underlyingValue.isSet
+        }
+
+        internal init(value: FormItem.ValueType, required: Bool) {
+            self.underlyingValue = value
+            self.required = required
+        }
+
+        func getValue() -> String {
+            underlyingValue.value
+        }
+
+        mutating func setValue(_ newValue: String) {
+            switch underlyingValue {
+            case .single:
+                underlyingValue = .single(newValue)
+            case .multi(let existingValues):
+                // Toggle the value to be included in the set.
+                underlyingValue = .multi(existingValues.symmetricDifference([newValue]))
+            }
+        }
+
+        func contains(searchValue: String) -> Bool {
+            switch underlyingValue {
+            case .single(let value):
+                return value == searchValue
+            case .multi(let existingValues):
+                return existingValues.contains(searchValue)
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepRootView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepRootView.swift
@@ -13,9 +13,11 @@ internal struct ExperienceStepRootView<Content: View>: View {
     let rootView: Content
 
     @ObservedObject var viewModel: ExperienceStepViewModel
+    @ObservedObject var stepState: ExperienceData.StepState
 
     var body: some View {
         rootView
             .environmentObject(viewModel)
+            .environmentObject(stepState)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -22,11 +22,11 @@ internal class ExperienceStepViewController: UIViewController {
 
     private let contentViewController: UIViewController
 
-    init(viewModel: ExperienceStepViewModel, notificationCenter: NotificationCenter? = nil) {
+    init(viewModel: ExperienceStepViewModel, stepState: ExperienceData.StepState, notificationCenter: NotificationCenter? = nil) {
         self.viewModel = viewModel
         self.notificationCenter = notificationCenter
 
-        let rootView = ExperienceStepRootView(rootView: viewModel.step.content.view, viewModel: viewModel)
+        let rootView = ExperienceStepRootView(rootView: viewModel.step.content.view, viewModel: viewModel, stepState: stepState)
         self.contentViewController = AppcuesHostingController(rootView: rootView)
         self.contentViewController.view.backgroundColor = .clear
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -20,12 +20,6 @@ internal class ExperienceStepViewModel: ObservableObject {
     private let actions: [UUID: [Experience.Action]]
     private let actionRegistry: ActionRegistry?
 
-    @Published private var formComponents: [UUID: FormItem]
-
-    var formIsComplete: Bool {
-        !formComponents.contains { !$0.value.isSatisfied }
-    }
-
     init(step: Experience.Step.Child, actionRegistry: ActionRegistry) {
         self.step = step
         // Update the action list to be keyed by the UUID.
@@ -34,8 +28,6 @@ internal class ExperienceStepViewModel: ObservableObject {
             dict[uuidKey] = item.value
         }
         self.actionRegistry = actionRegistry
-
-        self.formComponents = step.content.formComponents
     }
 
     // Create an empty view model for contexts that require an `ExperienceStepViewModel` but aren't in a step context.
@@ -51,7 +43,6 @@ internal class ExperienceStepViewModel: ObservableObject {
             actions: [:])
         self.actions = [:]
         self.actionRegistry = nil
-        self.formComponents = [:]
     }
 
     func enqueueActions(_ actions: [Experience.Action]) {
@@ -62,91 +53,13 @@ internal class ExperienceStepViewModel: ObservableObject {
         // An unknown trigger value will get lumped into Dictionary[nil] and be ignored.
         Dictionary(grouping: actions[id] ?? []) { ActionType(rawValue: $0.trigger) }
     }
-
-    // MARK: Bindings for SwiftUI form controls
-
-    func formBinding(for key: UUID) -> Binding<String> {
-        return .init(
-            get: { self.formComponents[key]?.getValue() ?? "" },
-            set: { self.formComponents[key]?.setValue($0) })
-    }
-
-    func formBinding(for key: UUID, value: String) -> Binding<Bool> {
-        return .init(
-            get: { self.formComponents[key]?.contains(searchValue: value) ?? false },
-            set: { _ in self.formComponents[key]?.setValue(value) })
-    }
-}
-
-@available(iOS 13.0, *)
-extension ExperienceStepViewModel {
-
-    struct FormItem {
-        enum ValueType {
-            case single(String)
-            case multi(Set<String>)
-
-            var isSet: Bool {
-                switch self {
-                case .single(let value):
-                    return !value.isEmpty
-                case .multi(let values):
-                    return !values.isEmpty
-                }
-            }
-
-            var value: String {
-                switch self {
-                case .single(let value):
-                    return value
-                case .multi(let values):
-                    return values.joined(separator: ",")
-                }
-            }
-        }
-
-        private var underlyingValue: ValueType
-        private let required: Bool
-
-        var isSatisfied: Bool {
-            return !required || underlyingValue.isSet
-        }
-
-        internal init(value: FormItem.ValueType, required: Bool) {
-            self.underlyingValue = value
-            self.required = required
-        }
-
-        func getValue() -> String {
-            underlyingValue.value
-        }
-
-        mutating func setValue(_ newValue: String) {
-            switch underlyingValue {
-            case .single:
-                underlyingValue = .single(newValue)
-            case .multi(let existingValues):
-                // Toggle the value to be included in the set.
-                underlyingValue = .multi(existingValues.symmetricDifference([newValue]))
-            }
-        }
-
-        func contains(searchValue: String) -> Bool {
-            switch underlyingValue {
-            case .single(let value):
-                return value == searchValue
-            case .multi(let existingValues):
-                return existingValues.contains(searchValue)
-            }
-        }
-    }
 }
 
 @available(iOS 13.0, *)
 extension ExperienceComponent {
     /// Recursively get all the form components in the `ExperienceContent`.
-    var formComponents: [UUID: ExperienceStepViewModel.FormItem] {
-        var components: [UUID: ExperienceStepViewModel.FormItem] = [:]
+    var formComponents: [UUID: ExperienceData.FormItem] {
+        var components: [UUID: ExperienceData.FormItem] = [:]
 
         switch self {
         case .text, .button, .image, .spacer, .embed:

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -25,7 +25,7 @@ class ExperienceRendererTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         let presentExpectation = expectation(description: "Experience presented")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
@@ -35,7 +35,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: Experience.mock, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -53,14 +53,14 @@ class ExperienceRendererTests: XCTestCase {
         let presentExpectation = expectation(description: "Experience presented")
         presentExpectation.expectedFulfillmentCount = 2
         let dismissExpectation = expectation(description: "Experience dismissed")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(
             presentExpectation: presentExpectation,
             dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: Experience.mock, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -68,7 +68,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: Experience.mock, priority: .normal, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .normal, published: true) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -87,14 +87,14 @@ class ExperienceRendererTests: XCTestCase {
         let presentExpectation = expectation(description: "Experience presented")
         presentExpectation.expectedFulfillmentCount = 2
         let dismissExpectation = expectation(description: "Experience dismissed")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(
             presentExpectation: presentExpectation,
             dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: Experience.mock, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -103,7 +103,7 @@ class ExperienceRendererTests: XCTestCase {
         // NOTE: No waiting for initial .show() to complete like the test case above does.
 
         // Act
-        experienceRenderer.show(experience: Experience.mock, priority: .normal, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .normal, published: true) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -119,12 +119,12 @@ class ExperienceRendererTests: XCTestCase {
         let preconditionExpectation = expectation(description: "Precondition completion called")
         let presentExpectation = expectation(description: "Experience presented")
         let failureExpectation = expectation(description: "Experience presentation failed called")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: Experience.mock, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -132,7 +132,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation, presentExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: Experience.mock, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
             print(result)
             if case .failure(ExperienceStateMachine.ExperienceError.experienceAlreadyActive) = result {
                 failureExpectation.fulfill()
@@ -148,7 +148,7 @@ class ExperienceRendererTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         let presentExpectation = expectation(description: "Experience presented")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
@@ -158,7 +158,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: Experience.mock, priority: .low, published: false) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: false) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -173,8 +173,8 @@ class ExperienceRendererTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         let presentExpectation = expectation(description: "Experience presented")
-        let brokenExperience = Experience.mock
-        let validExperience = Experience.mock
+        let brokenExperience = ExperienceData.mock
+        let validExperience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = validExperience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { experience, _ in
             if experience.instanceID == validExperience.instanceID {
@@ -190,7 +190,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(qualifiedExperiences: [brokenExperience, validExperience], priority: .low) { result in
+        experienceRenderer.show(qualifiedExperiences: [brokenExperience.model, validExperience.model], priority: .low) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -206,10 +206,10 @@ class ExperienceRendererTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         let preconditionPresentExpectation = expectation(description: "Experience presented")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         var preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience, priority: .low, published: true, completion: nil)
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Now that we've shown the first step, set the expectation for the 2nd step transition that we're testing
@@ -234,10 +234,10 @@ class ExperienceRendererTests: XCTestCase {
 
         let preconditionPresentExpectation = expectation(description: "Experience presented")
         let dismissExpectation = expectation(description: "Experience dismissed")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience, priority: .low, published: true, completion: nil)
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -257,19 +257,19 @@ class ExperienceRendererTests: XCTestCase {
         let failureExpectation = expectation(description: "Second experience: failure called")
 
         let presentExpectation = expectation(description: "Experience presented")
-        let firstExperienceInstance = Experience.mock
-        let secondExperienceInstance = Experience.mock
+        let firstExperienceInstance = ExperienceData.mock
+        let secondExperienceInstance = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = firstExperienceInstance.packageWithDelay(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: firstExperienceInstance, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: firstExperienceInstance.model, priority: .low, published: true) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
         }
 
-        experienceRenderer.show(experience: secondExperienceInstance, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: secondExperienceInstance.model, priority: .low, published: true) { result in
             if case let .failure(error) = result {
                 XCTAssertEqual(
                     error as! ExperienceStateMachine.ExperienceError,
@@ -294,10 +294,10 @@ class ExperienceRendererTests: XCTestCase {
         let dismissExpectation = expectation(description: "Experience dismissed")
 
         let preconditionPresentExpectation = expectation(description: "Experience presented")
-        let experience = Experience.singleStepMock
+        let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience, priority: .low, published: true, completion: nil)
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -310,7 +310,7 @@ class ExperienceRendererTests: XCTestCase {
     }
 }
 
-private extension Experience {
+private extension ExperienceData {
     @available(iOS 13.0, *)
     func packageWithDelay(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
         let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()])

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -45,7 +45,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateBeginningExperienceState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.beginningExperience(Experience.mock)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.beginningExperience(ExperienceData.mock)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -54,7 +54,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateBeginningStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.beginningStep(Experience.mock, .initial, Experience.mock.package(), isFirst: true)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.beginningStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), isFirst: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -66,7 +66,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         XCTAssertNil(appcues.storage.lastContentShownAt)
 
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(Experience.mock, .initial, Experience.mock.package(), isFirst: true)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), isFirst: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -99,7 +99,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateRenderingStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(Experience.mock, .initial, Experience.mock.package(), isFirst: false)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), isFirst: false)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -131,7 +131,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(Experience.mock, .initial, Experience.mock.package())))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mock, .initial, ExperienceData.mock.package())))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -163,7 +163,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingExperienceState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(Experience.mock, .initial, markComplete: false)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, .initial, markComplete: false)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -195,7 +195,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingExperienceStateMarkComplete() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(Experience.mock, .initial, markComplete: true)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, .initial, markComplete: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -222,7 +222,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingExperienceLastStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(Experience.mock, Experience.StepIndex(group: 1, item: 0), markComplete: false)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, Experience.StepIndex(group: 1, item: 0), markComplete: false)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -252,7 +252,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         UUID.generator = { UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181")! }
 
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.experience(Experience.mock, "error")))
+        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.experience(ExperienceData.mock, "error")))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -286,7 +286,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         UUID.generator = { UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181")! }
 
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.step(Experience.mock, .initial, "error")))
+        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.step(ExperienceData.mock, .initial, "error")))
 
         // Assert
         XCTAssertFalse(isCompleted)

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -34,7 +34,7 @@ class ExperienceStateMachineTests: XCTestCase {
     func test_stateIsIdling_whenStartExperience_transitionsToRenderingStep() throws {
         // Arrange
         let presentExpectation = expectation(description: "Experience presented")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, stepIndex in
             XCTAssertEqual(stepIndex, Experience.StepIndex(group: 0, item: 0))
@@ -63,7 +63,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Arrange
         let presentExpectation = expectation(description: "Experience presented")
         presentExpectation.isInverted = true
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
 
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 0), package, isFirst: false)
@@ -92,7 +92,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
         // Arrange
         let presentExpectation = expectation(description: "Experience presented")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, stepIndex in
             XCTAssertEqual(stepIndex, Experience.StepIndex(group: 1, item: 0))
@@ -119,7 +119,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
         // Arrange
         let dismissExpectation = expectation(description: "Experience dismissed")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(dismissExpectation: dismissExpectation)
 
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 1, item: 0), package, isFirst: false)
@@ -139,7 +139,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
         // Arrange
         let dismissExpectation = expectation(description: "Experience dismissed")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(dismissExpectation: dismissExpectation)
 
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 1), package, isFirst: false)
@@ -159,7 +159,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
         // Arrange
         let dismissExpectation = expectation(description: "Experience dismissed")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(dismissExpectation: dismissExpectation)
 
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 1), package, isFirst: false)
@@ -182,7 +182,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
         let dismissExpectation = expectation(description: "Experience dismissed")
         let nextContentLoadedExpectation = expectation(description: "Next content ID requested")
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(dismissExpectation: dismissExpectation)
 
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 1), package, isFirst: false)
@@ -190,7 +190,7 @@ class ExperienceStateMachineTests: XCTestCase {
         let stateMachine = givenState(is: initialState)
 
         appcues.experienceLoader.onLoad = { contentID, published, completion in
-            XCTAssertEqual(contentID, Experience.mock.nextContentID)
+            XCTAssertEqual(contentID, ExperienceData.mock.nextContentID)
             XCTAssertTrue(published)
             nextContentLoadedExpectation.fulfill()
             completion?(.success(()))
@@ -211,7 +211,7 @@ class ExperienceStateMachineTests: XCTestCase {
         let dismissExpectation = expectation(description: "Experience dismissed")
         let nextContentLoadedExpectation = expectation(description: "Next content ID requested")
         nextContentLoadedExpectation.isInverted = true
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(dismissExpectation: dismissExpectation)
 
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 1), package, isFirst: false)
@@ -236,7 +236,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Arrange
         let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
         let initialState: State = .idling
-        let action: Action = .startExperience(experience)
+        let action: Action = .startExperience(ExperienceData(experience: experience))
         let stateMachine = givenState(is: initialState)
 
         // Act
@@ -248,7 +248,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsIdling_whenStartExperienceDelegateBlocks_noTransition() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         appcues.traitComposer.onPackage = { _, _ in experience.package() }
 
         let initialState: State = .idling
@@ -267,7 +267,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsIdling_whenStartExperiencePackageFails_transitionsToIdling() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         appcues.traitComposer.onPackage = { _, stepIndex in
             throw TraitError(description: "Presenting capability trait required")
         }
@@ -288,7 +288,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsRenderingStep_whenStartStepPackageFails_transitionsToIdling() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         appcues.traitComposer.onPackage = { _, stepIndex in
             throw TraitError(description: "Presenting capability trait required")
         }
@@ -312,9 +312,9 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsRenderingStep_whenStartExperience_noTransition() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 1), experience.package(), isFirst: false)
-        let action: Action = .startExperience(Experience.mock)
+        let action: Action = .startExperience(ExperienceData.mock)
         let stateMachine = givenState(is: initialState)
 
         // Act
@@ -326,7 +326,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsRenderingStep_whenStartStepInvalid_noTransition() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 1), experience.package(), isFirst: false)
         let action: Action = .startStep(StepReference.index(1000))
         let stateMachine = givenState(is: initialState)
@@ -343,7 +343,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // (see test_stateIsRenderingStep_whenStartStepInvalid_noTransition above)
 
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let initialState: State = .endingStep(experience, Experience.StepIndex(group: 0, item: 1), experience.package())
         let action: Action = .startStep(StepReference.index(1000))
         let stateMachine = givenState(is: initialState)
@@ -356,7 +356,7 @@ class ExperienceStateMachineTests: XCTestCase {
     }
     func test_stateIsRenderingStep_whenReportNonFatalError_noTransition() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 0), experience.package(), isFirst: false)
         let action: Action = .reportError(ExperienceStateMachine.ExperienceError.noTransition(currentState: initialState), fatal: false)
         let stateMachine = givenState(is: initialState)
@@ -370,7 +370,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsRenderingStep_whenReportFatalError_transitionsToIdling() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 0), experience.package(), isFirst: false)
         let action: Action = .reportError(ExperienceStateMachine.ExperienceError.noTransition(currentState: initialState), fatal: true)
         let stateMachine = givenState(is: initialState)
@@ -384,7 +384,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func testFatalExperienceErrorNotifiesObserver() throws {
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 0), experience.package(), isFirst: false)
         let action: Action = .reportError(ExperienceStateMachine.ExperienceError.noTransition(currentState: initialState), fatal: true)
         let stateMachine = givenState(is: initialState)
@@ -413,7 +413,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Invalid action for given state
 
         // Arrange
-        let experience = Experience.mock
+        let experience = ExperienceData.mock
         let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 0), experience.package(), isFirst: false)
         let action: Action = .reset
         let stateMachine = givenState(is: initialState)

--- a/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
@@ -14,62 +14,62 @@ class StepRefTests: XCTestCase {
 
     func testResolveIndex() throws {
         XCTAssertEqual(
-            StepReference.index(0).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 0)),
+            StepReference.index(0).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 0)),
             SI(group: 0, item: 0)
         )
         XCTAssertEqual(
-            StepReference.index(0).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)),
+            StepReference.index(0).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)),
             SI(group: 0, item: 0)
         )
         XCTAssertEqual(
-            StepReference.index(0).resolve(experience: Experience.mock, currentIndex: SI(group: 1, item: 1)),
+            StepReference.index(0).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 1, item: 1)),
             SI(group: 0, item: 0)
         )
         XCTAssertEqual(
-            StepReference.index(3).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)),
+            StepReference.index(3).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)),
             SI(group: 1, item: 0)
         )
-        XCTAssertNil(StepReference.index(134).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)))
+        XCTAssertNil(StepReference.index(134).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)))
     }
 
     func testResolveOffset() throws {
         XCTAssertEqual(
-            StepReference.offset(1).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)),
+            StepReference.offset(1).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)),
             SI(group: 0, item: 2)
         )
         XCTAssertEqual(
-            StepReference.offset(-1).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)),
+            StepReference.offset(-1).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)),
             SI(group: 0, item: 0)
         )
         XCTAssertEqual(
-            StepReference.offset(2).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)),
+            StepReference.offset(2).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)),
             SI(group: 1, item: 0)
         )
         XCTAssertEqual(
-            StepReference.offset(0).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)),
+            StepReference.offset(0).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)),
             SI(group: 0, item: 1)
         )
-        XCTAssertNil(StepReference.offset(-10).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 1)))
+        XCTAssertNil(StepReference.offset(-10).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 1)))
     }
 
     func testResolveID() throws {
         XCTAssertEqual(
-            StepReference.stepID(UUID(uuidString: "fb529214-3c78-4d6d-ba93-b55d22497ca1")!).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 0)),
+            StepReference.stepID(UUID(uuidString: "fb529214-3c78-4d6d-ba93-b55d22497ca1")!).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 0)),
             SI(group: 0, item: 0)
         )
         XCTAssertEqual(
-            StepReference.stepID(UUID(uuidString: "fb529214-3c78-4d6d-ba93-b55d22497ca1")!).resolve(experience: Experience.mock, currentIndex: SI(group: 1, item: 0)),
+            StepReference.stepID(UUID(uuidString: "fb529214-3c78-4d6d-ba93-b55d22497ca1")!).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 1, item: 0)),
             SI(group: 0, item: 0)
         )
         XCTAssertEqual(
-            StepReference.stepID(UUID(uuidString: "149f335f-15f6-4d8a-9e38-29a4ca435fd2")!).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 0)),
+            StepReference.stepID(UUID(uuidString: "149f335f-15f6-4d8a-9e38-29a4ca435fd2")!).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 0)),
             SI(group: 0, item: 1)
         )
         XCTAssertEqual(
-            StepReference.stepID(UUID(uuidString: "03652bd5-f0cb-44f0-9274-e95b4441d857")!).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 0)),
+            StepReference.stepID(UUID(uuidString: "03652bd5-f0cb-44f0-9274-e95b4441d857")!).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 0)),
             SI(group: 1, item: 0)
         )
-        XCTAssertNil(StepReference.stepID(UUID(uuidString: "49e21be9-cd9c-4ec6-85de-e4f24a676e31")!).resolve(experience: Experience.mock, currentIndex: SI(group: 0, item: 0)))
+        XCTAssertNil(StepReference.stepID(UUID(uuidString: "49e21be9-cd9c-4ec6-85de-e4f24a676e31")!).resolve(experience: ExperienceData.mock, currentIndex: SI(group: 0, item: 0)))
     }
 
     func testEquatable() throws {

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -178,8 +178,8 @@ class MockDeepLinkHandler: DeepLinkHandling {
 
 class MockTraitComposer: TraitComposing {
 
-    var onPackage: ((Experience, Experience.StepIndex) throws -> ExperiencePackage)?
-    func package(experience: Experience, stepIndex: Experience.StepIndex) throws -> ExperiencePackage {
+    var onPackage: ((ExperienceData, Experience.StepIndex) throws -> ExperiencePackage)?
+    func package(experience: ExperienceData, stepIndex: Experience.StepIndex) throws -> ExperiencePackage {
         if let onPackage = onPackage {
             return try onPackage(experience, stepIndex)
         } else {

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -90,6 +90,35 @@ extension Experience {
             redirectURL: nil,
             nextContentID: nil)
     }
+}
+
+extension Experience.Step {
+    init(fixedID: String, children: [Child]) {
+        self = .group(Group(
+            id: UUID(uuidString: fixedID) ?? UUID(),
+            type: "group",
+            children: children,
+            traits: [],
+            actions: [:]
+        ))
+    }
+}
+
+extension Experience.Step.Child {
+    init(fixedID: String) {
+        self.init(
+            id: UUID(uuidString: fixedID) ?? UUID(),
+            type: "modal",
+            content: ExperienceComponent.spacer(ExperienceComponent.SpacerModel(id: UUID(), spacing: nil, style: nil)),
+            traits: [],
+            actions: [:]
+        )
+    }
+}
+
+extension ExperienceData {
+    static var mock: ExperienceData { ExperienceData(experience: .mock) }
+    static var singleStepMock: ExperienceData { ExperienceData(experience: .singleStepMock) }
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
@@ -115,29 +144,5 @@ extension Experience {
                 dismissExpectation?.fulfill()
                 $0?()
             })
-    }
-}
-
-extension Experience.Step {
-    init(fixedID: String, children: [Child]) {
-        self = .group(Group(
-            id: UUID(uuidString: fixedID) ?? UUID(),
-            type: "group",
-            children: children,
-            traits: [],
-            actions: [:]
-        ))
-    }
-}
-
-extension Experience.Step.Child {
-    init(fixedID: String) {
-        self.init(
-            id: UUID(uuidString: fixedID) ?? UUID(),
-            type: "modal",
-            content: ExperienceComponent.spacer(ExperienceComponent.SpacerModel(id: UUID(), spacing: nil, style: nil)),
-            traits: [],
-            actions: [:]
-        )
     }
 }

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -59,7 +59,7 @@ class TraitComposerTests: XCTestCase {
         nextContentID: nil)
 
         // Act
-        _ = try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -90,7 +90,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: backdropDecoratingExpectation)
 
         // Act
-        _ = try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -112,7 +112,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: expectation(description: "Backdrop decorate called"))
 
         // Act
-        _ = try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 1, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 1, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -128,7 +128,7 @@ class TraitComposerTests: XCTestCase {
         let experience = makeTestExperience()
 
         // Act/Assert
-        XCTAssertThrowsError(try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 0, item: 0)))
+        XCTAssertThrowsError(try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0)))
     }
 
     func testPackagePresenter() throws {
@@ -161,7 +161,7 @@ class TraitComposerTests: XCTestCase {
 
 
         // Act
-        let package = try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 0, item: 0))
+        let package = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         try package.presenter(nil)
         package.dismisser(nil)
@@ -195,12 +195,13 @@ class TraitComposerTests: XCTestCase {
             ],
             redirectURL: nil,
             nextContentID: nil)
+        let experienceData = ExperienceData(experience: experience)
 
         // Act
-        XCTAssertThrowsError(try traitComposer.package(experience: experience, stepIndex: Experience.StepIndex(group: 0, item: 0))) { error in
+        XCTAssertThrowsError(try traitComposer.package(experience: experienceData, stepIndex: Experience.StepIndex(group: 0, item: 0))) { error in
             XCTAssertEqual(
                 error as? ExperienceStateMachine.ExperienceError,
-                ExperienceStateMachine.ExperienceError.step(experience, .initial, "step group D9FBD360-2832-4C8E-A79E-C1731982F1F1 doesn't contain a child step at index 0")
+                ExperienceStateMachine.ExperienceError.step(experienceData, .initial, "step group D9FBD360-2832-4C8E-A79E-C1731982F1F1 doesn't contain a child step at index 0")
             )
         }
     }


### PR DESCRIPTION
The impetus for this change is to make form state persist across step container presentations.

Storing the form state in the ExperienceStepViewModel obviously doesn't work anymore since that gets created/destroyed with the step group. We need something associated with the Experience itself. The solution is `ExperienceData`, a wrapper class around the `Experience` object that also includes the form state and gets used in the `ExperienceStateMachine`.

## Miscellaneous thoughts
1. By using `@dynamicMemberLookup` I was able to limit the refactoring to mostly updating `Experience->ExperienceData` rather than also having to change `experience.id->experience.model.id`.
2. Because `ExperienceData` contains an `ObservableObject`, it has to be iOS 13+, which impacts a couple other spots, but that doesn't matter much.
3. I originally hoped the `ExperienceStepViewModel` would contain the reference to the `StepState` for each step, but that didn't work because an `ObservableObject` in an `ObservableObject` doesn't propagate changes the way you might hope. Instead it's passed in as a sibling `.environmentObject`.

## Next steps

Now we have the form data in the state machine, so I think we just need to update the `AnalyticsObserver` to send the new events at the right time. Should be pretty easy. `LifecycleEvent` has access to the `FormData` to be able to construct the properties.