### PR TITLE
Fix step_completed event being improperly triggered

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -136,11 +136,11 @@ extension ExperienceStateMachine: ExperienceContainerLifecycleHandler {
         case let .renderingStep(experience, stepIndex, package, _):
             let targetStepId = package.steps[newPageIndex].id
             if let newStepIndex = experience.stepIndex(for: targetStepId) {
-                state = .endingStep(experience, stepIndex, package)
+                state = .endingStep(experience, stepIndex, package, markComplete: true)
                 state = .beginningStep(experience, stepIndex, package, isFirst: false)
                 state = .renderingStep(experience, newStepIndex, package, isFirst: false)
             }
-        case let .endingStep(experience, _, package):
+        case let .endingStep(experience, _, package, _):
             let targetStepId = package.steps[newPageIndex].id
             if let newStepIndex = experience.stepIndex(for: targetStepId) {
                 state = .beginningStep(experience, newStepIndex, package, isFirst: false)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -16,6 +16,15 @@ internal protocol ExperienceStateObserver: AnyObject {
 
 @available(iOS 13.0, *)
 extension ExperienceStateMachine.State {
+    var isStepCompleted: Bool {
+        switch self {
+        case let .endingStep(experience, stepIndex, _, markComplete):
+            return markComplete || stepIndex == experience.stepIndices.last
+        default:
+            return false
+        }
+    }
+
     var isExperienceCompleted: Bool {
         switch self {
         case let .endingExperience(experience, stepIndex, markComplete):
@@ -28,6 +37,15 @@ extension ExperienceStateMachine.State {
 
 @available(iOS 13.0, *)
 extension Result where Success == ExperienceStateMachine.State, Failure == ExperienceStateMachine.ExperienceError {
+    var isStepCompleted: Bool {
+        switch self {
+        case let .success(state):
+            return state.isStepCompleted
+        default:
+            return false
+        }
+    }
+
     var isExperienceCompleted: Bool {
         switch self {
         case let .success(state):
@@ -47,7 +65,7 @@ extension Result where Success == ExperienceStateMachine.State, Failure == Exper
         case let .success(.beginningExperience(experience)),
             let .success(.beginningStep(experience, _, _, _)),
             let .success(.renderingStep(experience, _, _, _)),
-            let .success(.endingStep(experience, _, _)),
+            let .success(.endingStep(experience, _, _, _)),
             let .success(.endingExperience(experience, _, _)),
             let .failure(.experienceAlreadyActive(ignoredExperience: experience)),
             let .failure(.step(experience, _, _)),
@@ -100,9 +118,11 @@ extension ExperienceStateMachine {
                 trackLifecycleEvent(.stepSeen, LifecycleEvent.properties(experience, stepIndex))
             case let .success(.renderingStep(experience, stepIndex, _, isFirst: false)):
                 trackLifecycleEvent(.stepSeen, LifecycleEvent.properties(experience, stepIndex))
-            case let .success(.endingStep(experience, stepIndex, _)):
-                trackFormCompletion(experience, stepIndex)
-                trackLifecycleEvent(.stepCompleted, LifecycleEvent.properties(experience, stepIndex))
+            case let .success(.endingStep(experience, stepIndex, _, _)):
+                if result.isStepCompleted {
+                    trackFormCompletion(experience, stepIndex)
+                    trackLifecycleEvent(.stepCompleted, LifecycleEvent.properties(experience, stepIndex))
+                }
             case let .success(.endingExperience(experience, stepIndex, _)):
                 if result.isExperienceCompleted {
                     trackLifecycleEvent(.experienceCompleted, LifecycleEvent.properties(experience))

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -128,7 +128,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mock, .initial, ExperienceData.mock.package())))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), markComplete: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -159,9 +159,18 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         )
     }
 
+    func testEvaluateEndingStepStateWhenIncomplete() throws {
+        // Act
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), markComplete: false)))
+
+        // Assert
+        XCTAssertFalse(isCompleted)
+        XCTAssertEqual(updates.count, 0)
+    }
+
     func testEvaluateEndingStepStateWithForm() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mockWithForm, .initial, ExperienceData.mock.package())))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mockWithForm, .initial, ExperienceData.mock.package(), markComplete: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -344,7 +344,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
         // Arrange
         let experience = ExperienceData.mock
-        let initialState: State = .endingStep(experience, Experience.StepIndex(group: 0, item: 1), experience.package())
+        let initialState: State = .endingStep(experience, Experience.StepIndex(group: 0, item: 1), experience.package(), markComplete: true)
         let action: Action = .startStep(StepReference.index(1000))
         let stateMachine = givenState(is: initialState)
 


### PR DESCRIPTION
Then:

https://user-images.githubusercontent.com/845681/191343048-eb96a3c1-62c9-47ca-b1b6-f05939dabb9f.mp4

Now:

https://user-images.githubusercontent.com/845681/191343129-29375418-80b7-4374-af96-c15ea5a31634.mp4

I added a test case for not sending the analytics event, but that doesn't reach all the way into the logic for how `markComplete` is set. Open to ideas there since the state machine tests don't make capturing the intermediate transitions easy.
