### PR TITLE
Fix serialization of NSNumber values that are not actually booleans

### DIFF
--- a/Tests/AppcuesKitTests/Networking/DynamicCodingKeysTests.swift
+++ b/Tests/AppcuesKitTests/Networking/DynamicCodingKeysTests.swift
@@ -21,14 +21,14 @@ class DynamicCodingKeysTests: XCTestCase {
 
     func testEncodeDictAny() throws {
         // Arrange
-        let testData = TestData(dict: ["string": "value", "int": 42, "double": 3.14, "bool": true])
+        let testData = TestData(dict: ["string": "value", "int": 42, "double": 3.14, "number": NSNumber(1), "bool": true])
 
         // Act
         let data = try XCTUnwrap(encoder.encode(testData))
 
         // Assert
         let asString = try XCTUnwrap(String(data: data, encoding: .utf8))
-        XCTAssertEqual(asString, #"{"dict":{"bool":true,"double":3.14,"int":42,"string":"value"}}"#)
+        XCTAssertEqual(asString, #"{"dict":{"bool":true,"double":3.14,"int":42,"number":1,"string":"value"}}"#)
     }
 
     func testEncodeDictAnyInvalid() throws {


### PR DESCRIPTION
Issue noticed during testing of the Capacitor plugin, as the JS side was passing in a value of `1` that was being serialized as `true` in the resulting network call.  The reason was that it was actually NSNumber(1) and our code was checking if it could be casted to a Bool first, which it could.

This is an example of the same issue, in the native code.  I trigger an event with properties like 
```swift
        Appcues.shared.track(
            name: "event1",
            properties: [
                "myInt": NSNumber(1),
                "myBool": true
            ])
```

resulting JSON output before this change:
![Screen Shot 2022-09-23 at 1 26 50 PM](https://user-images.githubusercontent.com/19266448/192024295-84a29de1-95f9-4e6b-9316-5a156781c377.png)

resulting JSON output after this change:
![Screen Shot 2022-09-23 at 1 25 58 PM](https://user-images.githubusercontent.com/19266448/192024316-9408e56b-720b-4442-80a9-66a03f94dcee.png)

This also works as expected `"myBool": NSNumber(booleanLiteral: true)` -- output is boolean value in the JSON
