### PR TITLE
Add support for minimum and maximum option selects

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -200,8 +200,8 @@ extension ExperienceComponent {
         let selectMode: SelectMode
         let options: [FormOptionModel]
         let defaultValue: [String]?
-        // swiftlint:disable:next discouraged_optional_boolean
-        let required: Bool?
+        let minSelections: UInt?
+        let maxSelections: UInt?
         let controlPosition: ControlPosition?
         let displayFormat: DisplayFormat?
         let selectedColor: Style.DynamicColor?

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -73,26 +73,9 @@ extension ExperienceComponent {
                 components.merge($0.formComponents, uniquingKeysWith: { first, _ in first })
             }
         case .textInput(let model):
-            components[model.id] = .init(
-                type: "textInput",
-                label: model.label.text,
-                value: .single(model.defaultValue ?? ""),
-                required: model.required ?? false)
+            components[model.id] = .init(model: model)
         case .optionSelect(let model):
-            switch model.selectMode {
-            case .single:
-                components[model.id] = .init(
-                    type: "optionSelect",
-                    label: model.label.text,
-                    value: .single(model.defaultValue?.first ?? ""),
-                    required: model.required ?? false)
-            case .multi:
-                components[model.id] = .init(
-                    type: "optionSelect",
-                    label: model.label.text,
-                    value: .multi(Set(model.defaultValue ?? [])),
-                    required: model.required ?? false)
-            }
+            components[model.id] = .init(model: model)
         }
 
         return components

--- a/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
@@ -1,0 +1,189 @@
+//
+//  ExperienceDataTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2022-09-26.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class ExperienceDataTests: XCTestCase {
+
+    func testSingleSelectRequired() throws {
+        // Arrange
+        let model = ExperienceComponent.OptionSelectModel(
+            selectMode: .single,
+            optionCount: 5,
+            minSelections: 1,
+            maxSelections: nil)
+        var formItem = ExperienceData.FormItem(model: model)
+
+        // Act/Assert
+        XCTAssertFalse(formItem.isSatisfied)
+        formItem.setValue("2")
+        XCTAssertTrue(formItem.isSatisfied)
+        XCTAssertEqual(formItem.getValue(), "2")
+        formItem.setValue("4")
+        XCTAssertTrue(formItem.isSatisfied)
+        XCTAssertEqual(formItem.getValue(), "4")
+    }
+
+    func testMultiSelectOrder() throws {
+        // Arrange
+        let model = ExperienceComponent.OptionSelectModel(
+            selectMode: .multi,
+            optionCount: 5,
+            minSelections: nil,
+            maxSelections: nil)
+        var formItem = ExperienceData.FormItem(model: model)
+
+        // Act/Assert
+        XCTAssertTrue(formItem.isSatisfied)
+
+        formItem.setValue("0")
+        XCTAssertEqual(formItem.getValue(), "0")
+        formItem.setValue("1")
+        XCTAssertEqual(formItem.getValue(), "0,1")
+        formItem.setValue("0")
+        XCTAssertEqual(formItem.getValue(), "1")
+        formItem.setValue("0")
+        XCTAssertEqual(formItem.getValue(), "1,0")
+    }
+
+    func testMultiSelectMinSelections() throws {
+        // Arrange
+        let model = ExperienceComponent.OptionSelectModel(
+            selectMode: .multi,
+            optionCount: 5,
+            minSelections: 1,
+            maxSelections: nil)
+        var formItem = ExperienceData.FormItem(model: model)
+
+        // Act/Assert
+        XCTAssertFalse(formItem.isSatisfied)
+        formItem.setValue("0")
+        XCTAssertTrue(formItem.isSatisfied)
+        formItem.setValue("1")
+        XCTAssertTrue(formItem.isSatisfied)
+        formItem.setValue("1")
+        XCTAssertTrue(formItem.isSatisfied)
+        formItem.setValue("0")
+        XCTAssertFalse(formItem.isSatisfied)
+    }
+
+    func testMultiSelectMaxSelections() throws {
+        // Arrange
+        let model = ExperienceComponent.OptionSelectModel(
+            selectMode: .multi,
+            optionCount: 5,
+            minSelections: nil,
+            maxSelections: 2)
+        var formItem = ExperienceData.FormItem(model: model)
+
+        // Act/Assert
+        formItem.setValue("0")
+        XCTAssertEqual(formItem.getValue(), "0")
+        formItem.setValue("1")
+        XCTAssertEqual(formItem.getValue(), "0,1")
+        formItem.setValue("2")
+        XCTAssertEqual(formItem.getValue(), "0,1", "exceeding max not set")
+        formItem.setValue("1")
+        XCTAssertEqual(formItem.getValue(), "0")
+        formItem.setValue("2")
+        XCTAssertEqual(formItem.getValue(), "0,2")
+    }
+
+    // We do no handling of the scenario where defaultValue.count > maxSelections.
+    // The component will just initially be in an invalid state.
+    // The user will be able to unselect items to get below maxSelections and then unable to select more items as usual.
+    func testDefaultExceedsMax() throws {
+        // Arrange
+        let model = ExperienceComponent.OptionSelectModel(
+            selectMode: .multi,
+            optionCount: 5,
+            minSelections: nil,
+            maxSelections: 2,
+            defaultValue: ["0", "1", "2"])
+        var formItem = ExperienceData.FormItem(model: model)
+
+        // Act/Assert
+        XCTAssertFalse(formItem.isSatisfied)
+        XCTAssertEqual(formItem.getValue(), "0,1,2")
+
+        formItem.setValue("3")
+        XCTAssertEqual(formItem.getValue(), "0,1,2", "exceeding max not set")
+
+        formItem.setValue("2")
+        formItem.setValue("1")
+        formItem.setValue("3")
+        XCTAssertEqual(formItem.getValue(), "0,3")
+    }
+
+    // If minSelections > options.count, minSelections will be set to options.count.
+    func testMinSelectionsOverride() throws {
+        // Arrange
+        let model = ExperienceComponent.OptionSelectModel(
+            selectMode: .multi,
+            optionCount: 2,
+            minSelections: 5,
+            maxSelections: nil)
+        var formItem = ExperienceData.FormItem(model: model)
+
+        // Act/Assert
+        formItem.setValue("0")
+        XCTAssertFalse(formItem.isSatisfied)
+        formItem.setValue("1")
+        XCTAssertTrue(formItem.isSatisfied)
+    }
+
+    // If maxSelections < minSelections, maxSelections will be set to minSelections
+    func testMaxSelectionsOverride() throws {
+        // Arrange
+        let model = ExperienceComponent.OptionSelectModel(
+            selectMode: .multi,
+            optionCount: 5,
+            minSelections: 3,
+            maxSelections: 2)
+        var formItem = ExperienceData.FormItem(model: model)
+
+        // Act/Assert
+        formItem.setValue("0")
+        formItem.setValue("1")
+        formItem.setValue("2")
+        XCTAssertEqual(formItem.getValue(), "0,1,2")
+
+        formItem.setValue("3")
+        XCTAssertEqual(formItem.getValue(), "0,1,2")
+    }
+}
+
+extension ExperienceComponent.OptionSelectModel {
+    init(selectMode: SelectMode, optionCount: Int, minSelections: UInt?, maxSelections: UInt?, defaultValue: [String]? = nil) {
+        let options = (0..<optionCount).map {
+            ExperienceComponent.FormOptionModel(
+                value: "\($0)",
+                content: .spacer(ExperienceComponent.SpacerModel(id: UUID(), spacing: nil, style: nil)),
+                selectedContent: nil)
+        }
+
+        self.init(
+            id: UUID(),
+            label: ExperienceComponent.TextModel(id: UUID(), text: "Label", style: nil),
+            selectMode: selectMode,
+            options: options,
+            defaultValue: defaultValue,
+            minSelections: minSelections,
+            maxSelections: maxSelections,
+            controlPosition: .leading,
+            displayFormat: .verticalList,
+            selectedColor: nil,
+            unselectedColor: nil,
+            accentColor: nil,
+            pickerStyle: nil,
+            style: nil
+        )
+    }
+}

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -169,6 +169,20 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
     }
 
     func testEvaluateEndingStepStateWithForm() throws {
+        // Arrange
+        let expectedFormItem = ExperienceData.FormItem(model: ExperienceComponent.TextInputModel(
+            id: UUID(),
+            label: ExperienceComponent.TextModel(id: UUID(), text: "Form label", style: nil),
+            placeholder: nil,
+            defaultValue: "default value",
+            required: true,
+            numberOfLines: nil,
+            maxLength: nil,
+            dataType: nil,
+            textFieldStyle: nil,
+            cursorColor: nil,
+            style: nil))
+
         // Act
         let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mockWithForm, .initial, ExperienceData.mock.package(), markComplete: true)))
 
@@ -195,11 +209,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "interactionType": "Form Submitted",
             "interactionData": [
                 "formResponse": ExperienceData.StepState(formItems: [
-                    UUID(uuidString: "f002dc4f-c5fc-4439-8916-0047a5839741")!: ExperienceData.FormItem(
-                        type: "textInput",
-                        label: "Form label",
-                        value: .single("default value"),
-                        required: true)
+                    UUID(uuidString: "f002dc4f-c5fc-4439-8916-0047a5839741")!: expectedFormItem
                 ])
             ]
         ].verifyPropertiesMatch(updates[1].properties)


### PR DESCRIPTION
The tests are lined up with the rules listed in the spec PR: https://github.com/appcues/appcues-mobile-experience-spec/pull/84

This PR also orders the multi select output by the order checked.