### PR TITLE
Move form submission analytics to @appcues/submit-form action

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -31,6 +31,7 @@ internal class ActionRegistry {
         register(action: AppcuesTrackAction.self)
         register(action: AppcuesUpdateProfileAction.self)
         register(action: AppcuesContinueAction.self)
+        register(action: AppcuesSubmitFormAction.self)
     }
 
     func register(action: ExperienceAction.Type) {

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -1,0 +1,70 @@
+//
+//  AppcuesSubmitFormAction.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-09-28.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+internal class AppcuesSubmitFormAction: ExperienceAction, ExperienceActionQueueTransforming {
+    static let type = "@appcues/submit-form"
+
+    let skipValidation: Bool
+
+    required init?(config: [String: Any]?) {
+        self.skipValidation = config?["skipValidation"] as? Bool ?? false
+    }
+
+    func execute(inContext appcues: Appcues, completion: ActionRegistry.Completion) {
+        defer {
+            completion()
+        }
+
+        let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
+        let analyticsPublisher = appcues.container.resolve(AnalyticsPublishing.self)
+
+        guard let experienceData = experienceRenderer.getCurrentExperienceData(),
+              let stepIndex = experienceRenderer.getCurrentStepIndex(),
+              let stepState = experienceData.state(for: stepIndex) else { return }
+
+        let interactionProperties = [
+            "interactionType": "Form Submitted",
+            // Passing the actual StepState model is safe because of specific handling in `encodeSkippingInvalid`.
+            "interactionData": [ "formResponse": stepState ]
+        ]
+            .merging(LifecycleEvent.properties(experienceData, stepIndex)) { first, _ in first }
+
+        analyticsPublisher.publish(TrackingUpdate(
+            type: .profile,
+            properties: stepState.formattedAsProfileUpdate(),
+            isInternal: true))
+
+        analyticsPublisher.publish(TrackingUpdate(
+            type: .event(name: LifecycleEvent.stepInteraction.rawValue, interactive: false),
+            properties: interactionProperties,
+            isInternal: true))
+    }
+
+    // If the form state is invalid, remove this action and all subsequent.
+    func transformQueue(_ queue: [ExperienceAction], index: Int, inContext appcues: Appcues) -> [ExperienceAction] {
+        guard !skipValidation else { return queue }
+
+        let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
+
+        guard let experienceData = experienceRenderer.getCurrentExperienceData(),
+              let stepIndex = experienceRenderer.getCurrentStepIndex(),
+              let stepState = experienceData.state(for: stepIndex) else { return queue }
+
+        if stepState.stepFormIsComplete {
+            return queue
+        } else {
+            var truncatedQueue = queue
+            // Remove this action and all subsequent
+            truncatedQueue.removeSubrange(index..<truncatedQueue.count)
+            return truncatedQueue
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Actions/ExperienceActionQueueTransforming.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ExperienceActionQueueTransforming.swift
@@ -1,0 +1,22 @@
+//
+//  ExperienceActionQueueTransforming.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-09-28.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+/// An `ExperienceAction` that performs modifications of the action queue executed following an interaction in an experience.
+@objc
+internal protocol ExperienceActionQueueTransforming: ExperienceAction {
+
+    /// Modify the queue of actions executed in an experience.
+    /// - Parameters:
+    ///   - queue: The current queue of actions.
+    ///   - index: The index of the current action in the `queue`.
+    ///   - appcues: The `Appcues` instance that displayed the experience triggering the action.
+    /// - Returns: The updated queue.
+    func transformQueue(_ queue: [ExperienceAction], index: Int, inContext appcues: Appcues) -> [ExperienceAction]
+}

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -14,6 +14,8 @@ internal protocol ExperienceRendering: AnyObject {
     func show(qualifiedExperiences: [Experience], priority: RenderPriority, completion: ((Result<Void, Error>) -> Void)?)
     func show(stepInCurrentExperience stepRef: StepReference, completion: (() -> Void)?)
     func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?)
+    func getCurrentExperienceData() -> ExperienceData?
+    func getCurrentStepIndex() -> Experience.StepIndex?
 }
 
 @available(iOS 13.0, *)
@@ -165,5 +167,13 @@ internal class ExperienceRenderer: ExperienceRendering {
                 return false
             }
         }
+    }
+
+    func getCurrentExperienceData() -> ExperienceData? {
+        stateMachine.state.currentExperienceData
+    }
+
+    func getCurrentStepIndex() -> Experience.StepIndex? {
+        stateMachine.state.currentStepIndex
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -18,6 +18,31 @@ extension ExperienceStateMachine {
         case endingStep(ExperienceData, Experience.StepIndex, ExperiencePackage, markComplete: Bool)
         case endingExperience(ExperienceData, Experience.StepIndex, markComplete: Bool)
 
+        var currentExperienceData: ExperienceData? {
+            switch self {
+            case .idling:
+                return nil
+            case .beginningExperience(let experienceData),
+                    .beginningStep(let experienceData, _, _, _),
+                    .renderingStep(let experienceData, _, _, _),
+                    .endingStep(let experienceData, _, _, _),
+                    .endingExperience(let experienceData, _, _):
+                return experienceData
+            }
+        }
+
+        var currentStepIndex: Experience.StepIndex? {
+            switch self {
+            case .idling, .beginningExperience:
+                return nil
+            case .beginningStep(_, let stepIndex, _, _),
+                    .renderingStep(_, let stepIndex, _, _),
+                    .endingStep(_, let stepIndex, _, _),
+                    .endingExperience(_, let stepIndex, _):
+                return stepIndex
+            }
+        }
+
         func transition(for action: Action, traitComposer: TraitComposing) -> Transition? {
             switch (self, action) {
             case let (.idling, .startExperience(experience)):

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -120,7 +120,6 @@ extension ExperienceStateMachine {
                 trackLifecycleEvent(.stepSeen, LifecycleEvent.properties(experience, stepIndex))
             case let .success(.endingStep(experience, stepIndex, _, _)):
                 if result.isStepCompleted {
-                    trackFormCompletion(experience, stepIndex)
                     trackLifecycleEvent(.stepCompleted, LifecycleEvent.properties(experience, stepIndex))
                 }
             case let .success(.endingExperience(experience, stepIndex, _)):
@@ -148,23 +147,6 @@ extension ExperienceStateMachine {
                 TrackingUpdate(type: .event(name: name.rawValue, interactive: false),
                                properties: properties,
                                isInternal: true))
-        }
-
-        func trackFormCompletion(_ experience: ExperienceData, _ stepIndex: Experience.StepIndex) {
-            guard let stepID = experience.step(at: stepIndex)?.id else { return }
-            let stepState = experience.state(for: stepID)
-
-            guard !stepState.formItems.isEmpty else { return }
-
-            analyticsPublisher.publish(TrackingUpdate(type: .profile, properties: stepState.formattedAsProfileUpdate(), isInternal: true))
-
-            let properties = [
-                "interactionType": "Form Submitted",
-                // Passing the actual StepState model is safe because of specific handling in `encodeSkippingInvalid`.
-                "interactionData": [ "formResponse": stepState ]
-            ].merging(LifecycleEvent.properties(experience, stepIndex), uniquingKeysWith: { first, _ in first })
-
-            trackLifecycleEvent(.stepInteraction, properties)
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -30,6 +30,11 @@ internal class ExperienceData {
         return stepState
     }
 
+    func state(for stepIndex: Experience.StepIndex) -> StepState? {
+        guard let stepID = model.steps[safe: stepIndex.group]?.items[safe: stepIndex.item]?.id else { return nil }
+        return state(for: stepID)
+    }
+
     subscript<T>(dynamicMember keyPath: KeyPath<Experience, T>) -> T {
         return model[keyPath: keyPath]
     }

--- a/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
@@ -63,4 +63,5 @@ class AppcuesCloseActionTests: XCTestCase {
         // Assert
         XCTAssertEqual(completionCount, 1)
         XCTAssertEqual(dismissCount, 1)
-    }}
+    }
+}

--- a/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
@@ -1,0 +1,140 @@
+//
+//  AppcuesSubmitFormActionTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2022-09-29.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class AppcuesSubmitFormActionTests: XCTestCase {
+
+    var appcues: MockAppcues!
+
+    override func setUpWithError() throws {
+        appcues = MockAppcues()
+    }
+
+    func testInit() throws {
+        // Act
+        let action = AppcuesSubmitFormAction(config: nil)
+
+        // Assert
+        XCTAssertEqual(AppcuesSubmitFormAction.type, "@appcues/submit-form")
+        XCTAssertNotNil(action)
+        XCTAssertEqual(action?.skipValidation, false)
+    }
+
+    func testExecuteValidForm() throws {
+        // Arrange
+        let expectedFormItem = ExperienceData.FormItem(model: ExperienceComponent.TextInputModel(
+            id: UUID(),
+            label: ExperienceComponent.TextModel(id: UUID(), text: "Form label", style: nil),
+            placeholder: nil,
+            defaultValue: "default value",
+            required: true,
+            numberOfLines: nil,
+            maxLength: nil,
+            dataType: nil,
+            textFieldStyle: nil,
+            cursorColor: nil,
+            style: nil))
+
+        var completionCount = 0
+        var updates: [TrackingUpdate] = []
+
+        appcues.experienceRenderer.onGetCurrentExperienceData = {
+            ExperienceData.mockWithForm(defaultValue: "default value")
+        }
+        appcues.experienceRenderer.onGetCurrentStepIndex = {
+            .initial
+        }
+        appcues.analyticsPublisher.onPublish = { trackingUpdate in
+            updates.append(trackingUpdate)
+        }
+
+        let action = AppcuesSubmitFormAction(config: nil)
+
+        // Act
+        action?.execute(inContext: appcues, completion: { completionCount += 1 })
+
+        // Assert
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(updates.count, 2)
+
+        XCTAssertEqual(updates[0].type, .profile)
+        XCTAssertEqual(updates[1].type, .event(name: "appcues:v2:step_interaction", interactive: false))
+
+        [
+            "_appcuesForm_form-label": "default value"
+        ].verifyPropertiesMatch(updates[0].properties)
+
+        [
+            "experienceName": "Mock Experience: Single step with form",
+            "experienceId": "ded7b50f-bc24-42de-a0fa-b1f10fc10d00",
+            "version": 1632142800000,
+            "experienceType": "mobile",
+            "stepType": "modal",
+            "stepId": "6cf396f6-1f01-4449-9e38-7e845f5316c0",
+            "stepIndex": "0,0",
+            "interactionType": "Form Submitted",
+            "interactionData": [
+                "formResponse": ExperienceData.StepState(formItems: [
+                    UUID(uuidString: "f002dc4f-c5fc-4439-8916-0047a5839741")!: expectedFormItem
+                ])
+            ]
+        ].verifyPropertiesMatch(updates[1].properties)
+    }
+
+    func testTransformQueueInvalidForm() throws {
+        // Arrange
+        appcues.experienceRenderer.onGetCurrentExperienceData = {
+            ExperienceData.mockWithForm(defaultValue: nil)
+        }
+        appcues.experienceRenderer.onGetCurrentStepIndex = {
+            .initial
+        }
+
+        let action0 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let action = try XCTUnwrap(AppcuesSubmitFormAction(config: nil))
+        let action1 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let action2 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let initialQueue: [ExperienceAction] = [action0, action, action1, action2]
+
+        // Act
+        let updatedQueue = action.transformQueue(initialQueue, index: 1, inContext: appcues)
+
+        // Assert
+        XCTAssertEqual(updatedQueue.count, 1)
+        XCTAssertTrue(updatedQueue[0] === action0, "only the action before submit-form remains")
+    }
+
+    func testTransformQueueInvalidFormSkipValidation() throws {
+        // Arrange
+        appcues.experienceRenderer.onGetCurrentExperienceData = {
+            ExperienceData.mockWithForm(defaultValue: nil)
+        }
+        appcues.experienceRenderer.onGetCurrentStepIndex = {
+            .initial
+        }
+
+        let action0 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let action = try XCTUnwrap(AppcuesSubmitFormAction(config: ["skipValidation": true]))
+        let action1 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let action2 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let initialQueue: [ExperienceAction] = [action0, action, action1, action2]
+
+        // Act
+        let updatedQueue = action.transformQueue(initialQueue, index: 1, inContext: appcues)
+
+        // Assert
+        XCTAssertEqual(updatedQueue.count, 4)
+        XCTAssertTrue(updatedQueue[0] === action0)
+        XCTAssertTrue(updatedQueue[1] === action)
+        XCTAssertTrue(updatedQueue[2] === action1)
+        XCTAssertTrue(updatedQueue[3] === action2)
+    }
+}

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -168,63 +168,6 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         XCTAssertEqual(updates.count, 0)
     }
 
-    func testEvaluateEndingStepStateWithForm() throws {
-        // Arrange
-        let expectedFormItem = ExperienceData.FormItem(model: ExperienceComponent.TextInputModel(
-            id: UUID(),
-            label: ExperienceComponent.TextModel(id: UUID(), text: "Form label", style: nil),
-            placeholder: nil,
-            defaultValue: "default value",
-            required: true,
-            numberOfLines: nil,
-            maxLength: nil,
-            dataType: nil,
-            textFieldStyle: nil,
-            cursorColor: nil,
-            style: nil))
-
-        // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mockWithForm, .initial, ExperienceData.mock.package(), markComplete: true)))
-
-        // Assert
-        XCTAssertFalse(isCompleted)
-        XCTAssertEqual(updates.count, 3)
-
-        XCTAssertEqual(updates[0].type, .profile)
-        XCTAssertEqual(updates[1].type, .event(name: "appcues:v2:step_interaction", interactive: false))
-        XCTAssertEqual(updates[2].type, .event(name: "appcues:v2:step_completed", interactive: false))
-
-        [
-            "_appcuesForm_form-label": "default value"
-        ].verifyPropertiesMatch(updates[0].properties)
-
-        [
-            "experienceName": "Mock Experience: Single step with form",
-            "experienceId": "ded7b50f-bc24-42de-a0fa-b1f10fc10d00",
-            "version": 1632142800000,
-            "experienceType": "mobile",
-            "stepType": "modal",
-            "stepId": "6cf396f6-1f01-4449-9e38-7e845f5316c0",
-            "stepIndex": "0,0",
-            "interactionType": "Form Submitted",
-            "interactionData": [
-                "formResponse": ExperienceData.StepState(formItems: [
-                    UUID(uuidString: "f002dc4f-c5fc-4439-8916-0047a5839741")!: expectedFormItem
-                ])
-            ]
-        ].verifyPropertiesMatch(updates[1].properties)
-
-        [
-            "experienceName": "Mock Experience: Single step with form",
-            "experienceId": "ded7b50f-bc24-42de-a0fa-b1f10fc10d00",
-            "version": 1632142800000,
-            "experienceType": "mobile",
-            "stepType": "modal",
-            "stepId": "6cf396f6-1f01-4449-9e38-7e845f5316c0",
-            "stepIndex": "0,0"
-        ].verifyPropertiesMatch(updates[2].properties)
-    }
-
     func testEvaluateEndingExperienceState() throws {
         // Act
         let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, .initial, markComplete: false)))

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -131,6 +131,16 @@ class MockExperienceRenderer: ExperienceRendering {
     func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?) {
         onDismissCurrentExperience?(markComplete, completion)
     }
+
+    var onGetCurrentExperienceData: (() -> ExperienceData)?
+    func getCurrentExperienceData() -> ExperienceData? {
+        onGetCurrentExperienceData?()
+    }
+
+    var onGetCurrentStepIndex: (() -> Experience.StepIndex)?
+    func getCurrentStepIndex() -> AppcuesKit.Experience.StepIndex? {
+        onGetCurrentStepIndex?()
+    }
 }
 
 class MockSessionMonitor: SessionMonitoring {

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -91,7 +91,7 @@ extension Experience {
             nextContentID: nil)
     }
 
-    static var mockWithForm: Experience {
+    static func mockWithForm(defaultValue: String?) -> Experience {
         Experience(
             id: UUID(uuidString: "ded7b50f-bc24-42de-a0fa-b1f10fc10d00")!,
             name: "Mock Experience: Single step with form",
@@ -102,7 +102,7 @@ extension Experience {
                 Experience.Step(
                     fixedID: "02b83a13-537c-4cfc-89be-815e303d1c00",
                     children: [
-                        Step.Child(formWithFixedID: "6cf396f6-1f01-4449-9e38-7e845f5316c0")
+                        Step.Child(formWithFixedID: "6cf396f6-1f01-4449-9e38-7e845f5316c0", defaultValue: defaultValue)
                     ]
                 )
             ],
@@ -135,7 +135,7 @@ extension Experience.Step.Child {
         )
     }
 
-    init(formWithFixedID fixedID: String) {
+    init(formWithFixedID fixedID: String, defaultValue: String?) {
         self.init(
             id: UUID(uuidString: fixedID) ?? UUID(),
             type: "modal",
@@ -143,7 +143,7 @@ extension Experience.Step.Child {
                 id: UUID(uuidString: "f002dc4f-c5fc-4439-8916-0047a5839741")!,
                 label: ExperienceComponent.TextModel(id: UUID(), text: "Form label", style: nil),
                 placeholder: nil,
-                defaultValue: "default value",
+                defaultValue: defaultValue,
                 required: true,
                 numberOfLines: nil,
                 maxLength: nil,
@@ -161,7 +161,7 @@ extension Experience.Step.Child {
 extension ExperienceData {
     static var mock: ExperienceData { ExperienceData(experience: .mock) }
     static var singleStepMock: ExperienceData { ExperienceData(experience: .singleStepMock) }
-    static var mockWithForm: ExperienceData { ExperienceData(experience: .mockWithForm) }
+    static func mockWithForm(defaultValue: String?) -> ExperienceData { ExperienceData(experience: .mockWithForm(defaultValue: defaultValue)) }
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {


### PR DESCRIPTION
This PR introduces `ExperienceActionQueueTransforming` which modifies the array of actions triggered by a particular interaction. Any `ExperienceAction` can conform to the protocol and then be given a chance to modify the array of actions from the Experience data model before it gets enqueued to execute. This protocol is currently internal, but could easily be made public if we wanted to allow custom `ExperienceAction` implementations to have this capability (it's super powerful, and therefore super easy to mess things up).

## How Queue Transforming works

For each action in the original queue, we check if its still in the queue (it could have been removed by a previous action) and we check if it's `ExperienceActionQueueTransforming` and then apply the transformation.

A couple edge cases to note: if the order is changed, the transforms will still be applied in the order from the original queue. And newly added actions will not have their transforms applied. If we want to change this behaviour it would get much more complicated than the current `reduce` implementation, so I figured it's not worth it since there's no known use case.

## How the `@appcues/submit-form` action works

`AppcuesSubmitFormAction` implements `ExperienceActionQueueTransforming` and uses the `ExperienceRenderer` to grab the current step state and check if the form is valid. If it is valid, the queue is returned unmodified. Otherwise, the `submit-form` action and all subsequent actions are removed from the queue.

Then when it comes time to execute the action, we publish the profile update event and the `step_interaction` event like we did previously from the `AnalyticsObserver`.

Note that if the `@appcues/submit-form` action is included on the step and there's no survey components in the step layout, an empty `step_interaction` event will still fire (basically the non-existent form has no invalid components so it allows it). This is different from the prior `AnalyticsObserver` implementation, which checked `stepState.formItems.isEmpty`, but since including the `@appcues/submit-form` action is an explicit thing, submitting an empty interaction feels like the right move.

## What's next

Need to tackle the UI work to show the invalid states to wrap up sc-41062. To accomplish this, `StepState` will be updated to have a flag that the `@appcues/submit-form` action can set from the `transformQueue` function which will let the views check how they should display.

These changes also lay the groundwork for a future conditional routing actions that depend on the form state. Also now that we've exposed a way to get the current Experience via the ExperienceRenderer, it seems like it'd be possible to create actions that do things like a collapsible accordion within a step 🤔