### PR TITLE
Add UI for form component error states

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -160,6 +160,7 @@ extension ExperienceComponent {
         let id: UUID
 
         let label: TextModel
+        let errorLabel: TextModel?
         let placeholder: TextModel?
         let defaultValue: String?
         // swiftlint:disable:next discouraged_optional_boolean
@@ -197,6 +198,7 @@ extension ExperienceComponent {
         let id: UUID
 
         let label: TextModel
+        let errorLabel: TextModel?
         let selectMode: SelectMode
         let options: [FormOptionModel]
         let defaultValue: [String]?

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -61,6 +61,9 @@ internal class AppcuesSubmitFormAction: ExperienceAction, ExperienceActionQueueT
         if stepState.stepFormIsComplete {
             return queue
         } else {
+            // Update the UI to show error states
+            stepState.shouldShowErrors = true
+
             var truncatedQueue = queue
             // Remove this action and all subsequent
             truncatedQueue.removeSubrange(index..<truncatedQueue.count)

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -17,9 +17,10 @@ internal struct AppcuesOptionSelect: View {
 
     var body: some View {
         let style = AppcuesStyle(from: model.style)
+        let errorTintColor = stepState.shouldShowError(for: model.id) ? Color(dynamicColor: model.errorLabel?.style?.foregroundColor) : nil
 
         VStack(alignment: style.horizontalAlignment, spacing: 0) {
-            ExperienceComponent.text(model.label).view
+            TintedTextView(model: model.label, tintColor: errorTintColor)
 
             switch (model.selectMode, model.displayFormat) {
             case (.single, .picker):
@@ -40,16 +41,23 @@ internal struct AppcuesOptionSelect: View {
                     items
                 }
             }
+
+            if stepState.shouldShowError(for: model.id), let errorLabel = model.errorLabel {
+                AppcuesText(model: errorLabel)
+            }
         }
         .setupActions(on: viewModel, for: model.id)
         .applyAllAppcues(style)
     }
 
     @ViewBuilder var items: some View {
+        let primaryColor = stepState.shouldShowError(for: model.id) ? Color(dynamicColor: model.errorLabel?.style?.foregroundColor) : nil
+
         ForEach(model.options) { option in
             let binding = stepState.formBinding(for: model.id, value: option.value)
             SelectToggleView(
                 selected: binding,
+                primaryColor: primaryColor,
                 model: model
             ) {
                 if binding.wrappedValue {

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
@@ -24,9 +24,10 @@ internal struct AppcuesTextInput: View {
     var body: some View {
         let style = AppcuesStyle(from: model.style)
         let textFieldStyle = AppcuesStyle(from: model.textFieldStyle)
+        let errorTintColor = stepState.shouldShowError(for: model.id) ? Color(dynamicColor: model.errorLabel?.style?.foregroundColor) : nil
 
         VStack(alignment: style.horizontalAlignment, spacing: 0) {
-            ExperienceComponent.text(model.label).view
+            TintedTextView(model: model.label, tintColor: errorTintColor)
 
             let binding = stepState.formBinding(for: model.id)
 
@@ -34,6 +35,11 @@ internal struct AppcuesTextInput: View {
                 .frame(height: height)
                 .overlay(placeholder(binding), alignment: .topLeading)
                 .applyAllAppcues(textFieldStyle)
+                .overlay(errorBorder(errorTintColor, textFieldStyle))
+
+            if stepState.shouldShowError(for: model.id), let errorLabel = model.errorLabel {
+                AppcuesText(model: errorLabel)
+            }
         }
         .setupActions(on: viewModel, for: model.id)
         .applyAllAppcues(style)
@@ -41,9 +47,18 @@ internal struct AppcuesTextInput: View {
 
     @ViewBuilder func placeholder(_ binding: Binding<String>) -> some View {
         if let placeholder = model.placeholder, binding.wrappedValue.isEmpty {
-            ExperienceComponent.text(placeholder).view
+            AppcuesText(model: placeholder)
                 .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
                 .allowsHitTesting(false)
         }
     }
+
+    // Can't use an `.ifLet()` on the MultilineTextView since it changes the view identity and causes focus issues.
+    @ViewBuilder func errorBorder(_ color: Color?, _ style: AppcuesStyle) -> some View {
+        if let color = color {
+            RoundedRectangle(cornerRadius: style.cornerRadius ?? 0)
+                .stroke(color, lineWidth: max(style.borderWidth ?? 0, 1))
+        }
+    }
+
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/SelectToggleView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/SelectToggleView.swift
@@ -16,11 +16,12 @@ internal struct SelectToggleView<Content: View>: View {
     }
 
     @Binding var selected: Bool
+    let primaryColor: Color?
     let model: ExperienceComponent.OptionSelectModel
     @ViewBuilder var content: Content
 
     @ViewBuilder var control: some View {
-        Appearance(model.selectMode).symbol(selected: selected, model: model)
+        Appearance(model.selectMode).symbol(selected: selected, primaryColor: primaryColor, model: model)
             .imageScale(.large)
             // Ensure the minimum size leaves enough space to be an adequate touch target.
             .frame(minWidth: 48, minHeight: 48)
@@ -71,8 +72,16 @@ extension SelectToggleView.Appearance {
     }
 
     @ViewBuilder
-    func symbol(selected: Bool, model: ExperienceComponent.OptionSelectModel) -> some View {
-        let primaryColor = selected ? Color(dynamicColor: model.selectedColor) :  Color(dynamicColor: model.unselectedColor)
+    func symbol(selected: Bool, primaryColor: Color?, model: ExperienceComponent.OptionSelectModel) -> some View {
+        let primaryColor: Color? = {
+            if let primaryColor = primaryColor {
+                return primaryColor
+            } else if selected {
+                return Color(dynamicColor: model.selectedColor)
+            } else {
+                return Color(dynamicColor: model.unselectedColor)
+            }
+        }()
 
         switch (self, selected) {
         case (.checkbox, true):

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -1,0 +1,29 @@
+//
+//  TintedTextView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-10-03.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal struct TintedTextView: View {
+    let model: ExperienceComponent.TextModel
+    let tintColor: Color?
+
+    @EnvironmentObject var viewModel: ExperienceStepViewModel
+
+    var body: some View {
+        let style = AppcuesStyle(from: model.style)
+
+        Text(model.text)
+            .applyTextStyle(style)
+            .setupActions(on: viewModel, for: model.id)
+            .ifLet(tintColor) { view, val in
+                view.foregroundColor(val)
+            }
+            .applyAllAppcues(style)
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -81,6 +81,7 @@ extension ExperienceData {
 
     class StepState: ObservableObject {
         @Published var formItems: [UUID: FormItem]
+        @Published var shouldShowErrors = false
 
         var stepFormIsComplete: Bool {
             !formItems.contains { !$0.value.isSatisfied }
@@ -104,6 +105,10 @@ extension ExperienceData {
                 set: { _ in
                     self.formItems[key]?.setValue(value)
                 })
+        }
+
+        func shouldShowError(for key: UUID) -> Bool {
+            shouldShowErrors && !(formItems[key]?.isSatisfied ?? false)
         }
     }
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -131,7 +131,7 @@ extension ExperienceData {
                 case .single(let value):
                     return value
                 case .multi(let values, _):
-                    return values.joined(separator: ",")
+                    return values.joined(separator: "\n")
                 }
             }
         }

--- a/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
@@ -33,6 +33,7 @@ class AppcuesSubmitFormActionTests: XCTestCase {
         let expectedFormItem = ExperienceData.FormItem(model: ExperienceComponent.TextInputModel(
             id: UUID(),
             label: ExperienceComponent.TextModel(id: UUID(), text: "Form label", style: nil),
+            errorLabel: nil,
             placeholder: nil,
             defaultValue: "default value",
             required: true,

--- a/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
@@ -46,11 +46,11 @@ class ExperienceDataTests: XCTestCase {
         formItem.setValue("0")
         XCTAssertEqual(formItem.getValue(), "0")
         formItem.setValue("1")
-        XCTAssertEqual(formItem.getValue(), "0,1")
+        XCTAssertEqual(formItem.getValue(), "0\n1")
         formItem.setValue("0")
         XCTAssertEqual(formItem.getValue(), "1")
         formItem.setValue("0")
-        XCTAssertEqual(formItem.getValue(), "1,0")
+        XCTAssertEqual(formItem.getValue(), "1\n0")
     }
 
     func testMultiSelectMinSelections() throws {
@@ -87,13 +87,13 @@ class ExperienceDataTests: XCTestCase {
         formItem.setValue("0")
         XCTAssertEqual(formItem.getValue(), "0")
         formItem.setValue("1")
-        XCTAssertEqual(formItem.getValue(), "0,1")
+        XCTAssertEqual(formItem.getValue(), "0\n1")
         formItem.setValue("2")
-        XCTAssertEqual(formItem.getValue(), "0,1", "exceeding max not set")
+        XCTAssertEqual(formItem.getValue(), "0\n1", "exceeding max not set")
         formItem.setValue("1")
         XCTAssertEqual(formItem.getValue(), "0")
         formItem.setValue("2")
-        XCTAssertEqual(formItem.getValue(), "0,2")
+        XCTAssertEqual(formItem.getValue(), "0\n2")
     }
 
     // We do no handling of the scenario where defaultValue.count > maxSelections.
@@ -111,15 +111,15 @@ class ExperienceDataTests: XCTestCase {
 
         // Act/Assert
         XCTAssertFalse(formItem.isSatisfied)
-        XCTAssertEqual(formItem.getValue(), "0,1,2")
+        XCTAssertEqual(formItem.getValue(), "0\n1\n2")
 
         formItem.setValue("3")
-        XCTAssertEqual(formItem.getValue(), "0,1,2", "exceeding max not set")
+        XCTAssertEqual(formItem.getValue(), "0\n1\n2", "exceeding max not set")
 
         formItem.setValue("2")
         formItem.setValue("1")
         formItem.setValue("3")
-        XCTAssertEqual(formItem.getValue(), "0,3")
+        XCTAssertEqual(formItem.getValue(), "0\n3")
     }
 
     // If minSelections > options.count, minSelections will be set to options.count.
@@ -153,10 +153,10 @@ class ExperienceDataTests: XCTestCase {
         formItem.setValue("0")
         formItem.setValue("1")
         formItem.setValue("2")
-        XCTAssertEqual(formItem.getValue(), "0,1,2")
+        XCTAssertEqual(formItem.getValue(), "0\n1\n2")
 
         formItem.setValue("3")
-        XCTAssertEqual(formItem.getValue(), "0,1,2")
+        XCTAssertEqual(formItem.getValue(), "0\n1\n2")
     }
 }
 
@@ -172,6 +172,7 @@ extension ExperienceComponent.OptionSelectModel {
         self.init(
             id: UUID(),
             label: ExperienceComponent.TextModel(id: UUID(), text: "Label", style: nil),
+            errorLabel: nil,
             selectMode: selectMode,
             options: options,
             defaultValue: defaultValue,

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -142,6 +142,7 @@ extension Experience.Step.Child {
             content: ExperienceComponent.textInput(ExperienceComponent.TextInputModel(
                 id: UUID(uuidString: "f002dc4f-c5fc-4439-8916-0047a5839741")!,
                 label: ExperienceComponent.TextModel(id: UUID(), text: "Form label", style: nil),
+                errorLabel: nil,
                 placeholder: nil,
                 defaultValue: defaultValue,
                 required: true,


### PR DESCRIPTION
New `errorLabel` will show when appropriate. The `@appcues/submit-form` action sets `stepState.shouldShowErrors = true` and that is used to show the error states.

I introduced `TintedTextView` which is almost the same as `AppcuesText` but allows overriding the tint color to be set to the error color. It seemed strange to modify `AppcuesText` to support this, hence the new View.