### PR TITLE
Fix step_completed event being improperly triggered on backwards navigation

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
@@ -26,6 +26,15 @@ internal enum StepReference: Equatable {
         }
     }
 
+    var isNegativeOffset: Bool {
+        switch self {
+        case .offset(let offset) where offset < 0:
+            return true
+        default:
+            return false
+        }
+    }
+
     @available(iOS 13.0, *)
     func resolve(experience: ExperienceData, currentIndex: Experience.StepIndex) -> Experience.StepIndex? {
         switch self {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -133,6 +133,11 @@ internal class ExperienceRenderer: ExperienceRendering {
     }
 
     func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?) {
+        // Force `markComplete` to be true if dismissing from the last step in the experience.
+        let currentStepIndex = getCurrentStepIndex()
+        let forceMarkComplete = currentStepIndex != nil && currentStepIndex == getCurrentExperienceData()?.stepIndices.last
+        let markComplete = markComplete || forceMarkComplete
+
         guard Thread.isMainThread else {
             DispatchQueue.main.async {
                 self.dismissCurrentExperience(markComplete: markComplete, completion: completion)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -65,9 +65,9 @@ extension ExperienceStateMachine {
                 )
             case let (.endingStep(experience, currentIndex, _, _), .startStep(stepRef)):
                 return Transition.fromEndingStepToBeginningStep(experience, currentIndex, stepRef, traitComposer)
-            case let (.endingExperience(experience, _, _), .reset):
+            case let (.endingExperience(experience, _, markComplete), .reset):
                 var sideEffect: SideEffect?
-                if self.isExperienceCompleted {
+                if markComplete {
                     sideEffect = .processActions(experience.postExperienceActions)
                 }
                 return Transition(toState: .idling, sideEffect: sideEffect)
@@ -180,7 +180,8 @@ extension ExperienceStateMachine.Transition {
         }
 
         // Moving to a new step is an interaction that indicates the ending step is completed
-        return .init(toState: .endingStep(experience, stepIndex, package, markComplete: true), sideEffect: sideEffect)
+        // unless the step reference explicitly has an offset that's negative.
+        return .init(toState: .endingStep(experience, stepIndex, package, markComplete: !stepRef.isNegativeOffset), sideEffect: sideEffect)
     }
 
     static func fromEndingStepToBeginningStep(

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -121,10 +121,10 @@ extension ExperienceStateMachine: ExperienceContainerLifecycleHandler {
         switch state {
         case .endingExperience:
             experienceDidDisappear()
-        case let .renderingStep(_, _, package, _) where package.wrapperController.isBeingDismissed:
+        case let .renderingStep(experience, stepIndex, package, _) where package.wrapperController.isBeingDismissed:
             experienceDidDisappear()
             // Update state in response to UI changes that have happened already (a call to UIViewController.dismiss).
-            try? transition(.endExperience(markComplete: false))
+            try? transition(.endExperience(markComplete: stepIndex == experience.stepIndices.last))
         default:
             break
         }
@@ -136,7 +136,7 @@ extension ExperienceStateMachine: ExperienceContainerLifecycleHandler {
         case let .renderingStep(experience, stepIndex, package, _):
             let targetStepId = package.steps[newPageIndex].id
             if let newStepIndex = experience.stepIndex(for: targetStepId) {
-                state = .endingStep(experience, stepIndex, package, markComplete: true)
+                state = .endingStep(experience, stepIndex, package, markComplete: newPageIndex > oldPageIndex)
                 state = .beginningStep(experience, stepIndex, package, isFirst: false)
                 state = .renderingStep(experience, newStepIndex, package, isFirst: false)
             }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -15,45 +15,7 @@ internal protocol ExperienceStateObserver: AnyObject {
 }
 
 @available(iOS 13.0, *)
-extension ExperienceStateMachine.State {
-    var isStepCompleted: Bool {
-        switch self {
-        case let .endingStep(experience, stepIndex, _, markComplete):
-            return markComplete || stepIndex == experience.stepIndices.last
-        default:
-            return false
-        }
-    }
-
-    var isExperienceCompleted: Bool {
-        switch self {
-        case let .endingExperience(experience, stepIndex, markComplete):
-            return markComplete || stepIndex == experience.stepIndices.last
-        default:
-            return false
-        }
-    }
-}
-
-@available(iOS 13.0, *)
 extension Result where Success == ExperienceStateMachine.State, Failure == ExperienceStateMachine.ExperienceError {
-    var isStepCompleted: Bool {
-        switch self {
-        case let .success(state):
-            return state.isStepCompleted
-        default:
-            return false
-        }
-    }
-
-    var isExperienceCompleted: Bool {
-        switch self {
-        case let .success(state):
-            return state.isExperienceCompleted
-        default:
-            return false
-        }
-    }
 
     /// Check if the result pertains to a specific experience ID.
     func matches(instanceID: UUID?) -> Bool {
@@ -118,12 +80,12 @@ extension ExperienceStateMachine {
                 trackLifecycleEvent(.stepSeen, LifecycleEvent.properties(experience, stepIndex))
             case let .success(.renderingStep(experience, stepIndex, _, isFirst: false)):
                 trackLifecycleEvent(.stepSeen, LifecycleEvent.properties(experience, stepIndex))
-            case let .success(.endingStep(experience, stepIndex, _, _)):
-                if result.isStepCompleted {
+            case let .success(.endingStep(experience, stepIndex, _, markComplete)):
+                if markComplete {
                     trackLifecycleEvent(.stepCompleted, LifecycleEvent.properties(experience, stepIndex))
                 }
-            case let .success(.endingExperience(experience, stepIndex, _)):
-                if result.isExperienceCompleted {
+            case let .success(.endingExperience(experience, stepIndex, markComplete)):
+                if markComplete {
                     trackLifecycleEvent(.experienceCompleted, LifecycleEvent.properties(experience))
                 } else {
                     trackLifecycleEvent(.experienceDismissed, LifecycleEvent.properties(experience, stepIndex))

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -229,7 +229,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingExperienceLastStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, Experience.StepIndex(group: 1, item: 0), markComplete: false)))
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, Experience.StepIndex(group: 1, item: 0), markComplete: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)

--- a/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
@@ -84,4 +84,14 @@ class StepRefTests: XCTestCase {
 
         XCTAssertFalse(StepReference.index(1) == StepReference.offset(1))
     }
+
+    func testNegativeOffsetCheck() throws {
+        XCTAssertTrue(StepReference.offset(-1).isNegativeOffset)
+        XCTAssertTrue(StepReference.offset(-2).isNegativeOffset)
+        
+        XCTAssertFalse(StepReference.offset(1).isNegativeOffset)
+        XCTAssertFalse(StepReference.index(0).isNegativeOffset)
+        XCTAssertFalse(StepReference.index(2).isNegativeOffset)
+        XCTAssertFalse(StepReference.stepID(UUID(uuidString: "149f335f-15f6-4d8a-9e38-29a4ca435fd2")!).isNegativeOffset)
+    }
 }


### PR DESCRIPTION
There's two reasonably simple cases to handle here: swiping backwards in a carousel and a button with a negative offset.

Carousel handling:
https://github.com/appcues/appcues-ios-sdk/blob/ca5561dfe26c19f05f417f3b54fa32769d582017/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift#L139

Button handling:
https://github.com/appcues/appcues-ios-sdk/blob/ca5561dfe26c19f05f417f3b54fa32769d582017/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine%2BState.swift#L182-L184

The trickiest part of this was a gross bit of code where we would check `if result.isStepCompleted` instead of the actual value of `markComplete` in the state (see the retro below for how this ended up being gross). This check meant that navigating backwards from the last step in the experience would always mark the last step as complete even after the above fixes to the `markComplete` value.

I've added a unit test for the offset check, and the analytics tests that are part of the UI test suite verify that the `step_completed` event is no longer being triggered on the backwards swipe or negative offset button, and that the updated `markComplete` logic is correct.

## A brief retro

(More for my curiosity than anything else)

Way back in the early days of the state machine, we checked if the user was on the last step when the experience was dismissed, and if so, marked the experience as completed instead of dismissed. This was a fine solution:
https://github.com/appcues/appcues-ios-sdk/blob/a7bb5d390a4b0406fcbb985fd5a43b5980458478/Sources/AppcuesKit/UI/ExperienceStateObserver.swift#L45-L49

Then, we added the `@appcues/close` action with support for `markComplete` (https://github.com/appcues/appcues-ios-sdk/pull/168). This meant the State itself now held that flag: `case endingExperience(Experience, Experience.StepIndex, markComplete: Bool)`. The mistake was not updating the rest of the codebase to use that flag, and instead maintaining the previous check alongside the new state value: https://github.com/appcues/appcues-ios-sdk/blob/038d79487159eba6bd4fa3e425a246e1719ac759/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift#L85-L89

The 🚩 red flag was that the `markComplete` value in the `State` wasn't always correct, and we'd basically correct it in real time with the check for last step when deciding which analytics event to send.

Since then we also added `markComplete` to the `endingStep` state with the same pattern.

This has all now been fixed so that `ExperienceRenderer.dismissCurrentExperience()` and `ExperienceStateMachine.containerDidDisappear()` now are responsible for deciding if the experience should be marked complete and the State value is now always correct instead of sometimes being wrong 😎

Lesson learned: if the state in a state machine isn't actually accurate, it'll come back to bite you.