### PR TITLE
Fix step_completed event being improperly triggered

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
@@ -26,15 +26,6 @@ internal enum StepReference: Equatable {
         }
     }
 
-    var isNegativeOffset: Bool {
-        switch self {
-        case .offset(let offset) where offset < 0:
-            return true
-        default:
-            return false
-        }
-    }
-
     @available(iOS 13.0, *)
     func resolve(experience: ExperienceData, currentIndex: Experience.StepIndex) -> Experience.StepIndex? {
         switch self {
@@ -50,7 +41,7 @@ internal enum StepReference: Equatable {
 }
 
 extension Experience {
-    struct StepIndex: Equatable, CustomStringConvertible {
+    struct StepIndex: Equatable, Comparable, CustomStringConvertible {
         static var initial = StepIndex(group: 0, item: 0)
 
         var group: Int
@@ -69,6 +60,10 @@ extension Experience {
 
             self.group = parts[0]
             self.item = parts[1]
+        }
+
+        static func < (lhs: Experience.StepIndex, rhs: Experience.StepIndex) -> Bool {
+            lhs.group < rhs.group || (lhs.group == rhs.group && lhs.item < rhs.item)
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -181,7 +181,7 @@ extension ExperienceStateMachine.Transition {
 
         // Moving to a new step is an interaction that indicates the ending step is completed
         // unless the step reference explicitly has an offset that's negative.
-        return .init(toState: .endingStep(experience, stepIndex, package, markComplete: !stepRef.isNegativeOffset), sideEffect: sideEffect)
+        return .init(toState: .endingStep(experience, stepIndex, package, markComplete: newStepIndex > stepIndex), sideEffect: sideEffect)
     }
 
     static func fromEndingStepToBeginningStep(

--- a/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 class StepRefTests: XCTestCase {
     typealias SI = Experience.StepIndex
 
@@ -85,13 +86,13 @@ class StepRefTests: XCTestCase {
         XCTAssertFalse(StepReference.index(1) == StepReference.offset(1))
     }
 
-    func testNegativeOffsetCheck() throws {
-        XCTAssertTrue(StepReference.offset(-1).isNegativeOffset)
-        XCTAssertTrue(StepReference.offset(-2).isNegativeOffset)
-        
-        XCTAssertFalse(StepReference.offset(1).isNegativeOffset)
-        XCTAssertFalse(StepReference.index(0).isNegativeOffset)
-        XCTAssertFalse(StepReference.index(2).isNegativeOffset)
-        XCTAssertFalse(StepReference.stepID(UUID(uuidString: "149f335f-15f6-4d8a-9e38-29a4ca435fd2")!).isNegativeOffset)
+    func testStepIndexComparison() throws {
+        XCTAssertTrue(Experience.StepIndex(group: 0, item: 0) < Experience.StepIndex(group: 0, item: 1))
+        XCTAssertFalse(Experience.StepIndex(group: 0, item: 1) < Experience.StepIndex(group: 0, item: 1))
+        XCTAssertFalse(Experience.StepIndex(group: 0, item: 2) < Experience.StepIndex(group: 0, item: 1))
+
+        XCTAssertTrue(Experience.StepIndex(group: 1, item: 0) < Experience.StepIndex(group: 2, item: 0))
+        XCTAssertFalse(Experience.StepIndex(group: 1, item: 0) < Experience.StepIndex(group: 0, item: 1))
+        XCTAssertFalse(Experience.StepIndex(group: 2, item: 0) < Experience.StepIndex(group: 1, item: 1))
     }
 }


### PR DESCRIPTION
Requirements updated from specifically handling negative offsets to handling all cases where linking to a previous step (including by index or by step ID).