### PR TITLE
Add step_interaction analytics event for button presses

### DIFF
--- a/Sources/AppcuesKit/Data/Extensions/Sequence+CompactMapFirst.swift
+++ b/Sources/AppcuesKit/Data/Extensions/Sequence+CompactMapFirst.swift
@@ -1,0 +1,22 @@
+//
+//  Sequence+CompactMapFirst.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-10-06.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+extension Sequence {
+    // Functionally the same as Sequence.compactMap().first(), except returns immediately upon finding the first item.
+    func compactMapFirst<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) rethrows -> ElementOfResult? {
+        for item in self {
+            if let result = try transform(item) {
+                return result
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -11,6 +11,9 @@ import Foundation
 internal protocol ComponentModel {
     var id: UUID { get }
     var style: ExperienceComponent.Style? { get }
+
+    /// The text value of the component (including any children).
+    var textDescription: String? { get }
 }
 
 @dynamicMemberLookup
@@ -24,6 +27,29 @@ internal indirect enum ExperienceComponent {
     case embed(EmbedModel)
     case optionSelect(OptionSelectModel)
     case textInput(TextInputModel)
+
+    func component(matching id: UUID) -> ExperienceComponent? {
+        switch self {
+        case .stack(let model):
+            return model.id == id ? self : model.items.compactMapFirst { $0.component(matching: id) }
+        case .box(let model):
+            return model.id == id ? self : model.items.compactMapFirst { $0.component(matching: id) }
+        case .text(let model):
+            return model.id == id ? self : nil
+        case .button(let model):
+            return model.id == id ? self : model.content.component(matching: id)
+        case .image(let model):
+            return model.id == id ? self : nil
+        case .spacer(let model):
+            return model.id == id ? self : nil
+        case .embed(let model):
+            return model.id == id ? self : nil
+        case .optionSelect(let model):
+            return model.id == id ? self : nil
+        case .textInput(let model):
+            return model.id == id ? self : nil
+        }
+    }
 
     subscript<T>(dynamicMember keyPath: KeyPath<ComponentModel, T>) -> T {
         switch self {
@@ -101,6 +127,8 @@ extension ExperienceComponent {
         let items: [ExperienceComponent]
 
         let style: Style?
+
+        var textDescription: String? { items.compactMap { $0.textDescription }.joined(separator: " ") }
     }
 
     struct BoxModel: ComponentModel, Decodable {
@@ -108,6 +136,8 @@ extension ExperienceComponent {
         let items: [ExperienceComponent]
 
         let style: Style?
+
+        var textDescription: String? { items.compactMap { $0.textDescription }.joined(separator: " ") }
     }
 
     struct TextModel: ComponentModel, Decodable {
@@ -115,6 +145,8 @@ extension ExperienceComponent {
         let text: String
 
         let style: Style?
+
+        var textDescription: String? { text }
     }
 
     struct ButtonModel: ComponentModel, Decodable {
@@ -122,6 +154,8 @@ extension ExperienceComponent {
         let content: ExperienceComponent
 
         let style: Style?
+
+        var textDescription: String? { content.textDescription }
     }
 
     struct ImageModel: ComponentModel, Decodable {
@@ -143,6 +177,8 @@ extension ExperienceComponent {
             self.accessibilityLabel = nil
             self.style = nil
         }
+
+        var textDescription: String? { accessibilityLabel }
     }
 
     struct EmbedModel: ComponentModel, Decodable {
@@ -150,6 +186,8 @@ extension ExperienceComponent {
         let embed: String
         let intrinsicSize: IntrinsicSize?
         let style: Style?
+
+        var textDescription: String? { nil }
     }
 
     struct TextInputModel: ComponentModel, Decodable {
@@ -172,6 +210,8 @@ extension ExperienceComponent {
         let cursorColor: Style.DynamicColor?
 
         let style: Style?
+
+        var textDescription: String? { label.textDescription }
     }
 
     struct FormOptionModel: Decodable, Identifiable {
@@ -212,6 +252,8 @@ extension ExperienceComponent {
         let pickerStyle: Style?
 
         let style: Style?
+
+        var textDescription: String? { label.textDescription }
     }
 
     struct SpacerModel: ComponentModel, Decodable {
@@ -219,6 +261,8 @@ extension ExperienceComponent {
         let spacing: Double?
 
         let style: Style?
+
+        var textDescription: String? { nil }
     }
 
     struct Style: Decodable {

--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -28,29 +28,6 @@ internal indirect enum ExperienceComponent {
     case optionSelect(OptionSelectModel)
     case textInput(TextInputModel)
 
-    func component(matching id: UUID) -> ExperienceComponent? {
-        switch self {
-        case .stack(let model):
-            return model.id == id ? self : model.items.compactMapFirst { $0.component(matching: id) }
-        case .box(let model):
-            return model.id == id ? self : model.items.compactMapFirst { $0.component(matching: id) }
-        case .text(let model):
-            return model.id == id ? self : nil
-        case .button(let model):
-            return model.id == id ? self : model.content.component(matching: id)
-        case .image(let model):
-            return model.id == id ? self : nil
-        case .spacer(let model):
-            return model.id == id ? self : nil
-        case .embed(let model):
-            return model.id == id ? self : nil
-        case .optionSelect(let model):
-            return model.id == id ? self : nil
-        case .textInput(let model):
-            return model.id == id ? self : nil
-        }
-    }
-
     subscript<T>(dynamicMember keyPath: KeyPath<ComponentModel, T>) -> T {
         switch self {
         case .stack(let model): return model[keyPath: keyPath]

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -68,11 +68,21 @@ internal class ActionRegistry {
     }
 
     /// Enqueue an experience action data model to be executed.
-    func enqueue(actionModels: [Experience.Action]) {
+    func enqueue(actionModels: [Experience.Action], interactionType: String, viewDescription: String?) {
         let actionInstances = actionModels.compactMap {
             actions[$0.type]?.init(config: $0.config)
         }
-        enqueue(actionInstances: actionInstances)
+
+        // As a heuristic, take the last action that's `MetadataSettingAction`, since that's most likely
+        // to be the action that we'd want to see in the event export.
+        let primaryAction = actionInstances.reversed().compactMapFirst { $0 as? MetadataSettingAction }
+        let interactionAction = AppcuesStepInteractionAction(
+            interactionType: interactionType,
+            viewDescription: viewDescription ?? "",
+            category: primaryAction?.category ?? "",
+            destination: primaryAction?.destination ?? "")
+
+        enqueue(actionInstances: [interactionAction] + actionInstances)
     }
 
     // Queue transforms are applied in the order of the original queue,

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
@@ -1,0 +1,59 @@
+//
+//  AppcuesStepInteractionAction.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-10-05.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+/// Internal-only action: This action isn't registered in the `ActionRegistry`.
+@available(iOS 13.0, *)
+internal class AppcuesStepInteractionAction: ExperienceAction {
+
+    static let type = "@appcues/step_interaction"
+
+    let interactionType: String
+    let viewDescription: String
+    let category: String
+    let destination: String
+
+    required init?(config: [String: Any]?) {
+        // An internal-only action, so can't be initialized from an Experience.Action model.
+        return nil
+    }
+
+    init(interactionType: String, viewDescription: String, category: String, destination: String) {
+        self.interactionType = interactionType
+        self.viewDescription = viewDescription
+        self.category = category
+        self.destination = destination
+    }
+
+    func execute(inContext appcues: Appcues, completion: @escaping ActionRegistry.Completion) {
+        let analyticsPublisher = appcues.container.resolve(AnalyticsPublishing.self)
+        let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
+
+        var interactionProperties: [String: Any] = [
+            "interactionType": interactionType,
+            "interactionData": [
+                "category": category,
+                "destination": destination,
+                "text": viewDescription
+            ]
+        ]
+
+        if let experienceData = experienceRenderer.getCurrentExperienceData(),
+           let stepIndex = experienceRenderer.getCurrentStepIndex() {
+            interactionProperties = interactionProperties.merging(LifecycleEvent.properties(experienceData, stepIndex)) { first, _ in first }
+        }
+
+        analyticsPublisher.publish(TrackingUpdate(
+            type: .event(name: LifecycleEvent.stepInteraction.rawValue, interactive: false),
+            properties: interactionProperties,
+            isInternal: true))
+
+        completion()
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Actions/MetadataSettingAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/MetadataSettingAction.swift
@@ -1,0 +1,54 @@
+//
+//  MetadataSettingAction.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-10-06.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal protocol MetadataSettingAction {
+    var category: String { get }
+    var destination: String { get }
+}
+
+// MARK: - Implementations
+// These are the actions that can define the step_interaction analytic values.
+
+@available(iOS 13.0, *)
+extension AppcuesLinkAction: MetadataSettingAction {
+    var category: String { "link" }
+    var destination: String { url.absoluteString }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesLaunchExperienceAction: MetadataSettingAction {
+    var category: String { "internal" }
+    var destination: String { experienceID }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesContinueAction: MetadataSettingAction {
+    var category: String { "internal" }
+    var destination: String { stepReference.description }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesCloseAction: MetadataSettingAction {
+    var category: String { "internal" }
+    var destination: String { "end-experience" }
+}
+
+extension StepReference {
+    var description: String {
+        switch self {
+        case .index(let index):
+            return "#\(index)"
+        case .offset(let offset):
+            return offset > 0 ? "+\(offset)" : "\(offset)"
+        case .stepID(let stepID):
+            return stepID.uuidString
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -16,15 +16,15 @@ extension View {
         return self
             .ifLet(actions[.tap]) { view, actionHandlers in
                 view.simultaneousGesture(TapGesture().onEnded {
-                    viewModel.enqueueActions(actionHandlers)
+                    viewModel.enqueueActions(actionHandlers, type: "Button Tapped", componentID: id)
                 })
                 .accessibilityAction {
-                    viewModel.enqueueActions(actionHandlers)
+                    viewModel.enqueueActions(actionHandlers, type: "Button Activated", componentID: id)
                 }
             }
             .ifLet(actions[.longPress]) { view, actionHandlers in
                 view.simultaneousGesture(LongPressGesture().onEnded { _ in
-                    viewModel.enqueueActions(actionHandlers)
+                    viewModel.enqueueActions(actionHandlers, type: "Button Long Pressed", componentID: id)
                 })
             }
     }

--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -10,21 +10,21 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 extension View {
-    func setupActions(on viewModel: ExperienceStepViewModel, for id: UUID) -> some View {
-        let actions = viewModel.actions(for: id)
+    func setupActions(on viewModel: ExperienceStepViewModel, for componentModel: ComponentModel) -> some View {
+        let actions = viewModel.actions(for: componentModel.id)
         // simultaneousGesture is needed to make a Button support any of these gestures.
         return self
             .ifLet(actions[.tap]) { view, actionHandlers in
                 view.simultaneousGesture(TapGesture().onEnded {
-                    viewModel.enqueueActions(actionHandlers, type: "Button Tapped", componentID: id)
+                    viewModel.enqueueActions(actionHandlers, type: "Button Tapped", viewDescription: componentModel.textDescription)
                 })
                 .accessibilityAction {
-                    viewModel.enqueueActions(actionHandlers, type: "Button Activated", componentID: id)
+                    viewModel.enqueueActions(actionHandlers, type: "Button Activated", viewDescription: componentModel.textDescription)
                 }
             }
             .ifLet(actions[.longPress]) { view, actionHandlers in
                 view.simultaneousGesture(LongPressGesture().onEnded { _ in
-                    viewModel.enqueueActions(actionHandlers, type: "Button Long Pressed", componentID: id)
+                    viewModel.enqueueActions(actionHandlers, type: "Button Long Pressed", viewDescription: componentModel.textDescription)
                 })
             }
     }

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -142,16 +142,3 @@ private extension Optional {
         }
     }
 }
-
-private extension Array {
-    // Functionally the same as Array.compactMap().first(), except returns immediately upon finding the first item.
-    func compactMapFirst<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) rethrows -> ElementOfResult? {
-        for item in self {
-            if let result = try transform(item) {
-                return result
-            }
-        }
-
-        return nil
-    }
-}

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesBox.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesBox.swift
@@ -22,7 +22,7 @@ internal struct AppcuesBox: View {
                 AnyView($0.view)
             }
         }
-        .setupActions(on: viewModel, for: model.id)
+        .setupActions(on: viewModel, for: model)
         .applyAllAppcues(style)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
@@ -39,6 +39,6 @@ internal struct AppcuesButton: View {
         .applyBackgroundStyle(style)
         .applyBorderStyle(style)
         .applyExternalLayout(style)
-        .setupActions(on: viewModel, for: model.id)
+        .setupActions(on: viewModel, for: model)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
@@ -23,7 +23,7 @@ internal struct AppcuesImage: View {
             .ifLet(model.accessibilityLabel) { view, val in
                 view.accessibility(label: Text(val))
             }
-            .setupActions(on: viewModel, for: model.id)
+            .setupActions(on: viewModel, for: model)
             .applyForegroundStyle(style)
             // set the aspect ratio before applying frame sizing
             .ifLet(ContentMode(string: model.contentMode)) { view, val in

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -46,7 +46,7 @@ internal struct AppcuesOptionSelect: View {
                 AppcuesText(model: errorLabel)
             }
         }
-        .setupActions(on: viewModel, for: model.id)
+        .setupActions(on: viewModel, for: model)
         .applyAllAppcues(style)
     }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
@@ -24,7 +24,7 @@ internal struct AppcuesStack: View {
                     AnyView($0.view)
                 }
             }
-            .setupActions(on: viewModel, for: model.id)
+            .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
         case (.horizontal, .center),
             (.horizontal, .none):
@@ -33,7 +33,7 @@ internal struct AppcuesStack: View {
                     AnyView($0.view)
                 }
             }
-            .setupActions(on: viewModel, for: model.id)
+            .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
         case (.horizontal, .equal):
             HStack(alignment: style.verticalAlignment, spacing: CGFloat(model.spacing ?? 0)) {
@@ -48,7 +48,7 @@ internal struct AppcuesStack: View {
                 }
             }
             .fixedSize(horizontal: false, vertical: true)
-            .setupActions(on: viewModel, for: model.id)
+            .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
         }
     }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -19,7 +19,7 @@ internal struct AppcuesText: View {
 
         Text(model.text)
             .applyTextStyle(style)
-            .setupActions(on: viewModel, for: model.id)
+            .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
@@ -41,7 +41,7 @@ internal struct AppcuesTextInput: View {
                 AppcuesText(model: errorLabel)
             }
         }
-        .setupActions(on: viewModel, for: model.id)
+        .setupActions(on: viewModel, for: model)
         .applyAllAppcues(style)
     }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -20,7 +20,7 @@ internal struct TintedTextView: View {
 
         Text(model.text)
             .applyTextStyle(style)
-            .setupActions(on: viewModel, for: model.id)
+            .setupActions(on: viewModel, for: model)
             .ifLet(tintColor) { view, val in
                 view.foregroundColor(val)
             }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -45,8 +45,11 @@ internal class ExperienceStepViewModel: ObservableObject {
         self.actionRegistry = nil
     }
 
-    func enqueueActions(_ actions: [Experience.Action]) {
-        actionRegistry?.enqueue(actionModels: actions)
+    func enqueueActions(_ actions: [Experience.Action], type: String, componentID: UUID) {
+        actionRegistry?.enqueue(
+            actionModels: actions,
+            interactionType: type,
+            viewDescription: step.content.component(matching: componentID)?.textDescription)
     }
 
     func actions(for id: UUID) -> [ActionType?: [Experience.Action]] {

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -45,11 +45,11 @@ internal class ExperienceStepViewModel: ObservableObject {
         self.actionRegistry = nil
     }
 
-    func enqueueActions(_ actions: [Experience.Action], type: String, componentID: UUID) {
+    func enqueueActions(_ actions: [Experience.Action], type: String, viewDescription: String?) {
         actionRegistry?.enqueue(
             actionModels: actions,
             interactionType: type,
-            viewDescription: step.content.component(matching: componentID)?.textDescription)
+            viewDescription: viewDescription)
     }
 
     func actions(for id: UUID) -> [ActionType?: [Experience.Action]] {

--- a/Sources/AppcuesKit/Vendor/FLAnimatedImage.swift
+++ b/Sources/AppcuesKit/Vendor/FLAnimatedImage.swift
@@ -654,19 +654,6 @@ extension FLAnimatedImage {
     }
 }
 
-private extension Sequence {
-    // Functionally the same as Array.compactMap().first(), except returns immediately upon finding the first item.
-    func compactMapFirst<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) rethrows -> ElementOfResult? {
-        for item in self {
-            if let result = try transform(item) {
-                return result
-            }
-        }
-
-        return nil
-    }
-}
-
 private extension FLAnimatedImage {
     class CacheSettingProxy: NSObject {
         weak var image: FLAnimatedImage?

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -33,10 +33,12 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.register(action: TestAction.self)
 
         // Assert
-        actionRegistry.enqueue(actionModels: [actionModel])
+        actionRegistry.enqueue(
+            actionModels: [actionModel],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
         waitForExpectations(timeout: 1)
     }
-
 
     func testUnknownAction() throws {
         // Arrange
@@ -52,7 +54,10 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.register(action: TestAction.self)
 
         // Assert
-        actionRegistry.enqueue(actionModels: [actionModel])
+        actionRegistry.enqueue(
+            actionModels: [actionModel],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
         waitForExpectations(timeout: 1)
 
     }
@@ -77,7 +82,10 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.register(action: TestAction2.self)
 
         // Assert
-        actionRegistry.enqueue(actionModels: [actionModel])
+        actionRegistry.enqueue(
+            actionModels: [actionModel],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
         waitForExpectations(timeout: 1)
     }
 
@@ -93,7 +101,11 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.register(action: TestAction.self)
 
         // Act
-        actionRegistry.enqueue(actionModels: [actionModel, actionModel, actionModel, actionModel, actionModel])
+        actionRegistry.enqueue(
+            actionModels: [actionModel, actionModel, actionModel, actionModel, actionModel],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -116,9 +128,16 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.register(action: TestAction.self)
 
         // Act
-        actionRegistry.enqueue(actionModels: [delayedActionModel])
+        actionRegistry.enqueue(
+            actionModels: [delayedActionModel],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
         // Enqueue more while the delayed one is processing
-        actionRegistry.enqueue(actionModels: [actionModel, actionModel, actionModel, actionModel])
+        actionRegistry.enqueue(
+            actionModels: [actionModel, actionModel, actionModel, actionModel],
+            interactionType: "Button Tapped",
+            viewDescription: "Another Button")
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -141,7 +160,10 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.register(action: TestAction.self)
 
         // Act
-        actionRegistry.enqueue(actionModels: [actionModel, actionModel, actionModel2, actionModel, actionModel])
+        actionRegistry.enqueue(
+            actionModels: [actionModel, actionModel, actionModel2, actionModel, actionModel],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
 
         // Assert
 

--- a/Tests/AppcuesKitTests/Actions/StepInteractionActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/StepInteractionActionTests.swift
@@ -1,0 +1,212 @@
+//
+//  StepInteractionActionTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2022-10-06.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class StepInteractionActionTests: XCTestCase {
+
+    var appcues: MockAppcues!
+    var actionRegistry: ActionRegistry!
+
+    override func setUpWithError() throws {
+        appcues = MockAppcues()
+        actionRegistry = ActionRegistry(container: appcues.container)
+    }
+
+    func testNextStep() throws {
+        // Arrange
+        var mostRecentUpdate: TrackingUpdate?
+        appcues.analyticsPublisher.onPublish = { update in mostRecentUpdate = update }
+
+        // Act
+        actionRegistry.enqueue(
+            actionModels: [
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/continue",
+                    config: ["offset": 1]),
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/track",
+                    config: ["eventName": "Some event"])
+            ],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
+        // Assert
+        let lastUpdate = try XCTUnwrap(mostRecentUpdate)
+        guard case .event(name: "appcues:v2:step_interaction", interactive: false) = lastUpdate.type else { return XCTFail() }
+        [
+            "interactionType": "Button Tapped",
+            "interactionData": [
+                "category": "internal",
+                "destination": "+1",
+                "text": "My Button"
+            ]
+        ].verifyPropertiesMatch(lastUpdate.properties)
+    }
+
+    func testPreviousStep() throws {
+        // Arrange
+        var mostRecentUpdate: TrackingUpdate?
+        appcues.analyticsPublisher.onPublish = { update in mostRecentUpdate = update }
+
+        // Act
+        actionRegistry.enqueue(
+            actionModels: [
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/continue",
+                    config: ["offset": -1]),
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/track",
+                    config: ["eventName": "Some event"])
+            ],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
+        // Assert
+        let lastUpdate = try XCTUnwrap(mostRecentUpdate)
+        guard case .event(name: "appcues:v2:step_interaction", interactive: false) = lastUpdate.type else { return XCTFail() }
+        [
+            "interactionType": "Button Tapped",
+            "interactionData": [
+                "category": "internal",
+                "destination": "-1",
+                "text": "My Button"
+            ]
+        ].verifyPropertiesMatch(lastUpdate.properties)
+    }
+
+    func testGoToLink() throws {
+        // Arrange
+        var mostRecentUpdate: TrackingUpdate?
+        appcues.analyticsPublisher.onPublish = { update in mostRecentUpdate = update }
+
+        // Act
+        actionRegistry.enqueue(
+            actionModels: [
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/close",
+                    config: ["markComplete":"true"]),
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/link",
+                    config: ["url": "https://appcues.com"])
+            ],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
+        // Assert
+        let lastUpdate = try XCTUnwrap(mostRecentUpdate)
+        guard case .event(name: "appcues:v2:step_interaction", interactive: false) = lastUpdate.type else { return XCTFail() }
+        [
+            "interactionType": "Button Tapped",
+            "interactionData": [
+                "category": "link",
+                "destination": "https://appcues.com",
+                "text": "My Button"
+            ]
+        ].verifyPropertiesMatch(lastUpdate.properties)
+    }
+
+    func testTriggerFlow() throws {
+        // Arrange
+        var mostRecentUpdate: TrackingUpdate?
+        appcues.analyticsPublisher.onPublish = { update in mostRecentUpdate = update }
+
+        // Act
+        actionRegistry.enqueue(
+            actionModels: [
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/link",
+                    config: ["url": "myapp://deeplink"]),
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/launch-experience",
+                    config: ["experienceID": "c1d5336f-6416-4805-9e82-4073c9b8cdb8"])
+            ],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
+        // Assert
+        let lastUpdate = try XCTUnwrap(mostRecentUpdate)
+        guard case .event(name: "appcues:v2:step_interaction", interactive: false) = lastUpdate.type else { return XCTFail() }
+        [
+            "interactionType": "Button Tapped",
+            "interactionData": [
+                "category": "internal",
+                "destination": "c1d5336f-6416-4805-9e82-4073c9b8cdb8",
+                "text": "My Button"
+            ]
+        ].verifyPropertiesMatch(lastUpdate.properties)
+    }
+
+    func testDismissFlow() throws {
+        // Arrange
+        var mostRecentUpdate: TrackingUpdate?
+        appcues.analyticsPublisher.onPublish = { update in mostRecentUpdate = update }
+
+        // Act
+        actionRegistry.enqueue(
+            actionModels: [
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/close",
+                    config: ["markComplete": true])
+            ],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
+        // Assert
+        let lastUpdate = try XCTUnwrap(mostRecentUpdate)
+        guard case .event(name: "appcues:v2:step_interaction", interactive: false) = lastUpdate.type else { return XCTFail() }
+        [
+            "interactionType": "Button Tapped",
+            "interactionData": [
+                "category": "internal",
+                "destination": "end-experience",
+                "text": "My Button"
+            ]
+        ].verifyPropertiesMatch(lastUpdate.properties)
+    }
+
+    func testGoToCustomStep() throws {
+        // Arrange
+        var mostRecentUpdate: TrackingUpdate?
+        appcues.analyticsPublisher.onPublish = { update in mostRecentUpdate = update }
+
+        // Act
+        actionRegistry.enqueue(
+            actionModels: [
+                Experience.Action(
+                    trigger: "tap",
+                    type: "@appcues/continue",
+                    config: ["stepID": "c1ba5af5-df15-4e38-834b-c7c33ee91e44"])
+            ],
+            interactionType: "Button Tapped",
+            viewDescription: "My Button")
+
+        // Assert
+        let lastUpdate = try XCTUnwrap(mostRecentUpdate)
+        guard case .event(name: "appcues:v2:step_interaction", interactive: false) = lastUpdate.type else { return XCTFail() }
+        [
+            "interactionType": "Button Tapped",
+            "interactionData": [
+                "category": "internal",
+                "destination": "C1BA5AF5-DF15-4E38-834B-C7C33EE91E44",
+                "text": "My Button"
+            ]
+        ].verifyPropertiesMatch(lastUpdate.properties)
+    }
+}


### PR DESCRIPTION
Whenever a button (or, technically any view with an action) is tapped, we want to record the `step_interaction` event with some metadata about that action.

To do this, we:
1. Look up the tapped element in the JSON model, and get its text description.
2. Try and figure out what the "primary" action is from the queue and fill out a `category` and `destination` value. To do this, the actions we care about conform to the `MetadataSettingAction` protocol. We go backwards through the action queue because that heuristic (currently) gives us the actions we care about with how they're ordered by the mobile builder. This isn't foolproof, but it's *mostly right* (entirely right for the current cases) and that's good enough.
3. Prefix the action queue with a new internal `AppcuesStepInteractionAction` that actually logs the analytics event. Adding at the start of the queue ensures the action is logged before and step changes or other related experience actions. There's an interested interplay with the `@appcues/submit-form` action since that only removes the actions following it when invalid, and so the `step_interaction` event is still logged even though the form was not submitted. I think this is ok because it's logging that the button was tapped (which is true and possibly helpful info), but we could add a special case to the submit form action to remove the step interaction action too.4. 

Note that I've got the following `interactionType` values: `Button Tapped`, `Button Activated` (for accessibility activations—I think it's interesting to have this differentiated from a tap, but we could make it the same), and `Button Long Pressed`.

I've added test cases to match each of the possible action lists from the builder.

The debugger work for survey interactions also works nicely for button interactions:

![Simulator Screen Shot - iPhone 13 Pro - 2022-10-06 at 14 39 11](https://user-images.githubusercontent.com/845681/194392924-8022e3e4-a382-4a3d-a668-8a1b8f47b833.png)
