### PR TITLE
Sanitize event properties to known types before broadcasting outside the SDK

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsBroadcaster.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsBroadcaster.swift
@@ -23,15 +23,48 @@ internal class AnalyticsBroadcaster: AnalyticsSubscribing {
     func track(update: TrackingUpdate) {
         guard let delegate = appcues?.analyticsDelegate else { return }
 
+        var properties = update.properties
+        properties?.values.sanitize()
+
         switch update.type {
         case let .event(name, _):
-            delegate.didTrack(analytic: .event, value: name, properties: update.properties, isInternal: update.isInternal)
+            delegate.didTrack(analytic: .event, value: name, properties: properties, isInternal: update.isInternal)
         case let .screen(title):
-            delegate.didTrack(analytic: .screen, value: title, properties: update.properties, isInternal: update.isInternal)
+            delegate.didTrack(analytic: .screen, value: title, properties: properties, isInternal: update.isInternal)
         case let .group(groupID):
-            delegate.didTrack(analytic: .group, value: groupID, properties: update.properties, isInternal: update.isInternal)
+            delegate.didTrack(analytic: .group, value: groupID, properties: properties, isInternal: update.isInternal)
         case .profile:
-            delegate.didTrack(analytic: .identify, value: storage.userID, properties: update.properties, isInternal: update.isInternal)
+            delegate.didTrack(analytic: .identify, value: storage.userID, properties: properties, isInternal: update.isInternal)
+        }
+    }
+}
+
+// Implemented an extension on MutableCollection rather than duplicating code for Dictionary<String, Any> and Array<Any>.
+private extension MutableCollection where Element == Any {
+    /// Transform a collection of properties to be standardized for consumption outside the SDK.
+    ///
+    /// In-place sanitizing of the MutableCollection values.
+    /// It's required to be this way because Dictionary doesn't conform to MutableCollection, only Dictionary.Values.
+    mutating func sanitize() {
+        for key in self.indices {
+            if #available(iOS 13.0, *), let stepState = self[key] as? ExperienceData.StepState {
+                // This needs to be separate from the switch for the version check,
+                // but it also means the switch applies to the dictionary value, ensuring it's also sanitized.
+                self[key] = stepState.formattedAsAny() ?? NSNull()
+            }
+
+            switch self[key] {
+            case let date as Date:
+                self[key] = date.millisecondsSince1970
+            case var dict as [String: Any]:
+                dict.values.sanitize()
+                self[key] = dict
+            case var arr as [Any]:
+                arr.sanitize()
+                self[key] = arr
+            default:
+                break
+            }
         }
     }
 }

--- a/Sources/AppcuesKit/Data/Networking/NetworkClient.swift
+++ b/Sources/AppcuesKit/Data/Networking/NetworkClient.swift
@@ -119,7 +119,7 @@ extension NetworkClient {
     }
 }
 
-private extension Date {
+extension Date {
     var millisecondsSince1970: Int64 {
         return Int64((self.timeIntervalSince1970 * 1_000.0).rounded())
     }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -219,6 +219,12 @@ extension ExperienceData.StepState {
             (formItem.label, formItem.getValue())
         }
     }
+
+    func formattedAsAny() -> [[String: Any]]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)) as? [[String: Any]]
+    }
+
 }
 
 @available(iOS 13.0, *)

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -91,28 +91,54 @@ class AnalyticsTrackerTests: XCTestCase {
 // Helpers to test an Activity request body is as expected
 extension Dictionary where Key == String, Value == Any {
 
-    func verifyPropertiesMatch(_ other: [String: Any]?) {
+    func verifyPropertiesMatch(_ other: [String: Any]?, file: StaticString = #file, line: UInt = #line) {
         guard let other = other else {
             XCTFail("dictionary of actual values must not be nil")
             return
         }
-        XCTAssertEqual(Set(self.keys), Set(other.keys))
+        XCTAssertEqual(Set(self.keys), Set(other.keys), file: file, line: line)
         self.keys.forEach { key in
             switch(self[key], other[key]) {
             case let (val1 as String, val2 as String):
-                XCTAssertEqual(val1, val2)
-            case let (val1 as Int, val2 as Int):
-                XCTAssertEqual(val1, val2)
-            case let (val1 as Double, val2 as Double):
-                XCTAssertEqual(val1, val2)
-            case let (val1 as Bool, val2 as Bool):
-                XCTAssertEqual(val1, val2)
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as NSNumber, val2 as NSNumber):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as [Any], val2 as [Any]):
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
             case let (val1 as [String: Any], val2 as [String: Any]):
-                val1.verifyPropertiesMatch(val2)
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
             case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
-                XCTAssertEqual(val1, val2)
+                XCTAssertEqual(val1, val2, file: file, line: line)
             default:
-                XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").")
+                XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").", file: file, line: line)
+            }
+        }
+    }
+}
+
+extension Array where Element == Any {
+
+    func verifyPropertiesMatch(_ other: [Any]?, file: StaticString = #file, line: UInt = #line) {
+        guard let other = other else {
+            XCTFail("dictionary of actual values must not be nil")
+            return
+        }
+        XCTAssertEqual(self.count, other.count, file: file, line: line)
+
+        zip(self, other).forEach { (selfVal, otherVal) in
+            switch(selfVal, otherVal) {
+            case let (val1 as String, val2 as String):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as NSNumber, val2 as NSNumber):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as [Any], val2 as [Any]):
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
+            case let (val1 as [String: Any], val2 as [String: Any]):
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
+            case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            default:
+                XCTFail("\(selfVal) does not match \(otherVal).", file: file, line: line)
             }
         }
     }


### PR DESCRIPTION
This PR converts `Date` objects to milliseconds and `StepState` objects to nested `[String: Any]` primitive JSON-compatible types.

The cool part is unlike the x-platform implementations (eg [React Native](https://github.com/appcues/appcues-react-native-module/blob/15d2d650d1cc812bdab26d5f512c900bbda99172/ios/AppcuesReactNative.swift)), I was able to do it without repeating the `switch` for `Dictionary` and `Array`. It's a bit tricky, and I learned a bunch (thanks to [this discussion](https://forums.swift.org/t/idea-mutatingforeach-for-collections/18442)), but the solution is quite nice.

I updated the tests to handle comparing arrays and the Int64 millisecond value. The `file: StaticString = #file, line: UInt = #line` stuff just makes it easier to understand failures in Xcode.

### React Native Example

|Now|Before|
|-|-|
|<img width="567" alt="after" src="https://user-images.githubusercontent.com/845681/194637661-6914808a-1b45-4698-93e0-7532ee5f61ea.png">|<img width="569" alt="before" src="https://user-images.githubusercontent.com/845681/194637653-1339e489-f27b-4e7d-854c-f55b4546d7bd.png">|
