### PR TITLE
Fix border rendering to be entirely inside the view bounds

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -100,6 +100,10 @@ extension View {
                 view.overlay(
                     RoundedRectangle(cornerRadius: style.cornerRadius ?? 0)
                         .stroke(val1, lineWidth: val2)
+                        // The RoundedRectangle overlay is added centered on the edge of the view, so
+                        // half of the width is outside the view bounds. Add padding for that to
+                        // ensure the border never gets half cropped out.
+                        .padding(val2 / 2)
                 )
             }
     }


### PR DESCRIPTION
The way we're drawing borders (a SwiftUI `RoundedRectangle` overlay) is inconsistent with Android and just plain looked weird. The center of the border line was the edge of the view, so half the border could get cropped out. This fixes things to draw the border entirely within the frame of the view (consistent with Android).

```json
"style": {
    "borderWidth": 5,
    "borderColor": { "light": "#ff0000" }
}
```

|Fixed|Broken|Android|
|-|-|-|
|![fixed](https://user-images.githubusercontent.com/845681/195435720-18b7db66-242f-43e0-8366-ebb8b51cc651.png)|![broken](https://user-images.githubusercontent.com/845681/195435774-e8ac60cd-37f2-4465-b087-f1daf85b3802.png)|![com appcues host ExperienceTests_testModalOne](https://user-images.githubusercontent.com/845681/195438152-9b754b7d-df74-4a58-b9a4-151eda1f761e.png)|
