### PR TITLE
Fix border radius rendering to match the corner radius

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -96,14 +96,15 @@ extension View {
 
     func applyBorderStyle(_ style: AppcuesStyle) -> some View {
         self
-            .ifLet(style.borderColor, style.borderWidth) { view, val1, val2 in
+            .ifLet(style.borderColor, style.borderWidth) { view, color, width in
                 view.overlay(
-                    RoundedRectangle(cornerRadius: style.cornerRadius ?? 0)
-                        .stroke(val1, lineWidth: val2)
+                    // Need to adjust the corner radius to match the radius applied to the view.
+                    RoundedRectangle(cornerRadius: (style.cornerRadius ?? 0) - width / 2)
+                        .stroke(color, lineWidth: width)
                         // The RoundedRectangle overlay is added centered on the edge of the view, so
                         // half of the width is outside the view bounds. Add padding for that to
                         // ensure the border never gets half cropped out.
-                        .padding(val2 / 2)
+                        .padding(width / 2)
                 )
             }
     }


### PR DESCRIPTION
As [James pointed out](https://github.com/appcues/appcues-mobile-experience-spec/pull/95#pullrequestreview-1139902647), I didn't quite get it right:

These examples have a translucent red border to see how it overlays.

||Good|Bad|
|-|-|-|
|1px border|![1-good](https://user-images.githubusercontent.com/845681/195676699-e0dc582b-74d7-4ee7-8d8b-b2d1a6f2d094.png)|![1-bad](https://user-images.githubusercontent.com/845681/195676705-5386b6af-7639-4751-a2d3-aa9dee0bc1dd.png)|
|4px border|![4-good](https://user-images.githubusercontent.com/845681/195677953-cef94d5a-8984-4aa1-a016-dcd3c4ce07eb.png)|![4-bad](https://user-images.githubusercontent.com/845681/195677946-6e17c4c1-9385-4fdb-97f6-c2675d0621c3.png)|
|10px border|![10-good](https://user-images.githubusercontent.com/845681/195676695-8ab2f8db-4990-4fb2-b11b-95cec19985c6.png)|![10-bad](https://user-images.githubusercontent.com/845681/195676701-f137c3fd-90d9-4a1c-9fcb-f55c71e2ab37.png)|