### PR TITLE
Update step_interaction analytic to enqueue separately from Experience actions

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -82,7 +82,10 @@ internal class ActionRegistry {
             category: primaryAction?.category ?? "",
             destination: primaryAction?.destination ?? "")
 
-        enqueue(actionInstances: [interactionAction] + actionInstances)
+        // Directly enqueue the interactionAction separately from the others so that it can't be modified by the queue transformation.
+        actionQueue.append(interactionAction)
+
+        enqueue(actionInstances: actionInstances)
     }
 
     // Queue transforms are applied in the order of the original queue,


### PR DESCRIPTION
Ensures the step_interaction isnt affected by or afffecting the queue transform for the other actions.

Matches the approach @andretortolano proposed in https://github.com/appcues/appcues-android-sdk/pull/248