### PR TITLE
Add support for experiments

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -94,7 +94,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
             case .success(let qualifyResponse):
                 if #available(iOS 13.0, *), let experienceRenderer = self?.container?.resolve(ExperienceRendering.self) {
                     let experiments = qualifyResponse.experiments ?? [:]
-                    let qualifiedExperienceData = qualifyResponse.experiences.map {
+                    let qualifiedExperienceData: [ExperienceData] = qualifyResponse.experiences.map {
                         var experiment: Experiment?
                         if let experimentID = $0.experimentID {
                             experiment = experiments[experimentID]

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -96,6 +96,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                     experienceRenderer.show(
                         qualifiedExperiences: qualifyResponse.experiences,
                         priority: qualifyResponse.renderPriority,
+                        experiments: qualifyResponse.experiments ?? [:],
                         completion: nil)
                 } else {
                     self?.config.logger.info("iOS 13 or above is required to render an Appcues experience")

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -93,11 +93,15 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
             switch result {
             case .success(let qualifyResponse):
                 if #available(iOS 13.0, *), let experienceRenderer = self?.container?.resolve(ExperienceRendering.self) {
-                    experienceRenderer.show(
-                        qualifiedExperiences: qualifyResponse.experiences,
-                        priority: qualifyResponse.renderPriority,
-                        experiments: qualifyResponse.experiments ?? [:],
-                        completion: nil)
+                    let experiments = qualifyResponse.experiments ?? [:]
+                    let qualifiedExperienceData = qualifyResponse.experiences.map {
+                        var experiment: Experiment?
+                        if let experimentID = $0.experimentID {
+                            experiment = experiments[experimentID]
+                        }
+                        return ExperienceData($0, priority: qualifyResponse.renderPriority, published: true, experiment: experiment)
+                    }
+                    experienceRenderer.show(qualifiedExperiences: qualifiedExperienceData, completion: nil)
                 } else {
                     self?.config.logger.info("iOS 13 or above is required to render an Appcues experience")
                 }

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -93,11 +93,11 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
             switch result {
             case .success(let qualifyResponse):
                 if #available(iOS 13.0, *), let experienceRenderer = self?.container?.resolve(ExperienceRendering.self) {
-                    let experiments = qualifyResponse.experiments ?? [:]
+                    let experiments = qualifyResponse.experiments ?? []
                     let qualifiedExperienceData: [ExperienceData] = qualifyResponse.experiences.map {
                         var experiment: Experiment?
                         if let experimentID = $0.experimentID {
-                            experiment = experiments[experimentID]
+                            experiment = experiments.first { $0.experimentID == experimentID }
                         }
                         return ExperienceData($0, priority: qualifyResponse.renderPriority, published: true, experiment: experiment)
                     }

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -59,7 +59,7 @@ internal struct Experience {
     // TODO: Handle experience-level actions
     let traits: [Trait]
     let steps: [Step]
-    let experimentID: UUID?
+    let experimentID: String?
 
     // Post experience actions
     let redirectURL: URL?
@@ -77,7 +77,10 @@ extension Experience: Decodable {
         case publishedAt
         case traits
         case steps
-        case experimentID = "experiment_id"
+        // note: the actual json key is "experiment_id", however, we use a JSON decoder with
+        // decoder.keyDecodingStrategy = .convertFromSnakeCase
+        // which causes it to convert to "experimentId" prior to usage in these CodingKeys
+        case experimentID = "experimentId"
         case redirectURL = "redirectUrl"
         case nextContentID = "nextContentId"
     }

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -59,6 +59,7 @@ internal struct Experience {
     // TODO: Handle experience-level actions
     let traits: [Trait]
     let steps: [Step]
+    let experimentID: UUID?
 
     // Post experience actions
     let redirectURL: URL?
@@ -70,7 +71,15 @@ internal struct Experience {
 
 extension Experience: Decodable {
     private enum CodingKeys: String, CodingKey {
-        case id, name, type, publishedAt, traits, steps, redirectURL = "redirectUrl", nextContentID = "nextContentId"
+        case id
+        case name
+        case type
+        case publishedAt
+        case traits
+        case steps
+        case experimentID = "experiment_id"
+        case redirectURL = "redirectUrl"
+        case nextContentID = "nextContentId"
     }
 }
 

--- a/Sources/AppcuesKit/Data/Models/Experiment.swift
+++ b/Sources/AppcuesKit/Data/Models/Experiment.swift
@@ -11,29 +11,15 @@ import Foundation
 internal struct Experiment {
     let group: String
     let experimentID: String
+
+    var shouldExecute: Bool {
+        return group != "control"
+    }
 }
 
 extension Experiment: Decodable {
     private enum CodingKeys: String, CodingKey {
         case group
         case experimentID = "experimentId"
-    }
-}
-
-extension Experiment {
-    func shouldExecute() -> Bool {
-        return group != "control"
-    }
-
-    func track(appcues: Appcues?) {
-        guard let analyticsPublisher = appcues?.container.resolve(AnalyticsPublishing.self) else { return }
-
-        analyticsPublisher.publish(TrackingUpdate(
-            type: .event(name: "appcues:experiment_entered", interactive: false),
-            properties: [
-                "experimentId": experimentID,
-                "group": group
-            ],
-            isInternal: true))
     }
 }

--- a/Sources/AppcuesKit/Data/Models/Experiment.swift
+++ b/Sources/AppcuesKit/Data/Models/Experiment.swift
@@ -9,13 +9,5 @@
 import Foundation
 
 internal struct Experiment: Decodable {
-
-    enum ExperimentGroup: String, Decodable {
-        case control
-        case exposed
-    }
-
-    // making this optional so an unknown experiment group does not fail
-    // the entire qualify response deserialization
-    let group: ExperimentGroup?
+    let group: String
 }

--- a/Sources/AppcuesKit/Data/Models/Experiment.swift
+++ b/Sources/AppcuesKit/Data/Models/Experiment.swift
@@ -1,0 +1,21 @@
+//
+//  Experiment.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 10/17/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal struct Experiment: Decodable {
+
+    enum ExperimentGroup: String, Decodable {
+        case control
+        case exposed
+    }
+
+    // making this optional so an unknown experiment group does not fail
+    // the entire qualify response deserialization
+    let group: ExperimentGroup?
+}

--- a/Sources/AppcuesKit/Data/Models/Experiment.swift
+++ b/Sources/AppcuesKit/Data/Models/Experiment.swift
@@ -8,8 +8,16 @@
 
 import Foundation
 
-internal struct Experiment: Decodable {
+internal struct Experiment {
     let group: String
+    let experimentID: String
+}
+
+extension Experiment: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case group
+        case experimentID = "experimentId"
+    }
 }
 
 extension Experiment {
@@ -17,9 +25,8 @@ extension Experiment {
         return group != "control"
     }
 
-    func track(appcues: Appcues?, experimentID: String?) {
-        guard let experimentID = experimentID,
-              let analyticsPublisher = appcues?.container.resolve(AnalyticsPublishing.self) else { return }
+    func track(appcues: Appcues?) {
+        guard let analyticsPublisher = appcues?.container.resolve(AnalyticsPublishing.self) else { return }
 
         analyticsPublisher.publish(TrackingUpdate(
             type: .event(name: "appcues:experiment_entered", interactive: false),

--- a/Sources/AppcuesKit/Data/Models/Experiment.swift
+++ b/Sources/AppcuesKit/Data/Models/Experiment.swift
@@ -11,3 +11,22 @@ import Foundation
 internal struct Experiment: Decodable {
     let group: String
 }
+
+extension Experiment {
+    func shouldExecute() -> Bool {
+        return group != "control"
+    }
+
+    func track(appcues: Appcues?, experimentID: String?) {
+        guard let experimentID = experimentID,
+              let analyticsPublisher = appcues?.container.resolve(AnalyticsPublishing.self) else { return }
+
+        analyticsPublisher.publish(TrackingUpdate(
+            type: .event(name: "appcues:experiment_entered", interactive: false),
+            properties: [
+                "experimentId": experimentID,
+                "group": group
+            ],
+            isInternal: true))
+    }
+}

--- a/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
+++ b/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
@@ -22,7 +22,7 @@ internal struct QualifyResponse {
     let experiences: [Experience]
     let performedQualification: Bool
     let qualificationReason: QualificationReason?
-    let experiments: [UUID: Experiment]?
+    let experiments: [String: Experiment]?
 }
 
 extension QualifyResponse: Decodable {
@@ -39,6 +39,6 @@ extension QualifyResponse: Decodable {
         performedQualification = try container.decode(Bool.self, forKey: .performedQualification)
         // Optional try so that an unknown reason is treated as nil rather than failing the decode.
         qualificationReason = try? container.decode(QualificationReason.self, forKey: .qualificationReason)
-        experiments = try? container.decode([UUID: Experiment].self, forKey: .experiments)
+        experiments = try? container.decode([String: Experiment].self, forKey: .experiments)
     }
 }

--- a/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
+++ b/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
@@ -22,7 +22,7 @@ internal struct QualifyResponse {
     let experiences: [Experience]
     let performedQualification: Bool
     let qualificationReason: QualificationReason?
-    let experiments: [String: Experiment]?
+    let experiments: [Experiment]?
 }
 
 extension QualifyResponse: Decodable {
@@ -39,6 +39,6 @@ extension QualifyResponse: Decodable {
         performedQualification = try container.decode(Bool.self, forKey: .performedQualification)
         // Optional try so that an unknown reason is treated as nil rather than failing the decode.
         qualificationReason = try? container.decode(QualificationReason.self, forKey: .qualificationReason)
-        experiments = try? container.decode([String: Experiment].self, forKey: .experiments)
+        experiments = try? container.decode([Experiment].self, forKey: .experiments)
     }
 }

--- a/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
+++ b/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
@@ -22,6 +22,7 @@ internal struct QualifyResponse {
     let experiences: [Experience]
     let performedQualification: Bool
     let qualificationReason: QualificationReason?
+    let experiments: [UUID: Experiment]?
 }
 
 extension QualifyResponse: Decodable {
@@ -29,6 +30,7 @@ extension QualifyResponse: Decodable {
         case experiences
         case performedQualification
         case qualificationReason
+        case experiments
     }
 
     init(from decoder: Decoder) throws {
@@ -37,5 +39,6 @@ extension QualifyResponse: Decodable {
         performedQualification = try container.decode(Bool.self, forKey: .performedQualification)
         // Optional try so that an unknown reason is treated as nil rather than failing the decode.
         qualificationReason = try? container.decode(QualificationReason.self, forKey: .qualificationReason)
+        experiments = try? container.decode([UUID: Experiment].self, forKey: .experiments)
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
@@ -44,7 +44,11 @@ internal class ExperienceLoader: ExperienceLoading {
         ) { [weak self] (result: Result<Experience, Error>) in
             switch result {
             case .success(let experience):
-                self?.experienceRenderer.show(experience: experience, priority: .normal, published: published, completion: completion)
+                self?.experienceRenderer.show(experience: experience,
+                                              priority: .normal,
+                                              published: published,
+                                              experiment: nil,
+                                              completion: completion)
             case .failure(let error):
                 self?.config.logger.error("Loading experience %{public}s failed with error %{public}s", experienceID, "\(error)")
                 completion?(.failure(error))

--- a/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
@@ -44,11 +44,9 @@ internal class ExperienceLoader: ExperienceLoading {
         ) { [weak self] (result: Result<Experience, Error>) in
             switch result {
             case .success(let experience):
-                self?.experienceRenderer.show(experience: experience,
-                                              priority: .normal,
-                                              published: published,
-                                              experiment: nil,
-                                              completion: completion)
+                self?.experienceRenderer.show(
+                    experience: ExperienceData(experience, priority: .normal, published: published),
+                    completion: completion)
             case .failure(let error):
                 self?.config.logger.error("Loading experience %{public}s failed with error %{public}s", experienceID, "\(error)")
                 completion?(.failure(error))

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -51,7 +51,7 @@ internal class ExperienceRenderer: ExperienceRendering {
         if !(experience.experiment?.shouldExecute() ?? true) {
             // if we get here, it means we did have an experiment, but it was the control group and
             // we should not continue. So track experiment_entered analytics for it (always)..
-            experience.experiment?.track(appcues: appcues, experimentID: experience.experimentID)
+            experience.experiment?.track(appcues: appcues)
             // and exit early
             completion?(.failure(ExperienceRendererError.experimentControl))
             return
@@ -71,7 +71,7 @@ internal class ExperienceRenderer: ExperienceRendering {
 
         // if we get here, either we did not have an experiment, or it is active and did not exit early (not control group).
         // if an active experiment does exist, it should now track the experiment_entered analytic
-        experience.experiment?.track(appcues: appcues, experimentID: experience.experimentID)
+        experience.experiment?.track(appcues: appcues)
 
         // only track analytics on published experiences (not previews)
         // and only add the observer if the state machine is idling, otherwise there's already another experience in-flight

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -17,7 +17,7 @@ internal protocol ExperienceRendering: AnyObject {
               completion: ((Result<Void, Error>) -> Void)?)
     func show(qualifiedExperiences: [Experience],
               priority: RenderPriority,
-              experiments: [UUID: Experiment],
+              experiments: [String: Experiment],
               completion: ((Result<Void, Error>) -> Void)?)
     func show(stepInCurrentExperience stepRef: StepReference, completion: (() -> Void)?)
     func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?)
@@ -67,7 +67,7 @@ internal class ExperienceRenderer: ExperienceRendering {
             analyticsPublisher.publish(TrackingUpdate(
                 type: .event(name: "appcues:experiment_entered", interactive: false),
                 properties: [
-                    "experimentId": experimentID.uuidString.lowercased(),
+                    "experimentId": experimentID,
                     "group": group.rawValue
                 ],
                 isInternal: true))
@@ -118,7 +118,7 @@ internal class ExperienceRenderer: ExperienceRendering {
 
     func show(qualifiedExperiences: [Experience],
               priority: RenderPriority,
-              experiments: [UUID: Experiment],
+              experiments: [String: Experiment],
               completion: ((Result<Void, Error>) -> Void)?) {
         guard let experience = qualifiedExperiences.first else {
             // If given an empty list of qualified experiences, complete with a success because this function has completed without error.

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -48,10 +48,10 @@ internal class ExperienceRenderer: ExperienceRendering {
             return
         }
 
-        if !(experience.experiment?.shouldExecute() ?? true) {
+        guard experience.experiment?.shouldExecute ?? true else {
             // if we get here, it means we did have an experiment, but it was the control group and
             // we should not continue. So track experiment_entered analytics for it (always)..
-            experience.experiment?.track(appcues: appcues)
+            track(experiment: experience.experiment)
             // and exit early
             completion?(.failure(ExperienceRendererError.experimentControl))
             return
@@ -71,7 +71,7 @@ internal class ExperienceRenderer: ExperienceRendering {
 
         // if we get here, either we did not have an experiment, or it is active and did not exit early (not control group).
         // if an active experiment does exist, it should now track the experiment_entered analytic
-        experience.experiment?.track(appcues: appcues)
+        track(experiment: experience.experiment)
 
         // only track analytics on published experiences (not previews)
         // and only add the observer if the state machine is idling, otherwise there's already another experience in-flight
@@ -197,5 +197,20 @@ internal class ExperienceRenderer: ExperienceRendering {
 
     func getCurrentStepIndex() -> Experience.StepIndex? {
         stateMachine.state.currentStepIndex
+    }
+
+    private func track(experiment: Experiment?) {
+        guard let experiment = experiment,
+              let analyticsPublisher = appcues?.container.resolve(AnalyticsPublishing.self) else {
+            return
+        }
+
+        analyticsPublisher.publish(TrackingUpdate(
+            type: .event(name: "appcues:experiment_entered", interactive: false),
+            properties: [
+                "experimentId": experiment.experimentID,
+                "group": experiment.group
+            ],
+            isInternal: true))
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -68,7 +68,7 @@ internal class ExperienceRenderer: ExperienceRendering {
                 type: .event(name: "appcues:experiment_entered", interactive: false),
                 properties: [
                     "experimentId": experimentID.uuidString.lowercased(),
-                    "group": group
+                    "group": group.rawValue
                 ],
                 isInternal: true))
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -62,18 +62,18 @@ internal class ExperienceRenderer: ExperienceRendering {
         }
 
         // check if this experience is part of an active experiment
-        if let experiment = experiment, let experimentID = experience.experimentID, let group = experiment.group {
+        if let experimentID = experience.experimentID, let group = experiment?.group {
             // always send analytics for experiment_entered, with the group
             analyticsPublisher.publish(TrackingUpdate(
                 type: .event(name: "appcues:experiment_entered", interactive: false),
                 properties: [
                     "experimentId": experimentID,
-                    "group": group.rawValue
+                    "group": group
                 ],
                 isInternal: true))
 
             // if this user is in the control group, it should not show
-            if group == .control {
+            if group == "control" {
                 completion?(.failure(ExperienceRendererError.experimentControl))
                 return
             }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -12,10 +12,16 @@ import SwiftUI
 @dynamicMemberLookup
 internal class ExperienceData {
     let model: Experience
+    let priority: RenderPriority
+    let published: Bool
+    let experiment: Experiment?
     private let formState: FormState
 
-    internal init(experience: Experience) {
+    internal init(_ experience: Experience, priority: RenderPriority = .normal, published: Bool = true, experiment: Experiment? = nil) {
         self.model = experience
+        self.priority = priority
+        self.published = published
+        self.experiment = experiment
         self.formState = FormState(experience: experience)
     }
 

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -47,7 +47,7 @@ class ActivityProcessorTests: XCTestCase {
                 let data = try NetworkClient.encoder.encode(activity)
                 XCTAssertEqual(data, body)
                 onPostExpectation.fulfill()
-                completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil)))
+                completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
             } catch {
                 XCTFail()
             }
@@ -95,7 +95,7 @@ class ActivityProcessorTests: XCTestCase {
                     XCTAssertEqual("user1", userID)
                     let data = try NetworkClient.encoder.encode(activity1)
                     XCTAssertEqual(data, body)
-                    completion(.success(QualifyResponse(experiences: [], performedQualification: false, qualificationReason: nil)))
+                    completion(.success(QualifyResponse(experiences: [], performedQualification: false, qualificationReason: nil, experiments: nil)))
                     retryExpectation.fulfill()
                 } else if postCount == 3 {
                     // this should be the synchronous attempt for activity 2
@@ -104,7 +104,7 @@ class ActivityProcessorTests: XCTestCase {
                     XCTAssertEqual("user2", userID)
                     let data = try NetworkClient.encoder.encode(activity2)
                     XCTAssertEqual(data, body)
-                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil)))
+                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
                     onPostExpectation2.fulfill()
                 } else {
                     XCTFail()
@@ -159,7 +159,7 @@ class ActivityProcessorTests: XCTestCase {
                     XCTAssertEqual("user2", userID)
                     let data = try NetworkClient.encoder.encode(activity2)
                     XCTAssertEqual(data, body)
-                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil)))
+                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
                     onPostExpectation2.fulfill()
                 } else {
                     XCTFail()
@@ -266,7 +266,7 @@ class ActivityProcessorTests: XCTestCase {
                     XCTAssertEqual("user2", userID)
                     let data = try NetworkClient.encoder.encode(activity2)
                     XCTAssertEqual(data, body)
-                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil)))
+                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
                     onPostExpectation2.fulfill()
                 } else {
                     XCTFail()
@@ -307,7 +307,7 @@ class ActivityProcessorTests: XCTestCase {
         let activity = generateMockActivity(userID: "user1", event: Event(name: "event1", attributes: ["my_key": "my_value1", "another_key": 33]))
 
         appcues.networking.onPost = { endpoint, body, completion in
-            completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil)))
+            completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
             onPostExpectation.fulfill()
         }
 
@@ -326,7 +326,7 @@ class ActivityProcessorTests: XCTestCase {
         return Activity(accountID: "00000", userID: userID, events: [event], profileUpdate: nil, groupID: nil, groupUpdate: nil)
     }
 
-    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
+    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], experimentID: nil, redirectURL: nil, nextContentID: nil)
 
 }
 

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -29,9 +29,9 @@ class ExperienceLoaderTests: XCTestCase {
             )
             return .success(Experience.mock)
         }
-        appcues.experienceRenderer.onShowExperience = { experience, priority, published, experiment, completion in
-            XCTAssertEqual(priority, .normal)
-            XCTAssertTrue(published)
+        appcues.experienceRenderer.onShowExperience = { experience, completion in
+            XCTAssertEqual(experience.priority, .normal)
+            XCTAssertTrue(experience.published)
             completion?(.success(()))
         }
 
@@ -57,9 +57,9 @@ class ExperienceLoaderTests: XCTestCase {
             )
             return .success(Experience.mock)
         }
-        appcues.experienceRenderer.onShowExperience = { experience, priority, published, experiment, completion in
-            XCTAssertEqual(priority, .normal)
-            XCTAssertFalse(published)
+        appcues.experienceRenderer.onShowExperience = { experience, completion in
+            XCTAssertEqual(experience.priority, .normal)
+            XCTAssertFalse(experience.published)
             completion?(.success(()))
         }
 

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -29,7 +29,7 @@ class ExperienceLoaderTests: XCTestCase {
             )
             return .success(Experience.mock)
         }
-        appcues.experienceRenderer.onShowExperience = { experience, priority, published, completion in
+        appcues.experienceRenderer.onShowExperience = { experience, priority, published, experiment, completion in
             XCTAssertEqual(priority, .normal)
             XCTAssertTrue(published)
             completion?(.success(()))
@@ -57,7 +57,7 @@ class ExperienceLoaderTests: XCTestCase {
             )
             return .success(Experience.mock)
         }
-        appcues.experienceRenderer.onShowExperience = { experience, priority, published, completion in
+        appcues.experienceRenderer.onShowExperience = { experience, priority, published, experiment, completion in
             XCTAssertEqual(priority, .normal)
             XCTAssertFalse(published)
             completion?(.success(()))

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -314,7 +314,7 @@ class ExperienceRendererTests: XCTestCase {
         let failureExpectation = expectation(description: "Failure completion called")
         let presentExpectation = expectation(description: "Experience presented")
         presentExpectation.isInverted = true
-        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
         let experiment = Experiment(group: .control)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
@@ -335,7 +335,7 @@ class ExperienceRendererTests: XCTestCase {
         // Arrange
         let completionExpectation = expectation(description: "Completion called")
         let presentExpectation = expectation(description: "Experience presented")
-        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
         let experiment = Experiment(group: .exposed)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
@@ -355,11 +355,11 @@ class ExperienceRendererTests: XCTestCase {
     func testExperimentEnteredControlAnalytics() throws {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
-        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
         let experiment = Experiment(group: .control)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let properties: [String: Any] = [
-            "experimentId": experimentID.uuidString.lowercased(),
+            "experimentId": experimentID,
             "group": "control"
         ]
         var experimentUpdate: TrackingUpdate?
@@ -383,11 +383,11 @@ class ExperienceRendererTests: XCTestCase {
     func testExperimentEnteredExposedAnalytics() throws {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
-        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
         let experiment = Experiment(group: .exposed)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let properties: [String: Any] = [
-            "experimentId": experimentID.uuidString.lowercased(),
+            "experimentId": experimentID,
             "group": "exposed"
         ]
         var experimentUpdate: TrackingUpdate?

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -35,7 +35,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -60,7 +60,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -68,7 +68,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .normal, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .normal, published: true, experiment: nil) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -94,7 +94,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -103,7 +103,7 @@ class ExperienceRendererTests: XCTestCase {
         // NOTE: No waiting for initial .show() to complete like the test case above does.
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .normal, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .normal, published: true, experiment: nil) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -124,7 +124,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -132,7 +132,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation, presentExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
             print(result)
             if case .failure(ExperienceStateMachine.ExperienceError.experienceAlreadyActive) = result {
                 failureExpectation.fulfill()
@@ -158,7 +158,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: false) { result in
+        experienceRenderer.show(experience: experience.model, priority: .low, published: false, experiment: nil) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -190,7 +190,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(qualifiedExperiences: [brokenExperience.model, validExperience.model], priority: .low) { result in
+        experienceRenderer.show(qualifiedExperiences: [brokenExperience.model, validExperience.model], priority: .low, experiments: [:]) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -209,7 +209,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         var preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, completion: nil)
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil, completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Now that we've shown the first step, set the expectation for the 2nd step transition that we're testing
@@ -237,7 +237,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, completion: nil)
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil, completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -263,13 +263,13 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: firstExperienceInstance.model, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: firstExperienceInstance.model, priority: .low, published: true, experiment: nil) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
         }
 
-        experienceRenderer.show(experience: secondExperienceInstance.model, priority: .low, published: true) { result in
+        experienceRenderer.show(experience: secondExperienceInstance.model, priority: .low, published: true, experiment: nil) { result in
             if case let .failure(error) = result {
                 XCTAssertEqual(
                     error as! ExperienceStateMachine.ExperienceError,
@@ -297,7 +297,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, completion: nil)
+        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil, completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -315,7 +315,7 @@ class ExperienceRendererTests: XCTestCase {
         let presentExpectation = expectation(description: "Experience presented")
         presentExpectation.isInverted = true
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: .control)
+        let experiment = Experiment(group: "control")
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
@@ -336,7 +336,7 @@ class ExperienceRendererTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
         let presentExpectation = expectation(description: "Experience presented")
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: .exposed)
+        let experiment = Experiment(group: "exposed")
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
@@ -356,7 +356,7 @@ class ExperienceRendererTests: XCTestCase {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: .control)
+        let experiment = Experiment(group: "control")
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let properties: [String: Any] = [
             "experimentId": experimentID,
@@ -384,7 +384,7 @@ class ExperienceRendererTests: XCTestCase {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: .exposed)
+        let experiment = Experiment(group: "exposed")
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let properties: [String: Any] = [
             "experimentId": experimentID,

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -35,7 +35,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -60,7 +60,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -68,7 +68,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .normal, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -94,7 +94,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -103,7 +103,7 @@ class ExperienceRendererTests: XCTestCase {
         // NOTE: No waiting for initial .show() to complete like the test case above does.
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .normal, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -124,7 +124,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -132,7 +132,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation, presentExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
             print(result)
             if case .failure(ExperienceStateMachine.ExperienceError.experienceAlreadyActive) = result {
                 failureExpectation.fulfill()
@@ -158,7 +158,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: false, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: false)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -190,7 +190,9 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(qualifiedExperiences: [brokenExperience.model, validExperience.model], priority: .low, experiments: [:]) { result in
+        experienceRenderer.show(qualifiedExperiences: [
+            ExperienceData(brokenExperience.model, priority: .low),
+            ExperienceData(validExperience.model, priority: .low)]) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -209,7 +211,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         var preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil, completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Now that we've shown the first step, set the expectation for the 2nd step transition that we're testing
@@ -237,7 +239,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil, completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -263,13 +265,13 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: firstExperienceInstance.model, priority: .low, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(firstExperienceInstance.model, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
         }
 
-        experienceRenderer.show(experience: secondExperienceInstance.model, priority: .low, published: true, experiment: nil) { result in
+        experienceRenderer.show(experience: ExperienceData(secondExperienceInstance.model, priority: .low, published: true)) { result in
             if case let .failure(error) = result {
                 XCTAssertEqual(
                     error as! ExperienceStateMachine.ExperienceError,
@@ -297,7 +299,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: nil, completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -321,7 +323,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: experiment) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment)) { result in
             if case .failure = result {
                 failureExpectation.fulfill()
             }
@@ -342,7 +344,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: experiment) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -373,7 +375,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: experiment, completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -401,7 +403,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: experience.model, priority: .low, published: true, experiment: experiment, completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -317,7 +317,7 @@ class ExperienceRendererTests: XCTestCase {
         let presentExpectation = expectation(description: "Experience presented")
         presentExpectation.isInverted = true
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "control")
+        let experiment = Experiment(group: "control", experimentID: experimentID)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
@@ -338,7 +338,7 @@ class ExperienceRendererTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
         let presentExpectation = expectation(description: "Experience presented")
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "exposed")
+        let experiment = Experiment(group: "exposed", experimentID: experimentID)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
@@ -358,7 +358,7 @@ class ExperienceRendererTests: XCTestCase {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "control")
+        let experiment = Experiment(group: "control", experimentID: experimentID)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let properties: [String: Any] = [
             "experimentId": experimentID,
@@ -386,7 +386,7 @@ class ExperienceRendererTests: XCTestCase {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
         let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "exposed")
+        let experiment = Experiment(group: "exposed", experimentID: experimentID)
         let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
         let properties: [String: Any] = [
             "experimentId": experimentID,

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -236,7 +236,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Arrange
         let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], experimentID: nil, redirectURL: nil, nextContentID: nil)
         let initialState: State = .idling
-        let action: Action = .startExperience(ExperienceData(experience: experience))
+        let action: Action = .startExperience(ExperienceData(experience))
         let stateMachine = givenState(is: initialState)
 
         // Act

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -234,7 +234,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsIdling_whenStartExperienceWithNoSteps_noTransition() throws {
         // Arrange
-        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
+        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], experimentID: nil, redirectURL: nil, nextContentID: nil)
         let initialState: State = .idling
         let action: Action = .startExperience(ExperienceData(experience: experience))
         let stateMachine = givenState(is: initialState)

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -122,8 +122,8 @@ class MockExperienceRenderer: ExperienceRendering {
         onShowStep?(stepRef, completion)
     }
 
-    var onShowQualifiedExperiences: (([Experience], RenderPriority, [UUID: Experiment], ((Result<Void, Error>) -> Void)?) -> Void)?
-    func show(qualifiedExperiences: [Experience], priority: RenderPriority, experiments: [UUID: Experiment], completion: ((Result<Void, Error>) -> Void)?) {
+    var onShowQualifiedExperiences: (([Experience], RenderPriority, [String: Experiment], ((Result<Void, Error>) -> Void)?) -> Void)?
+    func show(qualifiedExperiences: [Experience], priority: RenderPriority, experiments: [String: Experiment], completion: ((Result<Void, Error>) -> Void)?) {
         onShowQualifiedExperiences?(qualifiedExperiences, priority, experiments, completion)
     }
 

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -112,9 +112,9 @@ class MockExperienceLoader: ExperienceLoading {
 
 class MockExperienceRenderer: ExperienceRendering {
 
-    var onShowExperience: ((Experience, RenderPriority, Bool, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func show(experience: Experience, priority: RenderPriority, published: Bool, completion: ((Result<Void, Error>) -> Void)?) {
-        onShowExperience?(experience, priority, published, completion)
+    var onShowExperience: ((Experience, RenderPriority, Bool, Experiment?, ((Result<Void, Error>) -> Void)?) -> Void)?
+    func show(experience: Experience, priority: RenderPriority, published: Bool, experiment: Experiment?, completion: ((Result<Void, Error>) -> Void)?) {
+        onShowExperience?(experience, priority, published, experiment, completion)
     }
 
     var onShowStep: ((StepReference, (() -> Void)?) -> Void)?
@@ -122,9 +122,9 @@ class MockExperienceRenderer: ExperienceRendering {
         onShowStep?(stepRef, completion)
     }
 
-    var onShowQualifiedExperiences: (([Experience], RenderPriority, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func show(qualifiedExperiences: [Experience], priority: RenderPriority, completion: ((Result<Void, Error>) -> Void)?) {
-        onShowQualifiedExperiences?(qualifiedExperiences, priority, completion)
+    var onShowQualifiedExperiences: (([Experience], RenderPriority, [UUID: Experiment], ((Result<Void, Error>) -> Void)?) -> Void)?
+    func show(qualifiedExperiences: [Experience], priority: RenderPriority, experiments: [UUID: Experiment], completion: ((Result<Void, Error>) -> Void)?) {
+        onShowQualifiedExperiences?(qualifiedExperiences, priority, experiments, completion)
     }
 
     var onDismissCurrentExperience: ((Bool, ((Result<Void, Error>) -> Void)?) -> Void)?

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -112,9 +112,9 @@ class MockExperienceLoader: ExperienceLoading {
 
 class MockExperienceRenderer: ExperienceRendering {
 
-    var onShowExperience: ((Experience, RenderPriority, Bool, Experiment?, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func show(experience: Experience, priority: RenderPriority, published: Bool, experiment: Experiment?, completion: ((Result<Void, Error>) -> Void)?) {
-        onShowExperience?(experience, priority, published, experiment, completion)
+    var onShowExperience: ((ExperienceData, ((Result<Void, Error>) -> Void)?) -> Void)?
+    func show(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?) {
+        onShowExperience?(experience, completion)
     }
 
     var onShowStep: ((StepReference, (() -> Void)?) -> Void)?
@@ -122,9 +122,9 @@ class MockExperienceRenderer: ExperienceRendering {
         onShowStep?(stepRef, completion)
     }
 
-    var onShowQualifiedExperiences: (([Experience], RenderPriority, [String: Experiment], ((Result<Void, Error>) -> Void)?) -> Void)?
-    func show(qualifiedExperiences: [Experience], priority: RenderPriority, experiments: [String: Experiment], completion: ((Result<Void, Error>) -> Void)?) {
-        onShowQualifiedExperiences?(qualifiedExperiences, priority, experiments, completion)
+    var onShowQualifiedExperiences: (([ExperienceData], ((Result<Void, Error>) -> Void)?) -> Void)?
+    func show(qualifiedExperiences: [ExperienceData], completion: ((Result<Void, Error>) -> Void)?) {
+        onShowQualifiedExperiences?(qualifiedExperiences, completion)
     }
 
     var onDismissCurrentExperience: ((Bool, ((Result<Void, Error>) -> Void)?) -> Void)?

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -68,6 +68,7 @@ extension Experience {
                     Step.Child(fixedID: "03652bd5-f0cb-44f0-9274-e95b4441d857")
                 )
             ],
+            experimentID: nil,
             redirectURL: nil,
             nextContentID: "abc")
     }
@@ -87,6 +88,7 @@ extension Experience {
                     ]
                 )
             ],
+            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
     }
@@ -106,6 +108,7 @@ extension Experience {
                     ]
                 )
             ],
+            experimentID: nil,
             redirectURL: nil,
             nextContentID: "abc")
     }

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -113,7 +113,7 @@ extension Experience {
             nextContentID: "abc")
     }
 
-    static func mockWithExperiment(experimentID: UUID) -> Experience {
+    static func mockWithExperiment(experimentID: String) -> Experience {
         Experience(
             id: UUID(uuidString: "09f3b0a2-c4b1-4bbe-9fb3-81061169f5f5")!,
             name: "Mock Experience: Single step with experiment",
@@ -189,7 +189,7 @@ extension ExperienceData {
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
         ExperienceData(experience: .mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
     }
-    static func mockWithExperiment(experimentID: UUID) -> ExperienceData { ExperienceData(experience: .mockWithExperiment(experimentID: experimentID)) }
+    static func mockWithExperiment(experimentID: String) -> ExperienceData { ExperienceData(experience: .mockWithExperiment(experimentID: experimentID)) }
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -113,6 +113,26 @@ extension Experience {
             nextContentID: "abc")
     }
 
+    static func mockWithExperiment(experimentID: UUID) -> Experience {
+        Experience(
+            id: UUID(uuidString: "09f3b0a2-c4b1-4bbe-9fb3-81061169f5f5")!,
+            name: "Mock Experience: Single step with experiment",
+            type: "mobile",
+            publishedAt: 1632142800000,
+            traits: [],
+            steps: [
+                Experience.Step(
+                    fixedID: "05d19cf7-60b5-45de-ae37-13a1706d4e37",
+                    children: [
+                        Step.Child(fixedID: "c25236ad-9587-4865-8b58-2817f1c1421a")
+                    ]
+                )
+            ],
+            experimentID: experimentID,
+            redirectURL: nil,
+            nextContentID: nil)
+    }
+
 }
 
 extension Experience.Step {
@@ -169,6 +189,7 @@ extension ExperienceData {
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
         ExperienceData(experience: .mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
     }
+    static func mockWithExperiment(experimentID: UUID) -> ExperienceData { ExperienceData(experience: .mockWithExperiment(experimentID: experimentID)) }
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -184,12 +184,12 @@ extension Experience.Step.Child {
 }
 
 extension ExperienceData {
-    static var mock: ExperienceData { ExperienceData(experience: .mock) }
-    static var singleStepMock: ExperienceData { ExperienceData(experience: .singleStepMock) }
+    static var mock: ExperienceData { ExperienceData(.mock) }
+    static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock) }
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
-        ExperienceData(experience: .mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
+        ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
     }
-    static func mockWithExperiment(experimentID: String) -> ExperienceData { ExperienceData(experience: .mockWithExperiment(experimentID: experimentID)) }
+    static func mockWithExperiment(experimentID: String) -> ExperienceData { ExperienceData(.mockWithExperiment(experimentID: experimentID)) }
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -60,7 +60,7 @@ class TraitComposerTests: XCTestCase {
             nextContentID: nil)
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -91,7 +91,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: backdropDecoratingExpectation)
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -113,7 +113,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: expectation(description: "Backdrop decorate called"))
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 1, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 1, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -129,7 +129,7 @@ class TraitComposerTests: XCTestCase {
         let experience = makeTestExperience()
 
         // Act/Assert
-        XCTAssertThrowsError(try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0)))
+        XCTAssertThrowsError(try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0)))
     }
 
     func testPackagePresenter() throws {
@@ -163,7 +163,7 @@ class TraitComposerTests: XCTestCase {
 
 
         // Act
-        let package = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        let package = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         try package.presenter(nil)
         package.dismisser(nil)
@@ -198,7 +198,7 @@ class TraitComposerTests: XCTestCase {
             experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
-        let experienceData = ExperienceData(experience: experience)
+        let experienceData = ExperienceData(experience)
 
         // Act
         XCTAssertThrowsError(try traitComposer.package(experience: experienceData, stepIndex: Experience.StepIndex(group: 0, item: 0))) { error in

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -55,8 +55,9 @@ class TraitComposerTests: XCTestCase {
             steps: [
                 .child(Experience.Step.Child(traits: []))
             ],
-        redirectURL: nil,
-        nextContentID: nil)
+            experimentID: nil,
+            redirectURL: nil,
+            nextContentID: nil)
 
         // Act
         _ = try traitComposer.package(experience: ExperienceData(experience: experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
@@ -156,6 +157,7 @@ class TraitComposerTests: XCTestCase {
             steps: [
                 .child(Experience.Step.Child(traits: []))
             ],
+            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
 
@@ -193,6 +195,7 @@ class TraitComposerTests: XCTestCase {
                     actions: [:]
                 ))
             ],
+            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
         let experienceData = ExperienceData(experience: experience)
@@ -268,8 +271,9 @@ class TraitComposerTests: XCTestCase {
                         ])
                 ]))
             ],
-        redirectURL: nil,
-        nextContentID: nil)
+            experimentID: nil,
+            redirectURL: nil,
+            nextContentID: nil)
     }
 }
 


### PR DESCRIPTION
* decode a top level `experiments` mapping on the `QualificationResponse`
* add support for an optional `experiment_id` on `Experience`
* modify `ExperienceRenderer` to support experiment logic, if there is a matching experiment for an `Experience` being rendered:
    * if group is `control` - block rendering the experience and move on to next priority, if any
    * if not (group `exposed`) - continue rendering the experience as usual
    * in both cases, trigger an `appcues:experiment_entered` analytic for the user, with the group and experiment ID

update: to make the `ExperienceRenderer` portion more compact and flexible - it now operates on `ExperienceData` objects passed in, rather than `Experience`.  `ExperienceData` can then expand to contain more metadata about the `Experience`, such as the `Experiment?` added for this use case.