### PR TITLE
Fix equal width stack layout

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
@@ -47,7 +47,6 @@ internal struct AppcuesStack: View {
                     AnyView($0.view.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: itemAlignment ?? .center))
                 }
             }
-            .fixedSize(horizontal: false, vertical: true)
             .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
         }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
@@ -36,14 +36,14 @@ internal struct AppcuesStack: View {
             .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
         case (.horizontal, .equal):
-            HStack(alignment: style.verticalAlignment, spacing: CGFloat(model.spacing ?? 0)) {
+            EqualWidthStack(alignment: style.verticalAlignment, spacing: CGFloat(model.spacing ?? 0), itemCount: model.items.count) {
                 ForEach(model.items) {
                     let itemAlignment = Alignment(
                         vertical: $0.style?.verticalAlignment,
                         horizontal: $0.style?.horizontalAlignment
                     )
-                    // `maxWidth: .infinity` sets equal widths
-                    // `maxHeight: .infinity` combined with `.fixedSize` below set equal heights
+                    // `maxWidth: .infinity` allows for horizontal alignment options to work
+                    // `maxHeight: .infinity` allows for vertical alignment options to work
                     AnyView($0.view.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: itemAlignment ?? .center))
                 }
             }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -21,5 +21,6 @@ internal struct AppcuesText: View {
             .applyTextStyle(style)
             .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
@@ -32,7 +32,8 @@ internal struct EqualWidthStack<Content: View>: View {
             Group {
                 content
             }
-            .frame(width: stackWidth / CGFloat(itemCount))
+            // maxWidth instead of width to allow the width to shrink after a resize or rotation.
+            .frame(maxWidth: stackWidth / CGFloat(itemCount))
             // Ensure the context never escapes the designated frame.
             .clipped()
         }

--- a/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
@@ -1,0 +1,54 @@
+//
+//  EqualWidthStack.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-10-12.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+private struct StackWidthPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        // no-op since there's only a single value
+    }
+}
+
+@available(iOS 13.0, *)
+internal struct EqualWidthStack<Content: View>: View {
+    @State private var stackWidth: CGFloat = 0
+
+    let alignment: VerticalAlignment
+    let spacing: CGFloat
+    let itemCount: Int
+
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        HStack(alignment: alignment, spacing: spacing) {
+            Group {
+                content
+            }
+            .frame(width: stackWidth / CGFloat(itemCount))
+            // Ensure the context never escapes the designated frame.
+            .clipped()
+        }
+        // Force a width so that it's not zero for the initial calculation.
+        .frame(maxWidth: .infinity)
+        // Attach GeometryReader to the background rather than wrapping the HStack to avoid the
+        // undesired behavior where the GeometryReader takes all available space.
+        .background(GeometryReader { geometry in
+            // GeometryReader can't modify the @State value directly because modifying the state
+            // during view update causes undefined behavior. Instead, use a PreferenceKey.
+            Color.clear
+                .preference(key: StackWidthPreferenceKey.self, value: geometry.size.width)
+        })
+        .onPreferenceChange(StackWidthPreferenceKey.self) {
+            // Set the width for another next layout pass.
+            stackWidth = $0
+        }
+    }
+}


### PR DESCRIPTION
_Behold_, after a week of experimenting and testing, a new `EqualWidthStack` component that does what you could do in UIKit with a `UIStackView` and `distribution = .fillEqually`.

Basically we want to measure the width available to the stack and set each the width of each item to `width/items.count`. The comments in the code hopefully explain why it is the way it is.

A few helpful references for posterity:
- https://www.fivestars.blog/articles/swiftui-share-layout-information/
- https://www.fivestars.blog/articles/preferencekey-reduce/
- https://www.swiftbysundell.com/articles/swiftui-layout-system-guide-part-2/#geometry-preferences-and-layout-dependencies