### PR TITLE
Add SdkMetrics to capture timings around experience rendering

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/ActivityProcessor.swift
+++ b/Sources/AppcuesKit/Data/Analytics/ActivityProcessor.swift
@@ -24,7 +24,7 @@ internal class ActivityProcessor: ActivityProcessing {
     // sent as first time requests - not fail/retry items that should be sent again...yet
     //
     // keep this list so they can be ignored when gathering up the stored files to attempt a retry with
-    private var processingItems: Set<String> = []
+    private var processingItems: Set<UUID> = []
 
     private let syncQueue = DispatchQueue(label: "appcues-activity-processor")
 
@@ -136,7 +136,8 @@ internal class ActivityProcessor: ActivityProcessing {
 
     private func handleActivity(activity: ActivityStorage, completion: @escaping () -> Void) {
         networking.post(to: APIEndpoint.activity(userID: activity.userID),
-                        body: activity.data) { [weak self] (result: Result<ActivityResponse, Error>) in
+                        body: activity.data,
+                        requestId: nil) { [weak self] (result: Result<ActivityResponse, Error>) in
             guard let self = self else { return }
             var success = true
             if case let .failure(error) = result, error.requiresRetry { success = false }
@@ -147,7 +148,8 @@ internal class ActivityProcessor: ActivityProcessing {
 
     private func handleQualify(activity: ActivityStorage, completion: @escaping (Result<QualifyResponse, Error>) -> Void) {
         networking.post(to: APIEndpoint.qualify(userID: activity.userID),
-                        body: activity.data) { [weak self] (result: Result<QualifyResponse, Error>) in
+                        body: activity.data,
+                        requestId: activity.requestID) { [weak self] (result: Result<QualifyResponse, Error>) in
             guard let self = self else { return }
             var success = true
             if case let .failure(error) = result, error.requiresRetry { success = false }

--- a/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
+++ b/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
@@ -90,5 +90,8 @@ internal class SessionMonitor: SessionMonitoring {
 
         // ensure any pending in-memory analytics get processed asap
         tracker.flush()
+
+        // clear out pending metrics
+        SdkMetrics.clear()
     }
 }

--- a/Sources/AppcuesKit/Data/Analytics/Storage/ActivityFileStorage.swift
+++ b/Sources/AppcuesKit/Data/Analytics/Storage/ActivityFileStorage.swift
@@ -43,14 +43,14 @@ internal class ActivityFileStorage: ActivityStoring {
 
         let jsonString = activity.toString()
         if let jsonData = jsonString.data(using: .utf8) {
-            let file = storageDirectory.appendingPathComponent(activity.requestID)
+            let file = storageDirectory.appendingPathComponent(activity.requestID.uuidString)
             // will replace if exists (shouldnt)
             FileManager.default.createFile(atPath: file.path, contents: jsonData)
         }
     }
 
     func remove(_ activity: ActivityStorage) {
-        let file = storageDirectory.appendingPathComponent(activity.requestID)
+        let file = storageDirectory.appendingPathComponent(activity.requestID.uuidString)
         try? FileManager.default.removeItem(atPath: file.path)
     }
 

--- a/Sources/AppcuesKit/Data/Analytics/Storage/ActivityStorage.swift
+++ b/Sources/AppcuesKit/Data/Analytics/Storage/ActivityStorage.swift
@@ -13,7 +13,7 @@ import Foundation
 internal struct ActivityStorage: Codable {
     let accountID: String
     let userID: String
-    let requestID: String
+    let requestID: UUID
     let data: Data
     let created: Date
 
@@ -28,7 +28,7 @@ internal struct ActivityStorage: Codable {
         }
         self.accountID = activity.accountID
         self.userID = activity.userID
-        self.requestID = activity.requestID.uuidString
+        self.requestID = activity.requestID
         self.data = data
         self.created = Date()
     }

--- a/Sources/AppcuesKit/Data/Models/SdkMetrics.swift
+++ b/Sources/AppcuesKit/Data/Models/SdkMetrics.swift
@@ -1,0 +1,81 @@
+//
+//  SdkMetrics.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 10/18/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal struct SdkMetrics {
+
+    private static var metrics: [UUID: SdkMetrics] = [:]
+
+    // the time when the tracking was first captured by the SDK - the call to `track(event)` for instance
+    private var trackedAt: Date?
+
+    // the time when the tracking request was sent out in an API call to check for qualification
+    private var requestedAt: Date?
+
+    // the time when the network response was received
+    private var respondedAt: Date?
+
+    static func clear() {
+        metrics.removeAll()
+    }
+
+    static func tracked(_ id: UUID, time: Date?) {
+        // only if a tracking time is known, allow creation of a new record
+        // other network calls not related to a captured tracking time, like batched background analytics
+        // or requests to get an experience by ID, are not tracked
+        guard let time = time else { return }
+        metrics[id, default: SdkMetrics()].trackedAt = time
+    }
+
+    static func requested(_ id: UUID?, time: Date = Date()) {
+        guard let id = id else { return }
+        // only capture if record is already created -- a known analytics tracking time
+        metrics[id]?.requestedAt = time
+    }
+
+    static func responded(_ id: UUID?, time: Date = Date()) {
+        guard let id = id else { return }
+        // only capture if record is already created -- a known analytics tracking time
+        metrics[id]?.respondedAt = time
+    }
+
+    static func remove(_ id: UUID) {
+        metrics.removeValue(forKey: id)
+    }
+
+    static func trackRender(_ id: UUID?) -> [String: Any] {
+        guard let id = id,
+              let timings = metrics[id],
+              let trackedAt = timings.trackedAt,
+              let requestedAt = timings.requestedAt,
+              let respondedAt = timings.respondedAt else {
+            return [:]
+        }
+
+        let renderedAt = Date()
+
+        let timeTotal = Int(renderedAt.millisecondsSince1970 - trackedAt.millisecondsSince1970)
+        let timeAfterResponse = Int(renderedAt.millisecondsSince1970 - respondedAt.millisecondsSince1970)
+        let timeNetwork = Int(respondedAt.millisecondsSince1970 - requestedAt.millisecondsSince1970)
+        let timeBeforeRequest = Int(requestedAt.millisecondsSince1970 - trackedAt.millisecondsSince1970)
+
+        // remove this item now that we've tracked it
+        remove(id)
+
+        return [
+            "_sdkMetrics": [
+                "timeBeforeRequest": timeBeforeRequest,
+                "timeNetwork": timeNetwork,
+                "timeAfterResponse": timeAfterResponse,
+                "timeTotal": timeTotal
+            ]
+        ]
+
+    }
+}

--- a/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
+++ b/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
@@ -37,9 +37,10 @@ extension KeyedEncodingContainer where K == DynamicCodingKeys {
         try dict?.forEach { key, value in
             let codingKey = DynamicCodingKeys(key: key)
 
-            if (key == "_identity" || key == "interactionData"), let nestedProps = value as? [String: Any] {
+            if (key == "_identity" || key == "interactionData" || key == "_sdkMetrics"), let nestedProps = value as? [String: Any] {
                 // "_identity" is a special case - the Appcues auto-properties that supply app/user/session data
                 // "interactionData" is a special case where a nested object is expected
+                // "_sdkMetrics" is a special case - the Experience rendering timing metrics
                 var autopropContainer = self.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: codingKey)
                 try autopropContainer.encodeSkippingInvalid(nestedProps)
             } else if #available(iOS 13.0, *), let stepState = value as? ExperienceData.StepState {

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
@@ -335,6 +335,12 @@ extension DebugViewModel {
                 .map { ($0.key, String(describing: $0.value)) }
             properties["_identity"] = nil
 
+            // flatten the nested `_sdkMetrics` properties into individual top level items.
+            let metricProps = (properties["_sdkMetrics"] as? [String: Any] ?? [:])
+                .sortedWithAutoProperties()
+                .map { ($0.key, String(describing: $0.value)) }
+            properties["_sdkMetrics"] = nil
+
             // flatten the nested `interactionData` properties into individual top level items.
             var interactionData = (properties["interactionData"] as? [String: Any] ?? [:])
             let formResponse = (interactionData["formResponse"] as? ExperienceData.StepState)?.formattedAsDebugData()
@@ -363,6 +369,10 @@ extension DebugViewModel {
 
             if !autoProps.isEmpty {
                 groups.append(("Identity Auto-properties", autoProps))
+            }
+
+            if !metricProps.isEmpty {
+                groups.append(("SDK Metrics", metricProps))
             }
 
             return groups

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -256,6 +256,7 @@ extension ExperienceStateMachine {
             objc_setAssociatedObject(package.wrapperController, &UIKitScreenTracker.untrackedScreenKey, true, .OBJC_ASSOCIATION_RETAIN)
 
             do {
+                SdkMetrics.renderStart(experience.requestID)
                 try package.presenter {
                     try? machine.transition(.renderStep)
                 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -76,7 +76,9 @@ extension ExperienceStateMachine {
                 break
             case let .success(.renderingStep(experience, stepIndex, _, isFirst: true)):
                 storage.lastContentShownAt = Date()
-                trackLifecycleEvent(.experienceStarted, LifecycleEvent.properties(experience))
+                let metrics = SdkMetrics.trackRender(experience.requestID)
+                let experienceStartProps = LifecycleEvent.properties(experience).merging(metrics) { _, new in new }
+                trackLifecycleEvent(.experienceStarted, experienceStartProps)
                 trackLifecycleEvent(.stepSeen, LifecycleEvent.properties(experience, stepIndex))
             case let .success(.renderingStep(experience, stepIndex, _, isFirst: false)):
                 trackLifecycleEvent(.stepSeen, LifecycleEvent.properties(experience, stepIndex))

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -15,13 +15,19 @@ internal class ExperienceData {
     let priority: RenderPriority
     let published: Bool
     let experiment: Experiment?
+    let requestID: UUID?
     private let formState: FormState
 
-    internal init(_ experience: Experience, priority: RenderPriority = .normal, published: Bool = true, experiment: Experiment? = nil) {
+    internal init(_ experience: Experience,
+                  priority: RenderPriority = .normal,
+                  published: Bool = true,
+                  experiment: Experiment? = nil,
+                  requestID: UUID? = nil) {
         self.model = experience
         self.priority = priority
         self.published = published
         self.experiment = experiment
+        self.requestID = requestID
         self.formState = FormState(experience: experience)
     }
 

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -40,7 +40,7 @@ class ActivityProcessorTests: XCTestCase {
         let onPostExpectation = expectation(description: "Activity request")
         let resultCallbackExpectation = expectation(description: "Process result")
         let activity = generateMockActivity(userID: "user1", event: Event(name: "eventName", attributes: ["my_key": "my_value", "another_key": 33]))
-        appcues.networking.onPost = { endpoint, body, completion in
+        appcues.networking.onPost = { endpoint, body, requestId, completion in
             do {
                 let apiEndpoint = try XCTUnwrap(endpoint as? APIEndpoint)
                 guard case .qualify(activity.userID) = apiEndpoint else { return XCTFail() }
@@ -80,7 +80,7 @@ class ActivityProcessorTests: XCTestCase {
         let activity2 = generateMockActivity(userID: "user2", event: Event(name: "event2", attributes: ["my_key": "my_value2", "another_key": 34]))
         var postCount = 0
 
-        appcues.networking.onPost = { endpoint, body, completion in
+        appcues.networking.onPost = { endpoint, body, requestId, completion in
             do {
                 postCount += 1
                 if postCount == 1 {
@@ -145,7 +145,7 @@ class ActivityProcessorTests: XCTestCase {
         let activity2 = generateMockActivity(userID: "user2", event: Event(name: "event2", attributes: ["my_key": "my_value2", "another_key": 34]))
         var postCount = 0
 
-        appcues.networking.onPost = { endpoint, body, completion in
+        appcues.networking.onPost = { endpoint, body, requestId, completion in
             do {
                 postCount += 1
                 if postCount == 1 {
@@ -195,7 +195,7 @@ class ActivityProcessorTests: XCTestCase {
         var currentError = URLError(networkIssues.first!)
         resultCallbackExpectation.expectedFulfillmentCount = networkIssues.count
 
-        appcues.networking.onPost = { endpoint, body, completion in
+        appcues.networking.onPost = { endpoint, body, requestId, completion in
             completion(.failure(currentError))
         }
 
@@ -220,7 +220,7 @@ class ActivityProcessorTests: XCTestCase {
         var currentError = URLError(networkIssues.first!)
         resultCallbackExpectation.expectedFulfillmentCount = networkIssues.count
 
-        appcues.networking.onPost = { endpoint, body, completion in
+        appcues.networking.onPost = { endpoint, body, requestId, completion in
             completion(.failure(currentError))
         }
 
@@ -252,7 +252,7 @@ class ActivityProcessorTests: XCTestCase {
         let activity2 = generateMockActivity(userID: "user2", event: Event(name: "event2", attributes: ["my_key": "my_value2", "another_key": 34]))
         var postCount = 0
 
-        appcues.networking.onPost = { endpoint, body, completion in
+        appcues.networking.onPost = { endpoint, body, requestId, completion in
             do {
                 postCount += 1
                 if postCount == 1 {
@@ -306,7 +306,7 @@ class ActivityProcessorTests: XCTestCase {
         let resultCallbackExpectation = expectation(description: "Process result 1")
         let activity = generateMockActivity(userID: "user1", event: Event(name: "event1", attributes: ["my_key": "my_value1", "another_key": 33]))
 
-        appcues.networking.onPost = { endpoint, body, completion in
+        appcues.networking.onPost = { endpoint, body, requestId, completion in
             completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
             onPostExpectation.fulfill()
         }

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -242,13 +242,13 @@ class MockNetworking: Networking {
         }
     }
 
-    var onPost: ((Endpoint, Data, ((Result<Any, Error>) -> Void)) -> Void)?
-    func post<T>(to endpoint: Endpoint, body: Data, completion: @escaping (Result<T, Error>) -> Void) where T : Decodable {
+    var onPost: ((Endpoint, Data, UUID?, ((Result<Any, Error>) -> Void)) -> Void)?
+    func post<T>(to endpoint: Endpoint, body: Data, requestId: UUID?, completion: @escaping (Result<T, Error>) -> Void) where T : Decodable {
         guard let onPost = onPost else {
             completion(.failure(MockError.noMock))
             return
         }
-        onPost(endpoint, body) { result in
+        onPost(endpoint, body, requestId) { result in
             switch result {
             case .success(let value):
                 if let converted = value as? T {

--- a/Tests/AppcuesKitTests/Networking/NetworkClientTests.swift
+++ b/Tests/AppcuesKitTests/Networking/NetworkClientTests.swift
@@ -80,7 +80,7 @@ class NetworkClientTests: XCTestCase {
 
         // Act
         let data = try NetworkClient.encoder.encode(model)
-        networkClient.post(to: APIEndpoint.activity(userID: "test"), body: data) { (result: Result<Bool, Error>) in
+        networkClient.post(to: APIEndpoint.activity(userID: "test"), body: data, requestId: nil) { (result: Result<Bool, Error>) in
             if case .success = result {
                 expectation.fulfill()
             }


### PR DESCRIPTION
This stacks on #258 , as it builds upon the updates to `ExperienceData` and the usage in `ExperienceRenderer`.

The approach here is a static registry of metrics by request ID - in `SdkMetrics`.  This is where other spots can track key points in the qualification/rendering lifecycle.
* the moment the analytic comes in to the sdk
* when it is sent out in the network request
* when it returns from the network
* when it starts presentation in the UI

Then, when the `experience_started` analytic is trigged on initial render, we can capture and send the new `_sdkMetrics` node in the attributes, for reporting usage.

A few approaches are used to keep this metrics collection from bloating in size at runtime
* only adds entries for things that might potentially trigger qualification - analytics sent in that are "interactive" / processed immediately (i.e. the customer app screens and events).  Does not capture entries for non-qualifying background/internal events like flow analytics
* remove items when a response comes back with no qualified experiences (common case) - since we know we'll never be rendering any thing there
* does not do any tracking for non-traditional experience rendering: ex. deeplinks, show(id), flow triggering another flow
* clean up other items that do have qualification as soon as the render metrics are sent out
* clean up all items on app backgrounding, as a safety net, since no longer current/relevant

end result gets us data like this example
![Screen Shot 2022-10-20 at 3 36 47 PM](https://user-images.githubusercontent.com/19266448/197041674-8f7eb00d-891f-40ca-bb42-21b63e18a2b1.png)
(only 9ms to process a response, parse JSON, and get into render start!! 🎉)

also updated to show in the debugger for this event, in a section at the bottom
![Screen Shot 2022-10-20 at 3 28 49 PM](https://user-images.githubusercontent.com/19266448/197041773-538fa3e9-425b-4550-a09b-c362f98c6822.png)
