### PR TITLE
Add support for custom attribute name to store survey question results

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -317,7 +317,7 @@ public class Appcues: NSObject {
             // and clear any stored group information - will have to be reset as needed
             storage.groupID = nil
         }
-        analyticsPublisher.publish(TrackingUpdate(type: .profile, properties: properties, isInternal: false))
+        analyticsPublisher.publish(TrackingUpdate(type: .profile(interactive: true), properties: properties, isInternal: false))
     }
 }
 

--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -157,9 +157,3 @@ extension TrackingUpdate {
         }
     }
 }
-
-extension Event {
-    var autoProperties: [String: Any]? {
-        return attributes?["_identity"] as? [String: Any]
-    }
-}

--- a/Sources/AppcuesKit/Data/Analytics/TrackingUpdate.swift
+++ b/Sources/AppcuesKit/Data/Analytics/TrackingUpdate.swift
@@ -13,7 +13,7 @@ internal struct TrackingUpdate {
     enum TrackingType: Equatable {
         case event(name: String, interactive: Bool)
         case screen(String)
-        case profile
+        case profile(interactive: Bool)
         case group(String?)
     }
 
@@ -45,7 +45,13 @@ internal struct TrackingUpdate {
         case .screen:
             return .queueThenFlush
 
-        case .group, .profile:
+        case let .profile(interactive):
+            // a profile update would only be non-interactive if it was not affecting the
+            // user login status at all, just updating some attributes that can be batched
+            // with the next event. If a new profile update comes in prior to this, the queued
+            return interactive ? .flushThenSend : .queue
+
+        case .group:
             return .flushThenSend
         }
     }

--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -185,6 +185,7 @@ extension ExperienceComponent {
         let dataType: DataType?
         let textFieldStyle: Style?
         let cursorColor: Style.DynamicColor?
+        let attributeName: String?
 
         let style: Style?
 
@@ -227,6 +228,7 @@ extension ExperienceComponent {
         let unselectedColor: Style.DynamicColor?
         let accentColor: Style.DynamicColor?
         let pickerStyle: Style?
+        let attributeName: String?
 
         let style: Style?
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -38,7 +38,7 @@ internal class AppcuesSubmitFormAction: ExperienceAction, ExperienceActionQueueT
             .merging(LifecycleEvent.properties(experienceData, stepIndex)) { first, _ in first }
 
         analyticsPublisher.publish(TrackingUpdate(
-            type: .profile,
+            type: .profile(interactive: false),
             properties: stepState.formattedAsProfileUpdate(),
             isInternal: true))
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -138,6 +138,7 @@ extension ExperienceData {
 
         fileprivate let type: String
         fileprivate let label: String
+        fileprivate let attributeName: String?
         fileprivate var underlyingValue: ValueType
         fileprivate let validators: [Validator]
         fileprivate let required: Bool
@@ -149,6 +150,7 @@ extension ExperienceData {
         init(model: ExperienceComponent.TextInputModel) {
             self.type = "textInput"
             self.label = model.label.text
+            self.attributeName = model.attributeName
             self.underlyingValue = .single(model.defaultValue ?? "")
             self.validators = model.validators()
             self.required = model.required ?? false
@@ -157,6 +159,7 @@ extension ExperienceData {
         init(model: ExperienceComponent.OptionSelectModel) {
             self.type = "optionSelect"
             self.label = model.label.text
+            self.attributeName = model.attributeName
             switch model.selectMode {
             case .single:
                 self.underlyingValue = .single(model.defaultValue?.first ?? "")
@@ -209,6 +212,10 @@ extension ExperienceData.StepState {
 
         formItems.forEach { _, item in
             update["_appcuesForm_\(item.label.asSlug)"] = item.getValue()
+
+            if let attributeName = item.attributeName {
+                update[attributeName] = item.getValue()
+            }
         }
 
         return update

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
@@ -59,7 +59,7 @@ class AnalyticsBroadcasterTests: XCTestCase {
 
     func testBroadcastProfile() throws {
         // Act
-        broadcaster.track(update: TrackingUpdate(type: .profile, properties: ["key": "value"], context: nil, isInternal: false))
+        broadcaster.track(update: TrackingUpdate(type: .profile(interactive: true), properties: ["key": "value"], context: nil, isInternal: false))
 
         // Assert
         XCTAssertEqual(delegate.lastAnalytic, .identify)
@@ -103,6 +103,7 @@ class AnalyticsBroadcasterTests: XCTestCase {
             dataType: nil,
             textFieldStyle: nil,
             cursorColor: nil,
+            attributeName: nil,
             style: nil))
 
         let update = TrackingUpdate(

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -36,7 +36,7 @@ class AnalyticsTrackerTests: XCTestCase {
             onRequestExpectation.fulfill()
         }
 
-        let update = TrackingUpdate(type: .profile, properties: ["my_key":"my_value", "another_key": 33], isInternal: false)
+        let update = TrackingUpdate(type: .profile(interactive: true), properties: ["my_key":"my_value", "another_key": 33], isInternal: false)
 
         // Act
         tracker.track(update: update)

--- a/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
@@ -77,7 +77,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
 
     func testProfile() throws {
         // Arrange
-        let update = TrackingUpdate(type: .profile, properties: ["CUSTOM": "value"], isInternal: false)
+        let update = TrackingUpdate(type: .profile(interactive: true), properties: ["CUSTOM": "value"], isInternal: false)
 
         // Act
         let decorated = decorator.decorate(update)

--- a/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
@@ -184,6 +184,7 @@ extension ExperienceComponent.OptionSelectModel {
             unselectedColor: nil,
             accentColor: nil,
             pickerStyle: nil,
+            attributeName: nil,
             style: nil
         )
     }

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -91,7 +91,7 @@ extension Experience {
             nextContentID: nil)
     }
 
-    static func mockWithForm(defaultValue: String?) -> Experience {
+    static func mockWithForm(defaultValue: String?, attributeName: String?) -> Experience {
         Experience(
             id: UUID(uuidString: "ded7b50f-bc24-42de-a0fa-b1f10fc10d00")!,
             name: "Mock Experience: Single step with form",
@@ -102,7 +102,7 @@ extension Experience {
                 Experience.Step(
                     fixedID: "02b83a13-537c-4cfc-89be-815e303d1c00",
                     children: [
-                        Step.Child(formWithFixedID: "6cf396f6-1f01-4449-9e38-7e845f5316c0", defaultValue: defaultValue)
+                        Step.Child(formWithFixedID: "6cf396f6-1f01-4449-9e38-7e845f5316c0", defaultValue: defaultValue, attributeName: attributeName)
                     ]
                 )
             ],
@@ -135,7 +135,7 @@ extension Experience.Step.Child {
         )
     }
 
-    init(formWithFixedID fixedID: String, defaultValue: String?) {
+    init(formWithFixedID fixedID: String, defaultValue: String?, attributeName: String?) {
         self.init(
             id: UUID(uuidString: fixedID) ?? UUID(),
             type: "modal",
@@ -151,6 +151,7 @@ extension Experience.Step.Child {
                 dataType: nil,
                 textFieldStyle: nil,
                 cursorColor: nil,
+                attributeName: attributeName,
                 style: nil)),
             traits: [],
             actions: [:]
@@ -162,7 +163,9 @@ extension Experience.Step.Child {
 extension ExperienceData {
     static var mock: ExperienceData { ExperienceData(experience: .mock) }
     static var singleStepMock: ExperienceData { ExperienceData(experience: .singleStepMock) }
-    static func mockWithForm(defaultValue: String?) -> ExperienceData { ExperienceData(experience: .mockWithForm(defaultValue: defaultValue)) }
+    static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
+        ExperienceData(experience: .mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
+    }
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {


### PR DESCRIPTION
The main change here is simple, and mostly isolated to just the `ExperienceData` file - where a new `attributeName` is handled, and used in the profile update if present. It adds a second profile attribute, in addition to the default update.

The other changes in the handling of the `.profile` tracking type are from noticing that we were not actually batching the form submit analytics together properly, previously. In the existing code, it would send out three separate requests: a `step_interaction` for the button tap (which had a flushed triggered by next item), a `profile_update` for the attribute which was set to always send immediately, and another `step_interaction` (and maybe more) for the form submit.

These can actually all be grouped together in this case, by allowing the `.profile` item to be considered non-interactive, and batched with the other flow analytics.  This results in the final output of a single call to the API like the image below. This is probably not critical, but I propose this change just to maximize our usage of activity batching in this common scenario.
![Screen Shot 2022-10-20 at 4 49 43 PM](https://user-images.githubusercontent.com/19266448/197058423-fe1253d8-2a50-4114-8d95-67f1f4dd22b6.png)
