### PR TITLE
Fix crash around modifying activity set

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/ActivityProcessor.swift
+++ b/Sources/AppcuesKit/Data/Analytics/ActivityProcessor.swift
@@ -161,14 +161,16 @@ internal class ActivityProcessor: ActivityProcessing {
     }
 
     private func postProcess(activity: ActivityStorage, success: Bool) {
-        // if it was successful (or retry not enabled), no retry needed - clean out the file
-        if success {
-            self.activityStorage.remove(activity)
-        }
+        syncQueue.sync {
+            // if it was successful (or retry not enabled), no retry needed - clean out the file
+            if success {
+                self.activityStorage.remove(activity)
+            }
 
-        // then, always remove it from the list of current items "in flight" - this allows
-        // a later retry to run, if it was needed
-        self.processingItems.remove(activity.requestID)
+            // then, always remove it from the list of current items "in flight" - this allows
+            // a later retry to run, if it was needed
+            self.processingItems.remove(activity.requestID)
+        }
     }
 
 }


### PR DESCRIPTION
`ActivityProcessor` maintains a `Set` of in-flight request IDs. This set needs to be accessed in a thread-safe manner, so a serial queue is used. However there was one spot where the set was modified outside the safety of the serial queue which could cause a crash if the set was simultaneously being modified from within the queue.