### PR TITLE
Add NPS display format to optionSelect component

### DIFF
--- a/Sources/AppcuesKit/Data/Extensions/Array+Chunked.swift
+++ b/Sources/AppcuesKit/Data/Extensions/Array+Chunked.swift
@@ -1,0 +1,17 @@
+//
+//  Array+Chunked.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 10/24/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -210,7 +210,7 @@ extension ExperienceComponent {
         }
 
         enum DisplayFormat: String, Decodable {
-            case verticalList, horizontalList, picker
+            case verticalList, horizontalList, picker, nps
         }
 
         let id: UUID

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -30,13 +30,15 @@ internal struct AppcuesOptionSelect: View {
                             .tag(option.value)
                     }
                 }
+            case (.single, .nps):
+                NPSView(model: model)
             case (_, .horizontalList):
                 HStack(alignment: model.controlPosition?.verticalAlignment ?? .center, spacing: 0) {
                     items
                 }
             case (_, .verticalList),
                 // fallbacks
-                (_, .none), (.multi, .picker):
+                (_, .none), (.multi, .picker), (.multi, .nps):
                 VStack(alignment: model.controlPosition?.horizontalAlignment ?? .center, spacing: 0) {
                     items
                 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/NPSView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/NPSView.swift
@@ -1,0 +1,45 @@
+//
+//  NPSView.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 10/24/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+// The NPSView is a specialized display format for the AppcuesOptionSelect component.
+// It can be used for single-select models. It splits the given set of options in half
+// and renders in a specific two row display format, for the net promotor score use case.
+@available(iOS 13.0, *)
+internal struct NPSView: View {
+    let model: ExperienceComponent.OptionSelectModel
+
+    @EnvironmentObject var stepState: ExperienceData.StepState
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 0) {
+            // It is expected to have 11 options for NPS: 0-10
+            // A bit more flexibility here though to just split the given options
+            // in half, taking the ceiling of an odd numbered set - which
+            // gives 6 on the first row and 5 on the second row, in the normal display
+            let rows = model.options.chunked(into: (model.options.count + 1) / 2)
+            ForEach(rows.indices, id: \.self) { rowIndex in
+                // Each row lays out items horizontally, with spacing defined within the model
+                HStack(spacing: 0) {
+                    ForEach(rows[rowIndex]) { option in
+                        let binding = stepState.formBinding(for: model.id, value: option.value)
+                        Group {
+                            if binding.wrappedValue {
+                                (option.selectedContent ?? option.content).view
+                            } else {
+                                option.content.view
+                            }
+                        }
+                        .onTapGesture { binding.wrappedValue.toggle() }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -25,5 +25,6 @@ internal struct TintedTextView: View {
                 view.foregroundColor(val)
             }
             .applyAllAppcues(style)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }


### PR DESCRIPTION
Adds support for `"displayFormat": "nps"` in the `optionSelect` model.

Also, a one-line fix to support text wrapping on the survey component label in `TintedTextView`.

![Screen Shot 2022-10-24 at 11 51 23 AM](https://user-images.githubusercontent.com/19266448/197570143-6551834b-677d-42bd-91c2-e66f718e3180.png)

corresponding spec change is here https://github.com/appcues/appcues-mobile-experience-spec/pull/102
