### PR TITLE
Release script enhancements

### DIFF
--- a/fastlane/build.sh
+++ b/fastlane/build.sh
@@ -10,6 +10,9 @@ SIMULATOR_ARCHIVE_PATH="${BUILD_FOLDER_NAME}/simulator.xcarchive"
 IOS_DEVICE_ARCHIVE_PATH="${BUILD_FOLDER_NAME}/iOS.xcarchive"
 ZIP_NAME="${XCFRAMEWORK_NAME}.zip"
 
+# Ensure the project file is up to date before trying to archive
+mint run xcodegen
+
 xcodebuild archive -quiet -scheme ${PROJECT_NAME} -destination="iOS Simulator" -archivePath "${SIMULATOR_ARCHIVE_PATH}" -sdk iphonesimulator SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES || exit 1
 xcodebuild archive -quiet -scheme ${PROJECT_NAME} -destination="iOS" -archivePath "${IOS_DEVICE_ARCHIVE_PATH}" -sdk iphoneos SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES || exit 1
 

--- a/release.sh
+++ b/release.sh
@@ -135,7 +135,7 @@ sed -i '' -e "s/$version/$newVersion/g" Appcues.podspec
 git commit -am "🍏 Update version to $newVersion"
 git push
 # gh release will make both the tag and the release itself.
-gh release create $newVersion -F $tempFile -t $newVersion
+gh release create $newVersion -F $tempFile -t $newVersion --target $branch
 
 # remove the tempfile.
 rm $tempFile


### PR DESCRIPTION
A couple tweaks from the hot fix release process:

1. the `gh release create` command defaults to `main` which was fine, but not when we're running from a `release/*` branch, so explicitly specify the [target](https://cli.github.com/manual/gh_release_create)
2. the XCFramework build script can fail if the project file is out of date, so run xcodegen first