### PR TITLE
Fix logic that links experiments and experiences in response

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -117,12 +117,9 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
     private func process(qualifyResponse: QualifyResponse, activity: Activity) {
         if let experienceRenderer = container?.resolve(ExperienceRendering.self) {
             let experiments = qualifyResponse.experiments ?? []
-            let qualifiedExperienceData: [ExperienceData] = qualifyResponse.experiences.map {
-                var experiment: Experiment?
-                if let experimentID = $0.experimentID {
-                    experiment = experiments.first { $0.experimentID == experimentID }
-                }
-                return ExperienceData($0,
+            let qualifiedExperienceData: [ExperienceData] = qualifyResponse.experiences.map { experience in
+                var experiment = experiments.first { $0.experienceID == experience.id }
+                return ExperienceData(experience,
                                       priority: qualifyResponse.renderPriority,
                                       published: true,
                                       experiment: experiment,

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -59,7 +59,6 @@ internal struct Experience {
     // TODO: Handle experience-level actions
     let traits: [Trait]
     let steps: [Step]
-    let experimentID: String?
 
     // Post experience actions
     let redirectURL: URL?
@@ -77,10 +76,6 @@ extension Experience: Decodable {
         case publishedAt
         case traits
         case steps
-        // note: the actual json key is "experiment_id", however, we use a JSON decoder with
-        // decoder.keyDecodingStrategy = .convertFromSnakeCase
-        // which causes it to convert to "experimentId" prior to usage in these CodingKeys
-        case experimentID = "experimentId"
         case redirectURL = "redirectUrl"
         case nextContentID = "nextContentId"
     }

--- a/Sources/AppcuesKit/Data/Models/Experiment.swift
+++ b/Sources/AppcuesKit/Data/Models/Experiment.swift
@@ -10,7 +10,8 @@ import Foundation
 
 internal struct Experiment {
     let group: String
-    let experimentID: String
+    let experimentID: UUID
+    let experienceID: UUID
 
     var shouldExecute: Bool {
         return group != "control"
@@ -21,5 +22,6 @@ extension Experiment: Decodable {
     private enum CodingKeys: String, CodingKey {
         case group
         case experimentID = "experimentId"
+        case experienceID = "experienceId"
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -208,7 +208,7 @@ internal class ExperienceRenderer: ExperienceRendering {
         analyticsPublisher.publish(TrackingUpdate(
             type: .event(name: "appcues:experiment_entered", interactive: false),
             properties: [
-                "experimentId": experiment.experimentID,
+                "experimentId": experiment.experimentID.uuidString.lowercased(),
                 "group": experiment.group
             ],
             isInternal: true))

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -348,7 +348,7 @@ class ActivityProcessorTests: XCTestCase {
         return Activity(accountID: "00000", userID: userID, events: [event], profileUpdate: nil, groupID: nil, groupUpdate: nil)
     }
 
-    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], experimentID: nil, redirectURL: nil, nextContentID: nil)
+    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
 
 }
 

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -316,9 +316,9 @@ class ExperienceRendererTests: XCTestCase {
         let failureExpectation = expectation(description: "Failure completion called")
         let presentExpectation = expectation(description: "Experience presented")
         presentExpectation.isInverted = true
-        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "control", experimentID: experimentID)
-        let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
+        let experience = ExperienceData.singleStepMock
+        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experiment = Experiment(group: "control", experimentID: experimentID, experienceID: experience.id)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
@@ -337,9 +337,9 @@ class ExperienceRendererTests: XCTestCase {
         // Arrange
         let completionExpectation = expectation(description: "Completion called")
         let presentExpectation = expectation(description: "Experience presented")
-        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "exposed", experimentID: experimentID)
-        let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
+        let experience = ExperienceData.singleStepMock
+        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experiment = Experiment(group: "exposed", experimentID: experimentID, experienceID: experience.id)
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
@@ -357,11 +357,11 @@ class ExperienceRendererTests: XCTestCase {
     func testExperimentEnteredControlAnalytics() throws {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
-        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "control", experimentID: experimentID)
-        let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
+        let experience = ExperienceData.singleStepMock
+        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experiment = Experiment(group: "control", experimentID: experimentID, experienceID: experience.id)
         let properties: [String: Any] = [
-            "experimentId": experimentID,
+            "experimentId": experimentID.uuidString.lowercased(),
             "group": "control"
         ]
         var experimentUpdate: TrackingUpdate?
@@ -385,11 +385,11 @@ class ExperienceRendererTests: XCTestCase {
     func testExperimentEnteredExposedAnalytics() throws {
         // Arrange
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
-        let experimentID = "6ce90d1d-4de2-41a6-bc93-07ae23b728c5"
-        let experiment = Experiment(group: "exposed", experimentID: experimentID)
-        let experience = ExperienceData.mockWithExperiment(experimentID: experimentID)
+        let experience = ExperienceData.singleStepMock
+        let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
+        let experiment = Experiment(group: "exposed", experimentID: experimentID, experienceID: experience.id)
         let properties: [String: Any] = [
-            "experimentId": experimentID,
+            "experimentId": experimentID.uuidString.lowercased(),
             "group": "exposed"
         ]
         var experimentUpdate: TrackingUpdate?

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -234,7 +234,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsIdling_whenStartExperienceWithNoSteps_noTransition() throws {
         // Arrange
-        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], experimentID: nil, redirectURL: nil, nextContentID: nil)
+        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
         let initialState: State = .idling
         let action: Action = .startExperience(ExperienceData(experience))
         let stateMachine = givenState(is: initialState)

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -68,7 +68,6 @@ extension Experience {
                     Step.Child(fixedID: "03652bd5-f0cb-44f0-9274-e95b4441d857")
                 )
             ],
-            experimentID: nil,
             redirectURL: nil,
             nextContentID: "abc")
     }
@@ -88,7 +87,6 @@ extension Experience {
                     ]
                 )
             ],
-            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
     }
@@ -108,31 +106,9 @@ extension Experience {
                     ]
                 )
             ],
-            experimentID: nil,
             redirectURL: nil,
             nextContentID: "abc")
     }
-
-    static func mockWithExperiment(experimentID: String) -> Experience {
-        Experience(
-            id: UUID(uuidString: "09f3b0a2-c4b1-4bbe-9fb3-81061169f5f5")!,
-            name: "Mock Experience: Single step with experiment",
-            type: "mobile",
-            publishedAt: 1632142800000,
-            traits: [],
-            steps: [
-                Experience.Step(
-                    fixedID: "05d19cf7-60b5-45de-ae37-13a1706d4e37",
-                    children: [
-                        Step.Child(fixedID: "c25236ad-9587-4865-8b58-2817f1c1421a")
-                    ]
-                )
-            ],
-            experimentID: experimentID,
-            redirectURL: nil,
-            nextContentID: nil)
-    }
-
 }
 
 extension Experience.Step {
@@ -189,7 +165,6 @@ extension ExperienceData {
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
         ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
     }
-    static func mockWithExperiment(experimentID: String) -> ExperienceData { ExperienceData(.mockWithExperiment(experimentID: experimentID)) }
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -55,7 +55,6 @@ class TraitComposerTests: XCTestCase {
             steps: [
                 .child(Experience.Step.Child(traits: []))
             ],
-            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
 
@@ -157,7 +156,6 @@ class TraitComposerTests: XCTestCase {
             steps: [
                 .child(Experience.Step.Child(traits: []))
             ],
-            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
 
@@ -195,7 +193,6 @@ class TraitComposerTests: XCTestCase {
                     actions: [:]
                 ))
             ],
-            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
         let experienceData = ExperienceData(experience)
@@ -271,7 +268,6 @@ class TraitComposerTests: XCTestCase {
                         ])
                 ]))
             ],
-            experimentID: nil,
             redirectURL: nil,
             nextContentID: nil)
     }


### PR DESCRIPTION
Once we had a real test response to try out, discovered a misunderstanding in the requirements around how the response would look. We need to link the experiment and experience as shown here - matching on the experience ID inside of the experiments array. There is no `experiment_id` in the `experience` response object.

![Screen Shot 2022-10-24 at 2 56 24 PM](https://user-images.githubusercontent.com/19266448/197609092-8d7cd166-2a28-45a5-9c7f-8a84bcb2fd6b.png)
