### PR TITLE
Handle text field keyboard interactions

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/UIView+FirstResponder.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIView+FirstResponder.swift
@@ -1,0 +1,25 @@
+//
+//  UIView+FirstResponder.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-10-26.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    var firstResponder: UIView? {
+        if isFirstResponder {
+            return self
+        }
+
+        for subview in subviews {
+            if let firstResponder = subview.firstResponder {
+                return firstResponder
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
@@ -50,6 +50,8 @@ internal struct MultilineTextView: UIViewRepresentable {
         }
         textView.textContentType = model.dataType?.textContentType
 
+        textView.inputAccessoryView = DismissToolbar(textView: textView)
+
         return textView
     }
 
@@ -69,6 +71,8 @@ internal struct MultilineTextView: UIViewRepresentable {
         }
         textField.textContentType = model.dataType?.textContentType
         textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        textField.inputAccessoryView = DismissToolbar(textField: textField)
 
         return textField
     }
@@ -134,6 +138,44 @@ extension MultilineTextView {
 
         override func editingRect(forBounds bounds: CGRect) -> CGRect {
             return self.textRect(forBounds: bounds)
+        }
+    }
+
+    /// A `UIToolbar` that include a "Done" button to end editing. Use as an `inputAccessoryView`.
+    ///
+    /// This exists over just creating a `UIToolbar` because `MultilineTextView` is a struct
+    /// and so can't have an `@objc` method for the selector.
+    class DismissToolbar: UIToolbar {
+        weak var view: UIView?
+
+        init(textView: UITextView) {
+            self.view = textView
+            super.init(frame: .zero)
+            setup()
+        }
+
+        init(textField: UITextField) {
+            self.view = textField
+            super.init(frame: .zero)
+            setup()
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        private func setup() {
+            items = [
+                UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissKeyboard))
+            ]
+            sizeToFit()
+        }
+
+        @objc
+        private func dismissKeyboard() {
+            view?.endEditing(true)
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -104,6 +104,9 @@ extension ExperienceStepViewController {
             view.translatesAutoresizingMaskIntoConstraints = false
             // Force a consistent safe area behavior regardless of whether the content scrolls
             view.contentInsetAdjustmentBehavior = .always
+
+            // For text input blocks, we want scrolling the modal content to be able to dismiss the keyboard.
+            view.keyboardDismissMode = .interactive
             return view
         }()
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -49,6 +49,17 @@ internal class ExperienceStepViewController: UIViewController {
         stepView.contentView.addSubview(contentViewController.view)
         contentViewController.view.pin(to: stepView.contentView.layoutMarginsGuide)
         contentViewController.didMove(toParent: self)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil)
     }
 
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
@@ -65,6 +76,23 @@ internal class ExperienceStepViewController: UIViewController {
         if motion == .motionShake {
             notificationCenter?.post(name: .shakeToRefresh, object: self)
         }
+    }
+
+    @objc
+    private func adjustForKeyboard(notification: Notification) {
+        guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+
+        if notification.name == UIResponder.keyboardWillHideNotification {
+            stepView.scrollView.contentInset.bottom = 0
+        } else {
+            let keyboardFrameInScreen = keyboardValue.cgRectValue
+            let keyboardFrameInView = stepView.scrollView.convert(keyboardFrameInScreen, from: view.window)
+            let intersection = stepView.scrollView.bounds.intersection(keyboardFrameInView)
+
+            stepView.scrollView.contentInset.bottom = intersection.height - view.safeAreaInsets.bottom
+        }
+
+        stepView.scrollView.scrollIndicatorInsets = stepView.scrollView.contentInset
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -93,6 +93,14 @@ internal class ExperienceStepViewController: UIViewController {
         }
 
         stepView.scrollView.scrollIndicatorInsets = stepView.scrollView.contentInset
+
+        // Scroll the first responder into view.
+        // This happens automatically in some cases (eg UITextField), but is a bit janky and this is smoother.
+        // Also UITextView doesn't automatically scroll to visible as expected and so requires this implementation.
+        if let targetView = view.firstResponder {
+            let frameInScrollView = stepView.scrollView.convert(targetView.frame, from: targetView)
+            stepView.scrollView.scrollRectToVisible(frameInScrollView, animated: false)
+        }
     }
 }
 


### PR DESCRIPTION
This PR:
- Adusts the content area when the keyboard shows to ensure no content gets stuck under the keyboard
- Adds a Done button in a toolbar to the keyboard
- Allows dismissal via scrolling

The code to scroll the first responder into view in`ExperienceStepViewController` shouldn't be necessary since that's supposed to happen automatically, but this implementation fixes 2 issues:
1. `UITextView` wasn't being scrolled to at all
2. `UITextField` scrolling was a bit janky (the difference was `animated: false`). See these videos:

https://user-images.githubusercontent.com/845681/198061771-fd9db0bf-3896-4b45-bb47-729c1b0c45a4.mp4

https://user-images.githubusercontent.com/845681/198061747-c4e19c5a-a309-4b5a-9f80-73bea74bb8cf.mp4




