### PR TITLE
Support auto downscaling on Text when available width is too narrow

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -129,7 +129,7 @@ extension View {
 
 @available(iOS 13.0, *)
 extension Text {
-    func applyTextStyle(_ style: AppcuesStyle) -> some View {
+    func applyTextStyle(_ style: AppcuesStyle, text: String) -> some View {
         self
             .ifLet(style.letterSpacing) { view, val in
                 view.kerning(val)
@@ -137,5 +137,13 @@ extension Text {
             .ifLet(style.textAlignment) { view, val in
                 view.multilineTextAlignment(val)
             }
+            // The following two lines allow text to scale down in cases where it is too
+            // large to fit in the bounds available, and otherwise unnatural clipping
+            // or wrapping would occur. For example, a large emoji in a side-by-side layout.
+            // SwiftUI requires a line limit to be set for the minimumScaleFactor to be applied,
+            // and it must be set to 1 line in the case of a single large character for scaling
+            // to be applied.
+            .lineLimit(text.count == 1 ? 1 : Int.max)
+            .minimumScaleFactor(text.count == 1 ? 0.1 : 0.5)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -18,7 +18,7 @@ internal struct AppcuesText: View {
         let style = AppcuesStyle(from: model.style)
 
         Text(model.text)
-            .applyTextStyle(style)
+            .applyTextStyle(style, text: model.text)
             .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
             .fixedSize(horizontal: false, vertical: true)

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -19,7 +19,7 @@ internal struct TintedTextView: View {
         let style = AppcuesStyle(from: model.style)
 
         Text(model.text)
-            .applyTextStyle(style)
+            .applyTextStyle(style, text: model.text)
             .setupActions(on: viewModel, for: model)
             .ifLet(tintColor) { view, val in
                 view.foregroundColor(val)


### PR DESCRIPTION
This is an approach to use the [`.minimumScaleFactor`](https://developer.apple.com/documentation/swiftui/view/minimumscalefactor(_:)) modifier to improve the situation noted in the ticket (clipping) - likely more common with side by side content.

An example to illustrate - uses 4 side-by-side text elements, all of which have too large of a font size to fit as normally expected.

* "Hello World" - 30pt
* "X" - 150pt
* "Somereallylongwordhere" - 30pt
* "👋🏼" - 200pt  <-- the primary issue in ticket

| After | Before |
| --- | --- |
|  ![Screen Shot 2022-10-28 at 4 42 20 PM](https://user-images.githubusercontent.com/19266448/198729344-9abef29a-e738-4962-b72d-ae60aa1b40f1.png)  | ![Screen Shot 2022-10-28 at 4 42 56 PM](https://user-images.githubusercontent.com/19266448/198729356-42ef5c1a-cdd2-47cf-bc63-adbb8aea5780.png)  |



