### PR TITLE
Add support for the url dataType on textInput

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -169,7 +169,7 @@ extension ExperienceComponent {
 
     struct TextInputModel: ComponentModel, Decodable {
         enum DataType: String, Decodable {
-            case text, number, email, phone, name, address
+            case text, number, email, phone, name, address, url
         }
 
         let id: UUID

--- a/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
@@ -191,6 +191,8 @@ extension ExperienceComponent.TextInputModel.DataType {
             return .emailAddress
         case .phone:
             return .phonePad
+        case .url:
+            return .URL
         }
     }
 
@@ -206,6 +208,8 @@ extension ExperienceComponent.TextInputModel.DataType {
             return .name
         case .address:
             return .fullStreetAddress
+        case .url:
+            return .URL
         }
     }
 }


### PR DESCRIPTION
As per the spec update:
- https://github.com/appcues/appcues-mobile-experience-spec/pull/110

I'm not sure specifically what difference `UITextContentType.URL` makes, but it seems like the right option.

![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 09 46 50](https://user-images.githubusercontent.com/845681/199505995-70ed046e-5305-44e3-a4ed-908f54c2637c.png)
