### PR TITLE
Support Universal Links for @appcues/link action

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.entitlements
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:appcues-mobile-links.netlify.app?mode=developer</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,61 +13,54 @@
 		3EADA9762D050C3E2ED69514 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */; };
 		40A181AE1ED5DE1982FA05CC /* Mulish-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */; };
 		64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB61619365785F4544ED13D /* GroupViewController.swift */; };
+		68E596FD295BCC69F06AF0B4 /* DeepLinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5548F50894583A174A85628C /* DeepLinkNavigator.swift */; };
 		866AA363BEFB1A42C8C1D149 /* Lato-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 547A647EB6D311E97F592C7C /* Lato-Black.ttf */; };
 		9E6FF9F4B22B8874E5AA6544 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93D50517BBE18B336D130E13 /* LaunchScreen.storyboard */; };
 		A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C713E67205D9507CE2DC80 /* AppDelegate.swift */; };
-		A24A736BF7726104BF014D20 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 808B6BBAEF75A6DD7AC11D0D /* Pods_AppcuesCocoapodsExample.framework */; };
 		A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */; };
-		CAFC2E38ACF9024AD211097D /* DeepLinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADB3815CE7FEA22224162CE /* DeepLinkNavigator.swift */; };
 		CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384497BA35A275E793B475C1 /* ProfileViewController.swift */; };
 		CD156254F042866368E77CC3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 024025AF9E2E0D38C368A6AC /* Main.storyboard */; };
 		DBE453F2B40A01B4818CB84E /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */; };
 		EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D26E6136C6539597C9E50A9 /* EventsViewController.swift */; };
+		FEF8EE8E5AE36F20D8EEAF5D /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2959A7124907FE4B3CA178CA /* Pods_AppcuesCocoapodsExample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		05171392CB1FB5611E5F7E22 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
-		0FC954E991346E02C5B07502 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		2959A7124907FE4B3CA178CA /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		384497BA35A275E793B475C1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		547A647EB6D311E97F592C7C /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
-		5ADB3815CE7FEA22224162CE /* DeepLinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkNavigator.swift; sourceTree = "<group>"; };
+		5548F50894583A174A85628C /* DeepLinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkNavigator.swift; sourceTree = "<group>"; };
 		5DC2B62290580560D162A8E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		808B6BBAEF75A6DD7AC11D0D /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82DED1437C1DA54F0C231566 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8663BEDD1883CC408AA4A302 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		9CB61619365785F4544ED13D /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		9D26E6136C6539597C9E50A9 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
+		A2321337B539BB6E988B3B43 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		AAD7ED9DCA5972361B3F5E67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B04ADFAB9E8A90EFC1D1B810 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
+		C9F4021429156236002E4D4C /* AppcuesCocoapodsExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AppcuesCocoapodsExample.entitlements; sourceTree = "<group>"; };
 		CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-VariableFont_wght.ttf"; sourceTree = "<group>"; };
-		D2C0EC54920737EBD7E2961F /* AppcuesCocoapodsExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AppcuesCocoapodsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2C0EC54920737EBD7E2961F /* AppcuesCocoapodsExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppcuesCocoapodsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		076ADDB763F38ABB6969CFD0 /* Frameworks */ = {
+		2544C992C9D2A5CEC51D18D7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A24A736BF7726104BF014D20 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
+				FEF8EE8E5AE36F20D8EEAF5D /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0288A604608F93BA48F1A2ED /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				808B6BBAEF75A6DD7AC11D0D /* Pods_AppcuesCocoapodsExample.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		3271BCB89D21367EC1AA9069 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -80,13 +73,22 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		44732449780B7902862D13CB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				B04ADFAB9E8A90EFC1D1B810 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
+				A2321337B539BB6E988B3B43 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */ = {
 			isa = PBXGroup;
 			children = (
 				3271BCB89D21367EC1AA9069 /* Fonts */,
 				10C713E67205D9507CE2DC80 /* AppDelegate.swift */,
 				2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */,
-				5ADB3815CE7FEA22224162CE /* DeepLinkNavigator.swift */,
+				5548F50894583A174A85628C /* DeepLinkNavigator.swift */,
 				9D26E6136C6539597C9E50A9 /* EventsViewController.swift */,
 				9CB61619365785F4544ED13D /* GroupViewController.swift */,
 				AAD7ED9DCA5972361B3F5E67 /* Info.plist */,
@@ -99,13 +101,12 @@
 			path = CocoapodsExample;
 			sourceTree = "<group>";
 		};
-		A3C1291F93787A404655DBDD /* Pods */ = {
+		B8B6EDF9FD292A74C9A5170B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				0FC954E991346E02C5B07502 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
-				05171392CB1FB5611E5F7E22 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+				2959A7124907FE4B3CA178CA /* Pods_AppcuesCocoapodsExample.framework */,
 			);
-			path = Pods;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		C743E51709EACC21B03B3A23 /* Products */ = {
@@ -119,10 +120,11 @@
 		C7A6ECAD43638C565FF25B3E = {
 			isa = PBXGroup;
 			children = (
+				C9F4021429156236002E4D4C /* AppcuesCocoapodsExample.entitlements */,
 				8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */,
 				C743E51709EACC21B03B3A23 /* Products */,
-				A3C1291F93787A404655DBDD /* Pods */,
-				0288A604608F93BA48F1A2ED /* Frameworks */,
+				44732449780B7902862D13CB /* Pods */,
+				B8B6EDF9FD292A74C9A5170B /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -133,12 +135,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7200554C7EB6F6E4E0D35C70 /* Build configuration list for PBXNativeTarget "AppcuesCocoapodsExample" */;
 			buildPhases = (
-				A34F5C62C79629D5D79B2D39 /* [CP] Check Pods Manifest.lock */,
+				BD910621CA667EBEE81CEBBF /* [CP] Check Pods Manifest.lock */,
 				39C4F25C30C2C38F00378FED /* Sources */,
 				4B41B1A9E3D52747D92B7344 /* Resources */,
 				6D4DB9FBC4445D937FD94125 /* SwiftLint */,
-				076ADDB763F38ABB6969CFD0 /* Frameworks */,
-				AC8FD716096001DA37411000 /* [CP] Embed Pods Frameworks */,
+				2544C992C9D2A5CEC51D18D7 /* Frameworks */,
+				37A306DB3591AFF53A5C23E3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -158,7 +160,7 @@
 				LastUpgradeCheck = 1200;
 			};
 			buildConfigurationList = 95033167E7E129F199208F61 /* Build configuration list for PBXProject "AppcuesCocoapodsExample" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -194,6 +196,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		37A306DB3591AFF53A5C23E3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		6D4DB9FBC4445D937FD94125 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -212,7 +231,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.44.0\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
 		};
-		A34F5C62C79629D5D79B2D39 /* [CP] Check Pods Manifest.lock */ = {
+		BD910621CA667EBEE81CEBBF /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -234,23 +253,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AC8FD716096001DA37411000 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -259,7 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */,
-				CAFC2E38ACF9024AD211097D /* DeepLinkNavigator.swift in Sources */,
+				68E596FD295BCC69F06AF0B4 /* DeepLinkNavigator.swift in Sources */,
 				EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */,
 				64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */,
 				CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */,
@@ -292,11 +294,13 @@
 /* Begin XCBuildConfiguration section */
 		015038143918E0C7F9D7E873 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0FC954E991346E02C5B07502 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
+			baseConfigurationReference = B04ADFAB9E8A90EFC1D1B810 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = AppcuesCocoapodsExample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = KHSQ25769M;
 				INFOPLIST_FILE = CocoapodsExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -373,11 +377,13 @@
 		};
 		266E5C088CC8701B4117B193 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 05171392CB1FB5611E5F7E22 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
+			baseConfigurationReference = A2321337B539BB6E988B3B43 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = AppcuesCocoapodsExample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = KHSQ25769M;
 				INFOPLIST_FILE = CocoapodsExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -43,6 +43,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return false
     }
     */
+
+    // The Appcues link action uses this method to handle universal links.
+    func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        // Get URL components from the incoming user activity.
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+            let incomingURL = userActivity.webpageURL,
+            let components = URLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+            return false
+        }
+
+        if let deepLink = DeepLinkNavigator.DeepLink(path: components.path),
+           let scene = application.connectedScenes.first(where: { $0.delegate is SceneDelegate }) {
+            (scene.delegate as? SceneDelegate)?.deepLinkNavigator.handle(deepLink: deepLink, in: scene)
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 extension Appcues {

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/DeepLinkNavigator.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/DeepLinkNavigator.swift
@@ -41,13 +41,8 @@ class DeepLinkNavigator {
 
         /// Init from universal link path.
         init?(path: String) {
-            switch path.lowercased() {
-            case "/signin/": self = .signIn
-            case "/events/": self = .events
-            case "/profile/": self = .profile
-            case "/group/": self = .group
-            default: return nil
-            }
+            // Expect a value like "/events/", so trim slashes.
+            self.init(host: path.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
         }
     }
 

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/SceneDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/SceneDelegate.swift
@@ -25,6 +25,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // Handle app-specific deep links.
         deepLinkNavigator.handle(scene, openURLContexts: unhandledURLContexts)
+
+        // Handle app-specific universal links.
+        connectionOptions.userActivities.forEach { userActivity in
+            guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+                let incomingURL = userActivity.webpageURL,
+                let components = URLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+                return
+            }
+
+            // Handle app-specific universal links.
+            if let deepLink = DeepLinkNavigator.DeepLink(path: components.path) {
+                deepLinkNavigator.handle(deepLink: deepLink, in: scene)
+            }
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -62,5 +76,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // Handle app-specific deep links.
         deepLinkNavigator.handle(scene, openURLContexts: unhandledURLContexts)
+    }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+            let incomingURL = userActivity.webpageURL,
+            let components = URLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+            return
+        }
+
+        // Handle app-specific universal links.
+        if let deepLink = DeepLinkNavigator.DeepLink(path: components.path) {
+            deepLinkNavigator.handle(deepLink: deepLink, in: scene)
+        }
     }
 }

--- a/Examples/DeveloperCocoapodsExample/Podfile.lock
+++ b/Examples/DeveloperCocoapodsExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Appcues (1.0.0-beta.4)
+  - Appcues (1.0.1)
 
 DEPENDENCIES:
   - Appcues (from `../../Appcues.podspec`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../../Appcues.podspec"
 
 SPEC CHECKSUMS:
-  Appcues: b9656ff8a85985f3a3feaa5728c71f7ce7f164b5
+  Appcues: bffd97b9beed86388d4a438b78580c26a1941af5
 
-PODFILE CHECKSUM: d073e1e0b242bcec57ace36973467c46cd0f6c03
+PODFILE CHECKSUM: 7a3abcd818687cb341a5696d302103f523e3edc0
 
 COCOAPODS: 1.11.3

--- a/Examples/DeveloperCocoapodsExample/README.md
+++ b/Examples/DeveloperCocoapodsExample/README.md
@@ -57,3 +57,15 @@ The app supports the following deep links.
 | Events  | appcues-example://events  |
 | Profile | appcues-example://profile |
 | Group   | appcues-example://group   |
+
+## Universal Links
+
+The app supports the following universal links.
+
+> These links only work when this example app is compiled with the Appcues Team ID and Bundle ID specified in the test server[apple-app-site-association](https://appcues-mobile-links.netlify.app/.well-known/apple-app-site-association) file.
+
+| Screen  | Link                      |
+| ------- | ------------------------- |
+| Events  | https://appcues-mobile-links.netlify.app/events  |
+| Profile | https://appcues-mobile-links.netlify.app/profile |
+| Group   | https://appcues-mobile-links.netlify.app/group   |

--- a/Examples/DeveloperCocoapodsExample/README.md
+++ b/Examples/DeveloperCocoapodsExample/README.md
@@ -62,7 +62,7 @@ The app supports the following deep links.
 
 The app supports the following universal links.
 
-> These links only work when this example app is compiled with the Appcues Team ID and Bundle ID specified in the test server[apple-app-site-association](https://appcues-mobile-links.netlify.app/.well-known/apple-app-site-association) file.
+> These links only work when this example app is compiled with the Appcues Team ID and Bundle ID specified in the test server [apple-app-site-association](https://appcues-mobile-links.netlify.app/.well-known/apple-app-site-association) file.
 
 | Screen  | Link                      |
 | ------- | ------------------------- |

--- a/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
@@ -16,6 +16,7 @@ A Swift library for sending user properties and events to the Appcues API and re
 - <doc:Identifying>
 - <doc:Tracking>
 - <doc:URLSchemeConfiguring>
+- <doc:UniversalLinking>
 - ``Appcues``
 
 ### Managing Experiences

--- a/Sources/AppcuesKit/AppcuesKit.docc/UniversalLinking.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/UniversalLinking.md
@@ -1,0 +1,37 @@
+# Configuring Handling of Universal Links
+
+The Appcues iOS SDK supports universal links as an option deep linking to screens within your app.
+
+## Overview
+
+You must implement `UIApplicationDelegate.application(_:continue:restorationHandler:)` to handle your universal links. The Appcues iOS SDK will call this method for every `https` link it tries to open to allow your app a chance to handle it internally instead of opening the link in a browser.
+
+> If your app has opted into [UIKit Scenes](https://developer.apple.com/documentation/uikit/app_and_environment/scenes), you still must implement the `UIApplicationDelegate` method to handle universal links triggered from the Appcues iOS SDK.
+
+## Implementing the NSUserActivity Handler
+
+Your implementation of `UIApplicationDelegate.application(_:continue:restorationHandler:)` must return `true` if you've successfully handled the link and `false` otherwise.
+
+If needed, you can identify links coming from the Appcues iOS SDK by a `referrer` property in the `NSUserActivity.userInfo` dictionary.
+
+```swift
+// AppDelegate.swift
+
+func application(_ application: UIApplication,
+                 continue userActivity: NSUserActivity,
+                 restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool
+{
+
+    // Get URL components from the incoming user activity.
+    guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+        let incomingURL = userActivity.webpageURL else {
+        return false
+    }
+
+    if userActivity.userInfo?["referrer"] as? String == "Appcues" {
+        // This userActivity was trigged from the Appcues iOS SDK.
+    }
+
+    // TODO: Parse the `incomingURL` here and return true if the link has been handled, false otherwise.
+}
+```

--- a/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
@@ -13,9 +13,10 @@ internal protocol TopControllerGetting {
 }
 internal protocol URLOpening {
     func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?)
+    func open(potentialUniversalLink: URL) -> Bool
 }
 
-extension UIApplication: TopControllerGetting, URLOpening {
+extension UIApplication: TopControllerGetting {
 
     @available(iOS 13.0, *)
     var activeWindowScenes: [UIWindowScene] {
@@ -61,5 +62,17 @@ extension UIApplication: TopControllerGetting, URLOpening {
             return topViewController(controller: presented)
         }
         return controller
+    }
+}
+
+extension UIApplication: URLOpening {
+    func open(potentialUniversalLink url: URL) -> Bool {
+        let userActivity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        userActivity.webpageURL = url
+        // Pass some metadata to allow the `NSUserActivity` handler to know a link is coming from the Appcues SDK.
+        userActivity.userInfo = [
+            "referrer": "Appcues"
+        ]
+        return delegate?.application?(UIApplication.shared, continue: userActivity) { _ in } ?? false
     }
 }

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -91,17 +91,46 @@ class AppcuesLinkActionTests: XCTestCase {
         XCTAssertEqual(completionCount, 1)
         XCTAssertEqual(openCount, 1, "A non http(s) link must always open externally, even if that means overriding the config")
     }
+
+    func testExecuteUniversal() throws {
+        // Arrange
+        var completionCount = 0
+        var openCount = 0
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.onUniversalOpen = { url in
+            XCTAssertEqual(url.absoluteString, "https://appcues.com")
+            openCount += 1
+            return true
+        }
+        mockURLOpener.onOpen = { url in
+            XCTFail("Shouldn't be called since the URL should be handled by the universal link")
+        }
+        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": true])
+        action?.urlOpener = mockURLOpener
+
+        // Act
+        action?.execute(inContext: appcues, completion: { completionCount += 1 })
+
+        // Assert
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(openCount, 1)
+    }
 }
 
 @available(iOS 13.0, *)
 extension AppcuesLinkActionTests {
     class MockURLOpener: TopControllerGetting, URLOpening {
         var onOpen: ((URL) -> Void)?
+        var onUniversalOpen: ((URL) -> Bool)?
         var onPresent: ((UIViewController) -> Void)?
 
         func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler: ((Bool) -> Void)?) {
             onOpen?(url)
             completionHandler?(true)
+        }
+
+        func open(potentialUniversalLink: URL) -> Bool {
+            onUniversalOpen?(potentialUniversalLink) ?? false
         }
 
         func topViewController() -> UIViewController? {


### PR DESCRIPTION
This PR adds support for opening universal links in-app. As per the documentation added, an app may implement `UIApplicationDelegate.application(_:continue:restorationHandler:)` which will receive all `https` links that the SDK is asked to open via the `@appcues/link` ("Go To Link") action.

The only slightly tricky bit is that `SFSafariViewController` only supports HTTP and HTTPS URLs and crashes otherwise, and then scheme links crash the `NSUserActivity` link opener, so we have to carefully check to make sure we don't pass the wrong type of link to the wrong handler.

I also opted to include a bit of metadata so an app can detect if the universal link is coming from the Appcues SDK. I don't have a specific user case in mind for this, but it can't hurt.

- [x] Unit test added
- [x] Example app updated with sample implementation
- [x] New documentation article explaining usage

Resolves #277.