### PR TITLE
Remove developer mode from universal link entitlements

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.entitlements
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:appcues-mobile-links.netlify.app?mode=developer</string>
+		<string>applinks:appcues-mobile-links.netlify.app</string>
 	</array>
 </dict>
 </plist>

--- a/Examples/DeveloperCocoapodsExample/project.yml
+++ b/Examples/DeveloperCocoapodsExample/project.yml
@@ -16,7 +16,7 @@ targets:
       path: AppcuesCocoapodsExample.entitlements
       properties:
         com.apple.developer.associated-domains:
-          - applinks:appcues-mobile-links.netlify.app?mode=developer
+          - applinks:appcues-mobile-links.netlify.app
     postbuildScripts:
     - name: SwiftLint
       script: 'if which mint >/dev/null; then


### PR DESCRIPTION
Developer mode won't work with TestFlight builds:

> As an additional precaution, only apps that you sign with a development profile can use developer mode, and users must opt-in on any device they use.
- https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_associated-domains
