### PR TITLE
Add support for screen navigation prior to presenting new step container

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -21,45 +21,53 @@
 		CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384497BA35A275E793B475C1 /* ProfileViewController.swift */; };
 		CD156254F042866368E77CC3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 024025AF9E2E0D38C368A6AC /* Main.storyboard */; };
 		DBE453F2B40A01B4818CB84E /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */; };
-		DF0E196317DF75927E79BD28 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FCA9CA72D9AA91530A0E945 /* Pods_AppcuesCocoapodsExample.framework */; };
 		EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D26E6136C6539597C9E50A9 /* EventsViewController.swift */; };
+		FD42922352D9006BD8EC5EB7 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F84506F49A0B6D20BD26A6 /* Pods_AppcuesCocoapodsExample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		2E1A69E4D4B48E802A9AFB6B /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		384497BA35A275E793B475C1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
-		4F46C56F819DE0DC24A4FCA5 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		547A647EB6D311E97F592C7C /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
 		5548F50894583A174A85628C /* DeepLinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkNavigator.swift; sourceTree = "<group>"; };
 		5DC2B62290580560D162A8E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		5FCA9CA72D9AA91530A0E945 /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82DED1437C1DA54F0C231566 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8663BEDD1883CC408AA4A302 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		9CB61619365785F4544ED13D /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		9D26E6136C6539597C9E50A9 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
 		AAD7ED9DCA5972361B3F5E67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		C3C0870EC574CE5621433BC1 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
+		BF4337FB1DE156596E9104A6 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
 		CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		D2C0EC54920737EBD7E2961F /* AppcuesCocoapodsExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AppcuesCocoapodsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2F84506F49A0B6D20BD26A6 /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		D2847183BB55F08393116382 /* Frameworks */ = {
+		7E6B1361E0AC9FD8AFC98B85 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DF0E196317DF75927E79BD28 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
+				FD42922352D9006BD8EC5EB7 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0D250FB9D26ADBA9F6B9D7EA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D2F84506F49A0B6D20BD26A6 /* Pods_AppcuesCocoapodsExample.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		3271BCB89D21367EC1AA9069 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -70,14 +78,6 @@
 				CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */,
 			);
 			path = Fonts;
-			sourceTree = "<group>";
-		};
-		3721F5655F8704B2163CAD39 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				5FCA9CA72D9AA91530A0E945 /* Pods_AppcuesCocoapodsExample.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */ = {
@@ -99,6 +99,16 @@
 			path = CocoapodsExample;
 			sourceTree = "<group>";
 		};
+		AEF5462E9E530B934361144D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				BF4337FB1DE156596E9104A6 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
+				2E1A69E4D4B48E802A9AFB6B /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		C743E51709EACC21B03B3A23 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -112,19 +122,9 @@
 			children = (
 				8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */,
 				C743E51709EACC21B03B3A23 /* Products */,
-				EA9531E6B523D3E5D12871A3 /* Pods */,
-				3721F5655F8704B2163CAD39 /* Frameworks */,
+				AEF5462E9E530B934361144D /* Pods */,
+				0D250FB9D26ADBA9F6B9D7EA /* Frameworks */,
 			);
-			sourceTree = "<group>";
-		};
-		EA9531E6B523D3E5D12871A3 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				4F46C56F819DE0DC24A4FCA5 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
-				C3C0870EC574CE5621433BC1 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -134,12 +134,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7200554C7EB6F6E4E0D35C70 /* Build configuration list for PBXNativeTarget "AppcuesCocoapodsExample" */;
 			buildPhases = (
-				4F944A4EC3A090504EEF2BFE /* [CP] Check Pods Manifest.lock */,
+				20AA5F5ACB8697BE76346708 /* [CP] Check Pods Manifest.lock */,
 				39C4F25C30C2C38F00378FED /* Sources */,
 				4B41B1A9E3D52747D92B7344 /* Resources */,
 				6D4DB9FBC4445D937FD94125 /* SwiftLint */,
-				D2847183BB55F08393116382 /* Frameworks */,
-				F9BEA382EF808EF85D61BE4C /* [CP] Embed Pods Frameworks */,
+				7E6B1361E0AC9FD8AFC98B85 /* Frameworks */,
+				3D2CC95099D60D3FE388AE56 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -197,7 +197,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4F944A4EC3A090504EEF2BFE /* [CP] Check Pods Manifest.lock */ = {
+		20AA5F5ACB8697BE76346708 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -219,6 +219,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		3D2CC95099D60D3FE388AE56 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		6D4DB9FBC4445D937FD94125 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -236,23 +253,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.44.0\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
-		};
-		F9BEA382EF808EF85D61BE4C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -295,7 +295,7 @@
 /* Begin XCBuildConfiguration section */
 		015038143918E0C7F9D7E873 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4F46C56F819DE0DC24A4FCA5 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
+			baseConfigurationReference = BF4337FB1DE156596E9104A6 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -377,7 +377,7 @@
 		};
 		266E5C088CC8701B4117B193 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C3C0870EC574CE5621433BC1 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
+			baseConfigurationReference = 2E1A69E4D4B48E802A9AFB6B /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -52,15 +52,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         // Get URL components from the incoming user activity.
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-            let incomingURL = userActivity.webpageURL,
-            let components = URLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+              let incomingURL = userActivity.webpageURL else {
             return false
         }
 
-        if let deepLink = DeepLinkNavigator.DeepLink(path: components.path),
-           let scene = application.connectedScenes.first(where: { $0.delegate is SceneDelegate }) {
-            (scene.delegate as? SceneDelegate)?.deepLinkNavigator.handle(deepLink: deepLink, in: scene)
-            return true
+        if let sceneDelegate = application.connectedScenes.first(where: { $0.delegate is SceneDelegate })?.delegate as? SceneDelegate {
+            return sceneDelegate.deepLinkNavigator.handle(url: incomingURL)
         } else {
             return false
         }

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/DeepLinkNavigator.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/DeepLinkNavigator.swift
@@ -53,7 +53,8 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                 self.experienceID = components.experienceID
             } else if url.host == "appcues-mobile-links.netlify.app" {
                 // try to handle as a universal link to our associated domain
-                guard let destination = Destination(path: components.path) else { return nil }
+                let path = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                guard let destination = Destination(path: path) else { return nil }
                 self.destination = destination
                 self.experienceID = components.experienceID
             } else {

--- a/Examples/DeveloperCocoapodsExample/Podfile.lock
+++ b/Examples/DeveloperCocoapodsExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Appcues (1.0.1)
+  - Appcues (1.1.1)
 
 DEPENDENCIES:
   - Appcues (from `../../Appcues.podspec`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../../Appcues.podspec"
 
 SPEC CHECKSUMS:
-  Appcues: bffd97b9beed86388d4a438b78580c26a1941af5
+  Appcues: 758c5d86c18e49d09f501e771ca0cfd67651a5ce
 
 PODFILE CHECKSUM: 7a3abcd818687cb341a5696d302103f523e3edc0
 

--- a/Examples/DeveloperSPMExample/AppcuesSPMExample.entitlements
+++ b/Examples/DeveloperSPMExample/AppcuesSPMExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:appcues-mobile-links.netlify.app</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = AppcuesSPMExample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = SPMExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -326,6 +327,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = AppcuesSPMExample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = SPMExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Examples/DeveloperSPMExample/README.md
+++ b/Examples/DeveloperSPMExample/README.md
@@ -53,3 +53,15 @@ The app supports the following deep links.
 | Events  | appcues-example://events  |
 | Profile | appcues-example://profile |
 | Group   | appcues-example://group   |
+
+## Universal Links
+
+The app supports the following universal links.
+
+> These links only work when this example app is compiled with the Appcues Team ID and Bundle ID specified in the test server [apple-app-site-association](https://appcues-mobile-links.netlify.app/.well-known/apple-app-site-association) file.
+
+| Screen  | Link                      |
+| ------- | ------------------------- |
+| Events  | https://appcues-mobile-links.netlify.app/events  |
+| Profile | https://appcues-mobile-links.netlify.app/profile |
+| Group   | https://appcues-mobile-links.netlify.app/group   |

--- a/Examples/DeveloperSPMExample/SPMExample/AppDelegate.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/AppDelegate.swift
@@ -43,6 +43,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return false
     }
     */
+
+    // The Appcues link action uses this method to handle universal links.
+    func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        // Get URL components from the incoming user activity.
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL else {
+            return false
+        }
+
+        if let sceneDelegate = application.connectedScenes.first(where: { $0.delegate is SceneDelegate })?.delegate as? SceneDelegate {
+            return sceneDelegate.deepLinkNavigator.handle(url: incomingURL)
+        } else {
+            return false
+        }
+    }
 }
 
 extension Appcues {

--- a/Examples/DeveloperSPMExample/SPMExample/DeepLinkNavigator.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/DeepLinkNavigator.swift
@@ -53,7 +53,8 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                 self.experienceID = components.experienceID
             } else if url.host == "appcues-mobile-links.netlify.app" {
                 // try to handle as a universal link to our associated domain
-                guard let destination = Destination(path: components.path) else { return nil }
+                let path = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                guard let destination = Destination(path: path) else { return nil }
                 self.destination = destination
                 self.experienceID = components.experienceID
             } else {

--- a/Examples/DeveloperSPMExample/SPMExample/DeepLinkNavigator.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/DeepLinkNavigator.swift
@@ -104,13 +104,23 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
     }
 
     private func handle(url: URL?, completion: ((Bool) -> Void)?) {
-        guard
-            let url = url,
-            let target = DeepLink(url: url),
-            let windowScene = scene as? UIWindowScene,
+        guard let url = url else {
+            // no valid URL given, cannot navigate
+            completion?(false)
+            return
+        }
+
+        guard let target = DeepLink(url: url) else {
+            // the link was not a known deep link for this application, so pass along off to OS to handle
+            UIApplication.shared.open(url, options: [:]) { success in completion?(success) }
+            return
+        }
+
+        guard let windowScene = scene as? UIWindowScene,
             let window = windowScene.windows.first(where: { $0.isKeyWindow }),
             let origin = AppScreen(rootController: window.rootViewController)
         else {
+            // cannot find the screen information to navigate, fail navigation
             completion?(false)
             return
         }

--- a/Examples/DeveloperSPMExample/SPMExample/SceneDelegate.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/SceneDelegate.swift
@@ -20,11 +20,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new
         // (see `application:configurationForConnectingSceneSession` instead).
 
+        // Provide the scene to the the DeepLinkNavigator instance
+        deepLinkNavigator.scene = scene
+
         // Handle Appcues deep links.
         let unhandledURLContexts = Appcues.shared.filterAndHandle(connectionOptions.urlContexts)
 
         // Handle app-specific deep links.
-        deepLinkNavigator.handle(scene, openURLContexts: unhandledURLContexts)
+        deepLinkNavigator.handle(openURLContexts: unhandledURLContexts)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -32,12 +35,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+
+        // Remove the scene reference in the DeepLinkNavigator instance
+        deepLinkNavigator.scene = nil
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
         deepLinkNavigator.didBecomeActive()
+
+        Appcues.shared.navigationDelegate = deepLinkNavigator
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
@@ -61,6 +69,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let unhandledURLContexts = Appcues.shared.filterAndHandle(URLContexts)
 
         // Handle app-specific deep links.
-        deepLinkNavigator.handle(scene, openURLContexts: unhandledURLContexts)
+        deepLinkNavigator.handle(openURLContexts: unhandledURLContexts)
     }
 }

--- a/Examples/DeveloperSPMExample/SPMExample/SceneDelegate.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/SceneDelegate.swift
@@ -27,7 +27,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let unhandledURLContexts = Appcues.shared.filterAndHandle(connectionOptions.urlContexts)
 
         // Handle app-specific deep links.
-        deepLinkNavigator.handle(openURLContexts: unhandledURLContexts)
+        deepLinkNavigator.handle(url: unhandledURLContexts.first?.url)
+
+        // Handle app-specific universal links.
+        connectionOptions.userActivities.forEach { userActivity in
+            guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+                let incomingURL = userActivity.webpageURL else {
+                return
+            }
+
+            // Handle app-specific universal links.
+            deepLinkNavigator.handle(url: incomingURL)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -69,6 +80,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let unhandledURLContexts = Appcues.shared.filterAndHandle(URLContexts)
 
         // Handle app-specific deep links.
-        deepLinkNavigator.handle(openURLContexts: unhandledURLContexts)
+        deepLinkNavigator.handle(url: unhandledURLContexts.first?.url)
+    }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+            let incomingURL = userActivity.webpageURL else {
+            return
+        }
+
+        // Handle app-specific universal links.
+        deepLinkNavigator.handle(url: incomingURL)
     }
 }

--- a/Examples/DeveloperSPMExample/project.yml
+++ b/Examples/DeveloperSPMExample/project.yml
@@ -11,6 +11,11 @@ targets:
     platform: iOS
     sources:
     - path: SPMExample
+    entitlements:
+      path: AppcuesSPMExample.entitlements
+      properties:
+        com.apple.developer.associated-domains:
+          - applinks:appcues-mobile-links.netlify.app
     postbuildScripts:
     - name: SwiftLint
       script: 'if which mint >/dev/null; then

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -193,7 +193,7 @@ public class Appcues: NSObject {
             return
         }
 
-        experienceLoader.load(experienceID: experienceID, published: true) { result in
+        experienceLoader.load(experienceID: experienceID, published: true, trigger: .showCall) { result in
             switch result {
             case .success:
                 completion?(true, nil)

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -67,6 +67,9 @@ public class Appcues: NSObject {
     /// The delegate object that observes published analytics events
     @objc public weak var analyticsDelegate: AppcuesAnalyticsDelegate?
 
+    /// The delegate object that handles application screen navigation during experience presentation.
+    @objc public weak var navigationDelegate: AppcuesNavigationDelegate?
+
     var sessionID: UUID?
     var isActive: Bool { sessionID != nil }
 

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -121,7 +121,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                 let (experience, error) = item.parsed
                 let experiment = experiments.first { $0.experienceID == experience.id }
                 return ExperienceData(experience,
-                                      trigger: .qualification(reason: qualifyResponse.qualificationReason?.rawValue),
+                                      trigger: .qualification(reason: qualifyResponse.qualificationReason),
                                       priority: qualifyResponse.renderPriority,
                                       published: true,
                                       experiment: experiment,

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -121,6 +121,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                 let (experience, error) = item.parsed
                 let experiment = experiments.first { $0.experienceID == experience.id }
                 return ExperienceData(experience,
+                                      trigger: .qualification(reason: qualifyResponse.qualificationReason?.rawValue),
                                       priority: qualifyResponse.renderPriority,
                                       published: true,
                                       experiment: experiment,

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -127,7 +127,8 @@ extension Experience {
         }
 
         if let nextContentID = nextContentID {
-            actions.append(AppcuesLaunchExperienceAction(experienceID: nextContentID))
+            actions.append(AppcuesLaunchExperienceAction(experienceID: nextContentID,
+                                                         trigger: .experienceCompletionAction(fromExperienceID: self.id)))
         }
 
         return actions

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -13,20 +13,41 @@ internal class AppcuesLaunchExperienceAction: ExperienceAction {
     static let type = "@appcues/launch-experience"
 
     let experienceID: String
+    let trigger: ExperienceTrigger?
 
     required init?(config: [String: Any]?) {
         if let experienceID = config?["experienceID"] as? String {
             self.experienceID = experienceID
+            self.trigger = nil
         } else {
             return nil
         }
     }
 
-    init(experienceID: String) {
+    init(experienceID: String, trigger: ExperienceTrigger) {
         self.experienceID = experienceID
+
+        // This is used when a flow is triggered as a post flow action from another flow.
+        // The trigger value is set during the StateMachine processing of the post-flow actions.
+        self.trigger = trigger
     }
 
     func execute(inContext appcues: Appcues, completion: @escaping ActionRegistry.Completion) {
-        appcues.show(experienceID: experienceID) { _, _  in completion() }
+        let experienceLoading = appcues.container.resolve(ExperienceLoading.self)
+
+        // If no trigger value is passedin, we know it was not triggered by a post-flow action
+        // and we can use the standard `.launchExperienceAction` case, for a normal link within a flow
+        // that launches another flow from a button, for example.
+        let trigger = self.trigger ?? launchExperienceTrigger(appcues)
+
+        experienceLoading.load(experienceID: experienceID, published: true, trigger: trigger) { _  in
+            completion()
+        }
+    }
+
+    private func launchExperienceTrigger(_ appcues: Appcues) -> ExperienceTrigger {
+        let experienceRendering = appcues.container.resolve(ExperienceRendering.self)
+        let currentExperienceId = experienceRendering.getCurrentExperienceData()?.id
+        return .launchExperienceAction(fromExperienceID: currentExperienceId)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -46,12 +46,16 @@ internal class AppcuesLinkAction: ExperienceAction {
                 completion()
             } else {
                 if openExternally {
-                    openLink(appcues: appcues, completion: completion)
+                    // since we know it is not a univeral link at this point, and it is a web link requesting to open
+                    // externally - we will launch the link directly here with the urlOpener and not pass through the
+                    // navigationDelegate in the openLink function
+                    urlOpener.open(url, options: [:]) { _ in completion() }
                 } else {
                     urlOpener.topViewController()?.present(SFSafariViewController(url: url), animated: true, completion: completion)
                 }
             }
         } else {
+            // pass to this helper that will optionally allow a navigationDelegate to handle
             openLink(appcues: appcues, completion: completion)
         }
     }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -46,12 +46,25 @@ internal class AppcuesLinkAction: ExperienceAction {
                 completion()
             } else {
                 if openExternally {
-                    urlOpener.open(url, options: [:]) { _ in completion() }
+                    openLink(appcues: appcues, completion: completion)
                 } else {
                     urlOpener.topViewController()?.present(SFSafariViewController(url: url), animated: true, completion: completion)
                 }
             }
         } else {
+            openLink(appcues: appcues, completion: completion)
+        }
+    }
+
+    private func openLink(appcues: Appcues, completion: @escaping ActionRegistry.Completion) {
+        if let delegate = appcues.navigationDelegate {
+            // if a delegate is provided from the host application, preference is to use it for
+            // handling navigation and invoking the completion handler.
+            delegate.navigate(to: url) { _ in completion() }
+        } else {
+            // if no delegate provided, fall back to automatic handling behavior provided by the
+            // UIApplication - caveat, the completion callback may execute before the app has
+            // fully navigated to the destination.
             urlOpener.open(url, options: [:]) { _ in completion() }
         }
     }

--- a/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
@@ -100,9 +100,15 @@ internal class DeepLinkHandler: DeepLinkHandling {
     private func handle(action: Action) {
         switch action {
         case .preview(let experienceID):
-            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID, published: false, completion: nil)
+            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID,
+                                                            published: false,
+                                                            trigger: .preview,
+                                                            completion: nil)
         case .show(let experienceID):
-            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID, published: true, completion: nil)
+            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID,
+                                                            published: true,
+                                                            trigger: .deepLink,
+                                                            completion: nil)
         case .debugger(let destination):
             container?.resolve(UIDebugging.self).show(destination: destination)
         case .verifyInstall(let token):

--- a/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @available(iOS 13.0, *)
 internal protocol ExperienceLoading: AnyObject {
-    func load(experienceID: String, published: Bool, completion: ((Result<Void, Error>) -> Void)?)
+    func load(experienceID: String, published: Bool, trigger: ExperienceTrigger, completion: ((Result<Void, Error>) -> Void)?)
 }
 
 @available(iOS 13.0, *)
@@ -33,7 +33,7 @@ internal class ExperienceLoader: ExperienceLoading {
         notificationCenter.addObserver(self, selector: #selector(refreshPreview), name: .shakeToRefresh, object: nil)
     }
 
-    func load(experienceID: String, published: Bool, completion: ((Result<Void, Error>) -> Void)?) {
+    func load(experienceID: String, published: Bool, trigger: ExperienceTrigger, completion: ((Result<Void, Error>) -> Void)?) {
 
         let endpoint = published ?
             APIEndpoint.content(experienceID: experienceID) :
@@ -45,7 +45,7 @@ internal class ExperienceLoader: ExperienceLoading {
             switch result {
             case .success(let experience):
                 self?.experienceRenderer.show(
-                    experience: ExperienceData(experience, priority: .normal, published: published),
+                    experience: ExperienceData(experience, trigger: trigger, priority: .normal, published: published),
                     completion: completion)
             case .failure(let error):
                 self?.config.logger.error("Loading experience %{public}s failed with error %{public}s", experienceID, "\(error)")
@@ -60,6 +60,6 @@ internal class ExperienceLoader: ExperienceLoading {
     private func refreshPreview(notification: Notification) {
         guard let experienceID = lastPreviewExperienceID else { return }
 
-        load(experienceID: experienceID, published: false, completion: nil)
+        load(experienceID: experienceID, published: false, trigger: .preview, completion: nil)
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -153,16 +153,12 @@ extension ExperienceStateMachine.Transition {
         do {
             let package = try traitComposer.package(experience: experience, stepIndex: stepIndex)
 
-            // for pre-step navigation actions - only allow these to execute if this experience is being launched for some
-            // other reason than qualification (i.e. deep links, preview, manual show). For any qualified experience, the initial
-            // starting state of the experience is determined solely by flow settings determining the trigger
-            // (i.e. trigger on certain screen).
             let navigationActions: [Experience.Action]
-            if case .qualification = experience.trigger {
-                navigationActions = []
-            } else {
+            if experience.trigger.shouldNavigateBeforeRender {
                 let stepGroup = experience.steps[stepIndex.group]
                 navigationActions = stepGroup.actions[stepGroup.id.appcuesFormatted]?.filter { $0.trigger == "navigate" } ?? []
+            } else {
+                navigationActions = []
             }
 
             return .init(

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -154,7 +154,7 @@ extension ExperienceStateMachine.Transition {
             let package = try traitComposer.package(experience: experience, stepIndex: stepIndex)
             return .init(
                 toState: .beginningStep(experience, stepIndex, package, isFirst: true),
-                sideEffect: .presentContainer(experience, stepIndex, package)
+                sideEffect: .presentContainer(experience, stepIndex, package, [])
             )
         } catch {
             return .init(toState: nil, sideEffect: .error(.step(experience, stepIndex, "\(error)"), reset: true))
@@ -198,11 +198,15 @@ extension ExperienceStateMachine.Transition {
                 sideEffect: .error(.step(experience, currentIndex, "Step at \(stepRef) does not exist"), reset: false))
         }
 
+        let stepGroup = experience.steps[stepIndex.group]
+        let navigationActions = stepGroup.actions[stepGroup.id.uuidString.lowercased()]?.filter { $0.trigger == "navigate" } ?? []
+
         do {
+            // moving to a new step group / container, we may need to navigate the app to a new screen
             let package = try traitComposer.package(experience: experience, stepIndex: stepIndex)
             return .init(
                 toState: .beginningStep(experience, stepIndex, package, isFirst: false),
-                sideEffect: .presentContainer(experience, stepIndex, package)
+                sideEffect: .presentContainer(experience, stepIndex, package, navigationActions)
             )
         } catch {
             return .init(toState: nil, sideEffect: .error(.step(experience, stepIndex, "\(error)"), reset: true))

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -199,7 +199,7 @@ extension ExperienceStateMachine.Transition {
         }
 
         let stepGroup = experience.steps[stepIndex.group]
-        let navigationActions = stepGroup.actions[stepGroup.id.uuidString.lowercased()]?.filter { $0.trigger == "navigate" } ?? []
+        let navigationActions = stepGroup.actions[stepGroup.id.appcuesFormatted]?.filter { $0.trigger == "navigate" } ?? []
 
         do {
             // moving to a new step group / container, we may need to navigate the app to a new screen

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
@@ -9,10 +9,23 @@
 import Foundation
 
 internal enum ExperienceTrigger {
-    case qualification(reason: String?)
+    case qualification(reason: QualifyResponse.QualificationReason?)
     case experienceCompletionAction(fromExperienceID: UUID?)
     case launchExperienceAction(fromExperienceID: UUID?)
     case showCall
     case deepLink
     case preview
+
+    // for pre-step navigation actions - only allow these to execute if this experience is being launched for some
+    // other reason than qualification (i.e. deep links, preview, manual show). For any qualified experience, the initial
+    // starting state of the experience is determined solely by flow settings determining the trigger
+    // (i.e. trigger on certain screen).
+    var shouldNavigateBeforeRender: Bool {
+        switch self {
+        case .qualification:
+            return false
+        case .experienceCompletionAction, .launchExperienceAction, .showCall, .deepLink, .preview:
+            return true
+        }
+    }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
@@ -1,0 +1,18 @@
+//
+//  ExperienceTrigger.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 12/8/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal enum ExperienceTrigger {
+    case qualification(reason: String?)
+    case experienceCompletionAction(fromExperienceID: UUID?)
+    case launchExperienceAction(fromExperienceID: UUID?)
+    case showCall
+    case deepLink
+    case preview
+}

--- a/Sources/AppcuesKit/Presentation/Public/AppcuesNavigationDelegate.swift
+++ b/Sources/AppcuesKit/Presentation/Public/AppcuesNavigationDelegate.swift
@@ -15,5 +15,5 @@ public protocol AppcuesNavigationDelegate: AnyObject {
     /// - Parameters:
     ///   - url: The URL of the destination to navigate.
     ///   - completion: Closure to invoke when navigation is completed, passing `true` if successfully navigated, `false` if not.
-    func navigate(to url: URL, completion: (Bool) -> Void)
+    func navigate(to url: URL, completion: @escaping (Bool) -> Void)
 }

--- a/Sources/AppcuesKit/Presentation/Public/AppcuesNavigationDelegate.swift
+++ b/Sources/AppcuesKit/Presentation/Public/AppcuesNavigationDelegate.swift
@@ -1,0 +1,19 @@
+//
+//  AppcuesNavigationDelegate.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 11/15/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+/// Allows the application to control navigation between screens when triggered by an Appcues experience.
+@objc
+public protocol AppcuesNavigationDelegate: AnyObject {
+    /// Requests the delegate navigate to the given destination, and report completion.
+    /// - Parameters:
+    ///   - url: The URL of the destination to navigate.
+    ///   - completion: Closure to invoke when navigation is completed, passing `true` if successfully navigated, `false` if not.
+    func navigate(to url: URL, completion: (Bool) -> Void)
+}

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -17,15 +17,18 @@ internal class ExperienceData {
     let experiment: Experiment?
     let requestID: UUID?
     let error: String?
+    let trigger: ExperienceTrigger
     private let formState: FormState
 
     internal init(_ experience: Experience,
+                  trigger: ExperienceTrigger,
                   priority: RenderPriority = .normal,
                   published: Bool = true,
                   experiment: Experiment? = nil,
                   requestID: UUID? = nil,
                   error: String? = nil) {
         self.model = experience
+        self.trigger = trigger
         self.priority = priority
         self.published = published
         self.experiment = experiment

--- a/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
@@ -35,8 +35,9 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var loadCount = 0
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTAssertEqual(contentID, "123")
+            guard case .launchExperienceAction = trigger else { return XCTFail() }
             loadCount += 1
             completion?(.success(()))
         }
@@ -54,8 +55,9 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var loadCount = 0
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTAssertEqual(contentID, "123")
+            guard case .launchExperienceAction = trigger else { return XCTFail() }
             loadCount += 1
             completion?(.failure(AppcuesError.noActiveSession))
         }

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -142,9 +142,10 @@ class AppcuesTests: XCTestCase {
         appcues.sessionID = UUID()
         var completionCount = 0
         var experienceShownCount = 0
-        appcues.experienceLoader.onLoad = { experienceID, published, completion in
+        appcues.experienceLoader.onLoad = { experienceID, published, trigger, completion in
             XCTAssertEqual(true, published)
             XCTAssertEqual("1234", experienceID)
+            guard case .showCall = trigger else { return XCTFail() }
             experienceShownCount += 1
             completion?(.success(()))
         }
@@ -166,7 +167,7 @@ class AppcuesTests: XCTestCase {
         appcues.sessionID = nil
         var completionCount = 0
         var experienceShownCount = 0
-        appcues.experienceLoader.onLoad = { experienceID, published, completion in
+        appcues.experienceLoader.onLoad = { experienceID, published, trigger, completion in
             experienceShownCount += 1
             completion?(.failure(AppcuesError.noActiveSession))
         }

--- a/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
+++ b/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
@@ -45,9 +45,10 @@ class DeepLinkHandlerTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "appcues-abc://sdk/experience_preview/f0edab83-5257-47a5-81fc-80389d14905b"))
 
         var loaderCalled = false
-        appcues.experienceLoader.onLoad = { id, published, completion in
+        appcues.experienceLoader.onLoad = { id, published, trigger, completion in
             XCTAssertEqual(id, "f0edab83-5257-47a5-81fc-80389d14905b")
             XCTAssertFalse(published)
+            guard case .preview = trigger else { return XCTFail() }
             loaderCalled = true
             completion?(.success(()))
         }
@@ -66,9 +67,10 @@ class DeepLinkHandlerTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "appcues-abc://sdk/experience_content/f0edab83-5257-47a5-81fc-80389d14905b"))
 
         var loaderCalled = false
-        appcues.experienceLoader.onLoad = { id, published, completion in
+        appcues.experienceLoader.onLoad = { id, published, trigger, completion in
             XCTAssertEqual(id, "f0edab83-5257-47a5-81fc-80389d14905b")
             XCTAssertTrue(published)
+            guard case .deepLink = trigger else { return XCTFail() }
             loaderCalled = true
             completion?(.success(()))
         }

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -32,13 +32,14 @@ class ExperienceLoaderTests: XCTestCase {
         appcues.experienceRenderer.onShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
             XCTAssertTrue(experience.published)
+            guard case .showCall = experience.trigger else { return XCTFail() }
             completion?(.success(()))
         }
 
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: true) { result in
+        experienceLoader.load(experienceID: "123", published: true, trigger: .showCall) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -60,13 +61,14 @@ class ExperienceLoaderTests: XCTestCase {
         appcues.experienceRenderer.onShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
             XCTAssertFalse(experience.published)
+            guard case .preview = experience.trigger else { return XCTFail() }
             completion?(.success(()))
         }
 
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: false) { result in
+        experienceLoader.load(experienceID: "123", published: false, trigger: .preview) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -85,7 +87,7 @@ class ExperienceLoaderTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: true) { result in
+        experienceLoader.load(experienceID: "123", published: true, trigger: .showCall) { result in
             if case .failure = result {
                 completionExpectation.fulfill()
             }
@@ -100,7 +102,7 @@ class ExperienceLoaderTests: XCTestCase {
         let reloadExpectation = expectation(description: "Data loaded called")
 
         // Load the initial preview
-        experienceLoader.load(experienceID: "123", published: false, completion: nil)
+        experienceLoader.load(experienceID: "123", published: false, trigger: .preview, completion: nil)
 
         appcues.networking.onGet = { endpoint in
             XCTAssertEqual(
@@ -125,9 +127,9 @@ class ExperienceLoaderTests: XCTestCase {
         reloadExpectation.isInverted = true
 
         // Load the initial preview
-        experienceLoader.load(experienceID: "123", published: false, completion: nil)
+        experienceLoader.load(experienceID: "123", published: false, trigger: .preview, completion: nil)
         // Load a published experience
-        experienceLoader.load(experienceID: "abc", published: true, completion: nil)
+        experienceLoader.load(experienceID: "abc", published: true, trigger: .preview, completion: nil)
 
         appcues.networking.onGet = { endpoint in
             reloadExpectation.fulfill()

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -35,7 +35,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -60,7 +60,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -68,7 +68,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .normal, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -94,7 +94,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -103,7 +103,7 @@ class ExperienceRendererTests: XCTestCase {
         // NOTE: No waiting for initial .show() to complete like the test case above does.
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .normal, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -124,7 +124,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -132,7 +132,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation, presentExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             print(result)
             if case .failure(ExperienceStateMachine.ExperienceError.experienceAlreadyActive) = result {
                 failureExpectation.fulfill()
@@ -158,7 +158,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: false)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: false)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -191,8 +191,8 @@ class ExperienceRendererTests: XCTestCase {
 
         // Act
         experienceRenderer.show(qualifiedExperiences: [
-            ExperienceData(brokenExperience.model, priority: .low),
-            ExperienceData(validExperience.model, priority: .low)]) { result in
+            ExperienceData(brokenExperience.model, trigger: .qualification(reason: nil), priority: .low),
+            ExperienceData(validExperience.model, trigger: .qualification(reason: nil), priority: .low)]) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -211,7 +211,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         var preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Now that we've shown the first step, set the expectation for the 2nd step transition that we're testing
@@ -239,7 +239,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -265,13 +265,13 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(firstExperienceInstance.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(firstExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
         }
 
-        experienceRenderer.show(experience: ExperienceData(secondExperienceInstance.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(secondExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case let .failure(error) = result {
                 XCTAssertEqual(
                     error as! ExperienceStateMachine.ExperienceError,
@@ -299,7 +299,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -323,7 +323,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
             if case .failure = result {
                 failureExpectation.fulfill()
             }
@@ -344,7 +344,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -378,7 +378,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -409,7 +409,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -189,7 +189,7 @@ class ExperienceStateMachineTests: XCTestCase {
         let action: Action = .endExperience(markComplete: true)
         let stateMachine = givenState(is: initialState)
 
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTAssertEqual(contentID, ExperienceData.mock.nextContentID)
             XCTAssertTrue(published)
             nextContentLoadedExpectation.fulfill()
@@ -218,7 +218,7 @@ class ExperienceStateMachineTests: XCTestCase {
         let action: Action = .endExperience(markComplete: false)
         let stateMachine = givenState(is: initialState)
 
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTFail("no next content should be shown")
         }
 
@@ -286,7 +286,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Arrange
         let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
         let initialState: State = .idling
-        let action: Action = .startExperience(ExperienceData(experience))
+        let action: Action = .startExperience(ExperienceData(experience, trigger: .showCall))
         let stateMachine = givenState(is: initialState)
 
         // Act
@@ -300,7 +300,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Arrange
         let failedExperience = FailedExperience(id: UUID(), name: "Invalid experience", type: "mobile", publishedAt: 1632142800000, error: "could not decode")
         let initialState: State = .idling
-        let experienceData = ExperienceData(failedExperience.skeletonExperience, error: failedExperience.error)
+        let experienceData = ExperienceData(failedExperience.skeletonExperience, trigger: .showCall, error: failedExperience.error)
         let action: Action = .startExperience(experienceData)
         let stateMachine = givenState(is: initialState)
 

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -104,9 +104,9 @@ class MockStorage: DataStoring {
 
 class MockExperienceLoader: ExperienceLoading {
 
-    var onLoad: ((String, Bool, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func load(experienceID: String, published: Bool, completion: ((Result<Void, Error>) -> Void)?) {
-        onLoad?(experienceID, published, completion)
+    var onLoad: ((String, Bool, ExperienceTrigger, ((Result<Void, Error>) -> Void)?) -> Void)?
+    func load(experienceID: String, published: Bool, trigger: ExperienceTrigger, completion: ((Result<Void, Error>) -> Void)?) {
+        onLoad?(experienceID, published, trigger, completion)
     }
 }
 

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -122,7 +122,8 @@ extension Experience {
                     fixedID: "fb529214-3c78-4d6d-ba93-b55d22497ca1",
                     children: [
                         Step.Child(fixedID: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
-                    ]
+                    ],
+                    actions: ["fb529214-3c78-4d6d-ba93-b55d22497ca1" : actions]
                 ),
                 Experience.Step(
                     fixedID: "149f335f-15f6-4d8a-9e38-29a4ca435fd2",
@@ -191,8 +192,8 @@ extension ExperienceData {
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
         ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ), trigger: .showCall)
     }
-    static func mockWithStepActions(actions: [Experience.Action]) -> ExperienceData {
-        ExperienceData(.mockWithStepActions(actions: actions), trigger: .showCall)
+    static func mockWithStepActions(actions: [Experience.Action], trigger: ExperienceTrigger) -> ExperienceData {
+        ExperienceData(.mockWithStepActions(actions: actions), trigger: trigger)
     }
 
     @available(iOS 13.0, *)

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -186,13 +186,13 @@ extension Experience.Step.Child {
 }
 
 extension ExperienceData {
-    static var mock: ExperienceData { ExperienceData(.mock) }
-    static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock) }
+    static var mock: ExperienceData { ExperienceData(.mock, trigger: .showCall) }
+    static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock, trigger: .showCall) }
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
-        ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
+        ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ), trigger: .showCall)
     }
     static func mockWithStepActions(actions: [Experience.Action]) -> ExperienceData {
-        ExperienceData(.mockWithStepActions(actions: actions))
+        ExperienceData(.mockWithStepActions(actions: actions), trigger: .showCall)
     }
 
     @available(iOS 13.0, *)

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -59,7 +59,7 @@ class TraitComposerTests: XCTestCase {
             nextContentID: nil)
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -90,7 +90,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: backdropDecoratingExpectation)
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -112,7 +112,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: expectation(description: "Backdrop decorate called"))
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 1, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 1, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -128,7 +128,7 @@ class TraitComposerTests: XCTestCase {
         let experience = makeTestExperience()
 
         // Act/Assert
-        XCTAssertThrowsError(try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0)))
+        XCTAssertThrowsError(try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0)))
     }
 
     func testPackagePresenter() throws {
@@ -161,7 +161,7 @@ class TraitComposerTests: XCTestCase {
 
 
         // Act
-        let package = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         try package.presenter(nil)
         package.dismisser(nil)
@@ -195,7 +195,7 @@ class TraitComposerTests: XCTestCase {
             ],
             redirectURL: nil,
             nextContentID: nil)
-        let experienceData = ExperienceData(experience)
+        let experienceData = ExperienceData(experience, trigger: .showCall)
 
         // Act
         XCTAssertThrowsError(try traitComposer.package(experience: experienceData, stepIndex: Experience.StepIndex(group: 0, item: 0))) { error in


### PR DESCRIPTION
Draft of POC for feedback around supporting the "navigate" pre-step actions proposed here https://github.com/appcues/appcues-mobile-experience-spec/pull/118.

The changes in the SDK were fairly minimal. This also includes some updates in the SPM example to implement the AppcuesNavigationDelegate and related code restructuring to satisfy SwiftLint and little details there.

The primary logic flow is in the StateMachine `fromEndingStepToBeginningStep` - where it inspects the new step group just before starting the presentation of a new container (`presentContainer` side effect). If there are "navigate" actions, then they are passed along and executed, in sequence, prior to presenting the new container. This does _not_ occur on `fromBeginningExperienceToBeginningStep` - the first step - since the presentation on the first step should occur wherever the flow was targeted and qualified.

Some refactoring was done in `ActionRegistry` to support this new style of action execution, in addition to the couple already in there, but attempting to maintain as much shared logic flow with those code paths as possible. Part of this involved moving away from the queue processing in there and into a more direct recursive execution flow for sequential actions - so we can definitively know when an array of actions has fully completed and invoke a completion callback needed in this use case.

Also some updates in the `AppcuesLinkAction` to support the new concept of an optional `AppcuesNavigationDelegate` that can be used to execute links coming from experiences. This allows delegation of link handling to the host application, which can provide definitive completion handlers to indicate that navigation to a new screen is fully completed, prior to launching the next step in the experience.

I don't plan to merge this until we have more general consensus around how navigation steps will be handled in the builder and data model, but figured I'd post the work in progress in the meantime.