### PR TITLE
Add configuration option to control universal link handling

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -41,6 +41,8 @@ public extension Appcues {
 
         var additionalAutoProperties: [String: Any] = [:]
 
+        var enableUniversalLinks = true
+
         /// Create an Appcues SDK configuration
         /// - Parameter accountID: Appcues Account ID - a string containing an integer, copied from the Account settings page in Studio.
         /// - Parameter applicationID: Appcues Application ID - a string containing a UUID,
@@ -146,6 +148,29 @@ public extension Appcues {
         @objc
         public func additionalAutoProperties(_ additionalAutoProperties: [String: Any]) -> Self {
             self.additionalAutoProperties = self.additionalAutoProperties.merging(additionalAutoProperties)
+            return self
+        }
+
+        /// Set the universal link handling preference for the configuration.
+        ///
+        /// When this property is enabled, the SDK will pass web links that are triggered by an experience back to the host
+        /// application to process. The host application should implement the `application(_:continue:restorationHandler:)`
+        /// in its `ApplicationDelegate`, to return `true` if the link provided in the given `NSUserActivity` has been handled
+        /// as a universal link inside the current application, or `false` if not. When a value of `true` is returned, this informs the SDK
+        /// that no further link handling is needed. When a value of `false` is returned, the SDK will continue handling the link and open
+        /// the web destination in the browser.
+        ///
+        /// When this property is disabled, any web links triggered by an experience will always be opened in the browser, regardless of
+        /// whether it was a universal link that may have been intended to deep link to another screen in the app.
+        ///
+        /// The default value for this configuration is `true`.
+        ///
+        /// - Parameter enabled: Whether universal link handling is enabled.
+        /// - Returns: The `Configuration` object.
+        @discardableResult
+        @objc
+        public func enableUniversalLinks(_ enabled: Bool) -> Self {
+            self.enableUniversalLinks = enabled
             return self
         }
     }

--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -155,7 +155,7 @@ public extension Appcues {
         ///
         /// When this property is enabled, the SDK will pass web links that are triggered by an experience back to the host
         /// application to process. The host application should implement the `application(_:continue:restorationHandler:)`
-        /// in its `ApplicationDelegate`, to return `true` if the link provided in the given `NSUserActivity` has been handled
+        /// in its `ApplicationDelegate` to return `true` if the link provided in the given `NSUserActivity` has been handled
         /// as a universal link inside the current application, or `false` if not. When a value of `true` is returned, this informs the SDK
         /// that no further link handling is needed. When a value of `false` is returned, the SDK will continue handling the link and open
         /// the web destination in the browser.

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -40,7 +40,7 @@ internal class AppcuesLinkAction: ExperienceAction {
         if isWebLink {
             // Check try opening the link as if it's a universal link, and if not,
             // then fall back to the desired in-app or external browser.
-            let successfullyHandledUniversalLink = urlOpener.open(potentialUniversalLink: url)
+            let successfullyHandledUniversalLink = appcues.config.enableUniversalLinks && urlOpener.open(potentialUniversalLink: url)
 
             if successfullyHandledUniversalLink {
                 completion()

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -115,6 +115,32 @@ class AppcuesLinkActionTests: XCTestCase {
         XCTAssertEqual(completionCount, 1)
         XCTAssertEqual(openCount, 1)
     }
+
+    func testExecuteUniversalDisabled() throws {
+        // Arrange
+        var completionCount = 0
+        var openCount = 0
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.onUniversalOpen = { url in
+            XCTFail("Shouldn't be called since universal link handling is disabled")
+            return false
+        }
+        mockURLOpener.onOpen = { url in
+            XCTAssertEqual(url.absoluteString, "https://appcues.com")
+            openCount += 1
+        }
+        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": true])
+        action?.urlOpener = mockURLOpener
+        let config = Appcues.Config(accountID: "00000", applicationID: "abc").enableUniversalLinks(false)
+        let appcuesDisabledUniversalLinks = MockAppcues(config: config)
+
+        // Act
+        action?.execute(inContext: appcuesDisabledUniversalLinks, completion: { completionCount += 1 })
+
+        // Assert
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(openCount, 1)
+    }
 }
 
 @available(iOS 13.0, *)


### PR DESCRIPTION
This approach would allow a customer to opt-out of the universal link handling logic, if their app was not compatible with this approach. The issue here arose in Ionic apps, and we can update our Capacitor plugin to disable this feature, by default, to avoid common issues.