### PR TITLE
Rework experiment analytics to support new requested properties

### DIFF
--- a/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
@@ -1,5 +1,5 @@
 //
-//  UUID+Init.swift
+//  UUID+Custom.swift
 //  AppcuesKit
 //
 //  Created by Matt on 2022-04-08.
@@ -14,5 +14,9 @@ extension UUID {
 
     static func create() -> UUID {
         return UUID.generator()
+    }
+
+    var appcuesFormatted: String {
+        return uuidString.lowercased()
     }
 }

--- a/Sources/AppcuesKit/Data/Models/Experiment.swift
+++ b/Sources/AppcuesKit/Data/Models/Experiment.swift
@@ -12,6 +12,8 @@ internal struct Experiment {
     let group: String
     let experimentID: UUID
     let experienceID: UUID
+    let goalID: String
+    let contentType: String
 
     var shouldExecute: Bool {
         return group != "control"
@@ -23,5 +25,7 @@ extension Experiment: Decodable {
         case group
         case experimentID = "experimentId"
         case experienceID = "experienceId"
+        case goalID = "goalId"
+        case contentType
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -208,8 +208,11 @@ internal class ExperienceRenderer: ExperienceRendering {
         analyticsPublisher.publish(TrackingUpdate(
             type: .event(name: "appcues:experiment_entered", interactive: false),
             properties: [
-                "experimentId": experiment.experimentID.uuidString.lowercased(),
-                "group": experiment.group
+                "experimentId": experiment.experimentID.appcuesFormatted,
+                "experimentGroup": experiment.group,
+                "experimentExperienceId": experiment.experienceID.appcuesFormatted,
+                "experimentContentType": experiment.contentType,
+                "experimentGoalId": experiment.goalID
             ],
             isInternal: true))
     }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
@@ -33,7 +33,7 @@ internal enum LifecycleEvent: String, CaseIterable {
                            _ stepIndex: Experience.StepIndex? = nil,
                            error: ErrorBody? = nil) -> [String: Any] {
         var properties: [String: Any] = [
-            "experienceId": experience.id.uuidString.lowercased(),
+            "experienceId": experience.id.appcuesFormatted,
             "experienceName": experience.name,
             "experienceType": experience.type
             // TODO: Add locale values to analytics for localized experiences
@@ -46,7 +46,7 @@ internal enum LifecycleEvent: String, CaseIterable {
         }
 
         if let stepIndex = stepIndex, let step = experience.step(at: stepIndex) {
-            properties["stepId"] = step.id.uuidString.lowercased()
+            properties["stepId"] = step.id.appcuesFormatted
             properties["stepType"] = step.type
             // stepIndex is added primarily for use by the debugger
             properties["stepIndex"] = stepIndex.description
@@ -54,7 +54,7 @@ internal enum LifecycleEvent: String, CaseIterable {
 
         if let error = error {
             properties["message"] = error.message
-            properties["errorId"] = error.id.uuidString
+            properties["errorId"] = error.id.appcuesFormatted
         }
 
         return properties

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -318,7 +318,7 @@ class ExperienceRendererTests: XCTestCase {
         presentExpectation.isInverted = true
         let experience = ExperienceData.singleStepMock
         let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
-        let experiment = Experiment(group: "control", experimentID: experimentID, experienceID: experience.id)
+        let experiment = Experiment(group: "control", experimentID: experimentID, experienceID: experience.id, goalID: "my-goal", contentType: "my-content-type")
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
@@ -339,7 +339,7 @@ class ExperienceRendererTests: XCTestCase {
         let presentExpectation = expectation(description: "Experience presented")
         let experience = ExperienceData.singleStepMock
         let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
-        let experiment = Experiment(group: "exposed", experimentID: experimentID, experienceID: experience.id)
+        let experiment = Experiment(group: "exposed", experimentID: experimentID, experienceID: experience.id, goalID: "my-goal", contentType: "my-content-type")
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
@@ -359,10 +359,13 @@ class ExperienceRendererTests: XCTestCase {
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
         let experience = ExperienceData.singleStepMock
         let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
-        let experiment = Experiment(group: "control", experimentID: experimentID, experienceID: experience.id)
+        let experiment = Experiment(group: "control", experimentID: experimentID, experienceID: experience.id, goalID: "my-goal", contentType: "my-content-type")
         let properties: [String: Any] = [
-            "experimentId": experimentID.uuidString.lowercased(),
-            "group": "control"
+            "experimentId": experimentID.appcuesFormatted,
+            "experimentGroup": "control",
+            "experimentExperienceId": experience.id.appcuesFormatted,
+            "experimentGoalId": "my-goal",
+            "experimentContentType": "my-content-type"
         ]
         var experimentUpdate: TrackingUpdate?
         appcues.analyticsPublisher.onPublish = { update in
@@ -387,10 +390,13 @@ class ExperienceRendererTests: XCTestCase {
         let analyticsExpectation = expectation(description: "Triggered experiment_entered analytics")
         let experience = ExperienceData.singleStepMock
         let experimentID = UUID(uuidString: "6ce90d1d-4de2-41a6-bc93-07ae23b728c5")!
-        let experiment = Experiment(group: "exposed", experimentID: experimentID, experienceID: experience.id)
+        let experiment = Experiment(group: "exposed", experimentID: experimentID, experienceID: experience.id, goalID: "my-goal", contentType: "my-content-type")
         let properties: [String: Any] = [
-            "experimentId": experimentID.uuidString.lowercased(),
-            "group": "exposed"
+            "experimentId": experimentID.appcuesFormatted,
+            "experimentGroup": "exposed",
+            "experimentExperienceId": experience.id.appcuesFormatted,
+            "experimentGoalId": "my-goal",
+            "experimentContentType": "my-content-type"
         ]
         var experimentUpdate: TrackingUpdate?
         appcues.analyticsPublisher.onPublish = { update in

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -272,7 +272,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "version": 1632142800000,
             "experienceType": "mobile",
             "message": "error",
-            "errorId": "A6D6E248-FAFF-4789-A03C-BD7F520C1181"
+            "errorId": "a6d6e248-faff-4789-a03c-bd7f520c1181"
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
@@ -309,7 +309,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "stepId": "e03ae132-91b7-4cb0-9474-7d4a0e308a07",
             "stepIndex": "0,0",
             "message": "error",
-            "errorId": "A6D6E248-FAFF-4789-A03C-BD7F520C1181"
+            "errorId": "a6d6e248-faff-4789-a03c-bd7f520c1181"
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(


### PR DESCRIPTION
* capture 2 new properties from the response for experiments
* update the `experience_entered` analytic to output 3 additional properties and rename another

Also added extension on `UUID` for string formatting, as originally mentioned in https://github.com/appcues/appcues-ios-sdk/pull/283#discussion_r1024438630