### PR TITLE
Support lossy decoding of Experience objects in qualify response

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -117,7 +117,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
     private func process(qualifyResponse: QualifyResponse, activity: Activity) {
         if let experienceRenderer = container?.resolve(ExperienceRendering.self) {
             let experiments = qualifyResponse.experiments ?? []
-            let qualifiedExperienceData: [ExperienceData] = qualifyResponse.experiences.map { experience in
+            let qualifiedExperienceData: [ExperienceData] = qualifyResponse.experiences.parsed().map { experience in
                 let experiment = experiments.first { $0.experienceID == experience.id }
                 return ExperienceData(experience,
                                       priority: qualifyResponse.renderPriority,

--- a/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
@@ -12,11 +12,11 @@ import Foundation
 extension UUID {
     static var generator: () -> UUID = UUID.init
 
-    static func create() -> UUID {
-        return UUID.generator()
-    }
-
     var appcuesFormatted: String {
         return uuidString.lowercased()
+    }
+
+    static func create() -> UUID {
+        return UUID.generator()
     }
 }

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -170,3 +170,16 @@ extension Experience.Action: Decodable {
     }
 
 }
+
+// utility to quickly extract the list of valid Experiences from an array of
+// LossyExperience values
+extension Array where Element == LossyExperience {
+    func parsed() -> [Experience] {
+        return self.compactMap {
+            if case let .decoded(experience) = $0 {
+                return experience
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -15,6 +15,19 @@ internal protocol StepModel {
     var actions: [String: [Experience.Action]] { get }
 }
 
+internal enum LossyExperience {
+    case decoded(Experience)
+    case failed(FailedExperience)
+}
+
+internal struct FailedExperience: Decodable {
+    let id: UUID
+    let name: String?
+    let type: String?
+    let publishedAt: Int?
+    var error: String?
+}
+
 internal struct Experience {
 
     @dynamicMemberLookup

--- a/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
+++ b/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
@@ -56,14 +56,8 @@ extension QualifyResponse: Decodable {
                     let experience = try experienceContainer.decode(Experience.self)
                     decodedExperiences.append(.decoded(experience))
                     continue
-                } catch let DecodingError.dataCorrupted(context) {
-                    errorMessage = "\(context)"
-                } catch let DecodingError.keyNotFound(key, context) {
-                    errorMessage = "key '\(key)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
-                } catch let DecodingError.valueNotFound(value, context) {
-                    errorMessage = "value '\(value)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
-                } catch let DecodingError.typeMismatch(type, context) {
-                    errorMessage = "type '\(type)' mismatch: \(context.debugDescription) codingPath: \(context.codingPath)"
+                } catch let error as DecodingError {
+                    errorMessage = error.decodingErrorMessage
                 } catch {
                     errorMessage = "error: \(error)"
                 }

--- a/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
+++ b/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
@@ -82,14 +82,3 @@ extension QualifyResponse: Decodable {
         experiences = decodedExperiences
     }
 }
-
-extension Array where Element == LossyExperience {
-    func parsed() -> [Experience] {
-        return self.compactMap {
-            if case let .decoded(experience) = $0 {
-                return experience
-            }
-            return nil
-        }
-    }
-}

--- a/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
+++ b/Sources/AppcuesKit/Data/Models/QualifyResponse.swift
@@ -19,7 +19,7 @@ internal struct QualifyResponse {
     }
 
     /// Mobile experience JSON structure.
-    let experiences: [Experience]
+    let experiences: [LossyExperience]
     let performedQualification: Bool
     let qualificationReason: QualificationReason?
     let experiments: [Experiment]?
@@ -35,10 +35,61 @@ extension QualifyResponse: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        experiences = try container.decode([Experience].self, forKey: .experiences)
         performedQualification = try container.decode(Bool.self, forKey: .performedQualification)
         // Optional try so that an unknown reason is treated as nil rather than failing the decode.
         qualificationReason = try? container.decode(QualificationReason.self, forKey: .qualificationReason)
         experiments = try? container.decode([Experiment].self, forKey: .experiments)
+
+        // special handling for experiences, to be lenient of malformed JSON for any particular
+        // item in the array, and preserve any valid items in priority order - don't let one bad
+        // response item fail the entire qualification response
+        var decodedExperiences: [LossyExperience] = []
+        if var experienceContainer = try? container.nestedUnkeyedContainer(forKey: .experiences) {
+            if let count = experienceContainer.count {
+                decodedExperiences.reserveCapacity(count)
+            }
+
+            var errorMessage: String?
+
+            while !experienceContainer.isAtEnd {
+                do {
+                    let experience = try experienceContainer.decode(Experience.self)
+                    decodedExperiences.append(.decoded(experience))
+                    continue
+                } catch let DecodingError.dataCorrupted(context) {
+                    errorMessage = "\(context)"
+                } catch let DecodingError.keyNotFound(key, context) {
+                    errorMessage = "key '\(key)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
+                } catch let DecodingError.valueNotFound(value, context) {
+                    errorMessage = "value '\(value)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
+                } catch let DecodingError.typeMismatch(type, context) {
+                    errorMessage = "type '\(type)' mismatch: \(context.debugDescription) codingPath: \(context.codingPath)"
+                } catch {
+                    errorMessage = "error: \(error)"
+                }
+
+                // if we get here, it means we failed normal decoding. Try to decode the minimal
+                // info needed to report a flow issue that we can troubleshoot
+                if var element = try? experienceContainer.decode(FailedExperience.self) {
+                    element.error = errorMessage
+                    decodedExperiences.append(.failed(element))
+                } else {
+                    // cannot decode anything at all about this experience, skip it
+                    try experienceContainer.skip()
+                }
+            }
+        }
+        experiences = decodedExperiences
+    }
+}
+
+extension Array where Element == LossyExperience {
+    func parsed() -> [Experience] {
+        return self.compactMap {
+            if case let .decoded(experience) = $0 {
+                return experience
+            }
+            return nil
+        }
     }
 }

--- a/Sources/AppcuesKit/Data/Networking/DecodingError+Custom.swift
+++ b/Sources/AppcuesKit/Data/Networking/DecodingError+Custom.swift
@@ -1,0 +1,26 @@
+//
+//  DecodingError+Custom.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 12/2/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+extension DecodingError {
+    var decodingErrorMessage: String? {
+        switch self {
+        case let DecodingError.dataCorrupted(context):
+            return "\(context)"
+        case let DecodingError.keyNotFound(key, context):
+            return "key '\(key)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
+        case let DecodingError.valueNotFound(value, context):
+            return "value '\(value)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
+        case let DecodingError.typeMismatch(type, context):
+            return "type '\(type)' mismatch: \(context.debugDescription) codingPath: \(context.codingPath)"
+        @unknown default:
+            return "error: \(self)"
+        }
+    }
+}

--- a/Sources/AppcuesKit/Data/Networking/UnkeyedCodingContainer+Skip.swift
+++ b/Sources/AppcuesKit/Data/Networking/UnkeyedCodingContainer+Skip.swift
@@ -1,0 +1,18 @@
+// swiftlint:disable:this file_name
+//
+//  UnkeyedCodingContainer+Skip.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 12/2/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+private struct Empty: Decodable { }
+
+extension UnkeyedDecodingContainer {
+    mutating func skip() throws {
+        _ = try decode(Empty.self)
+    }
+}

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -47,7 +47,7 @@ class ActivityProcessorTests: XCTestCase {
                 let data = try NetworkClient.encoder.encode(activity)
                 XCTAssertEqual(data, body)
                 onPostExpectation.fulfill()
-                completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
+                completion(.success(QualifyResponse(experiences: [.decoded(self.mockExperience)], performedQualification: true, qualificationReason: nil, experiments: nil)))
             } catch {
                 XCTFail()
             }
@@ -58,7 +58,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
             resultCallbackExpectation.fulfill()
         }
 
@@ -104,7 +104,7 @@ class ActivityProcessorTests: XCTestCase {
                     XCTAssertEqual("user2", userID)
                     let data = try NetworkClient.encoder.encode(activity2)
                     XCTAssertEqual(data, body)
-                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
+                    completion(.success(QualifyResponse(experiences: [.decoded(self.mockExperience)], performedQualification: true, qualificationReason: nil, experiments: nil)))
                     onPostExpectation2.fulfill()
                 } else {
                     XCTFail()
@@ -123,7 +123,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
             resultCallbackExpectation2.fulfill()
 
         }
@@ -159,7 +159,7 @@ class ActivityProcessorTests: XCTestCase {
                     XCTAssertEqual("user2", userID)
                     let data = try NetworkClient.encoder.encode(activity2)
                     XCTAssertEqual(data, body)
-                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
+                    completion(.success(QualifyResponse(experiences: [.decoded(self.mockExperience)], performedQualification: true, qualificationReason: nil, experiments: nil)))
                     onPostExpectation2.fulfill()
                 } else {
                     XCTFail()
@@ -179,7 +179,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
             XCTAssertEqual(0, self.mockStorage.count) // all cleared out
             resultCallbackExpectation2.fulfill()
 
@@ -266,7 +266,7 @@ class ActivityProcessorTests: XCTestCase {
                     XCTAssertEqual("user2", userID)
                     let data = try NetworkClient.encoder.encode(activity2)
                     XCTAssertEqual(data, body)
-                    completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
+                    completion(.success(QualifyResponse(experiences: [.decoded(self.mockExperience)], performedQualification: true, qualificationReason: nil, experiments: nil)))
                     onPostExpectation2.fulfill()
                 } else {
                     XCTFail()
@@ -287,7 +287,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
             XCTAssertEqual(0, self.mockStorage.count) // all cleared out
             resultCallbackExpectation2.fulfill()
 
@@ -307,7 +307,7 @@ class ActivityProcessorTests: XCTestCase {
         let activity = generateMockActivity(userID: "user1", event: Event(name: "event1", attributes: ["my_key": "my_value1", "another_key": 33]))
 
         appcues.networking.onPost = { endpoint, body, requestId, completion in
-            completion(.success(QualifyResponse(experiences: [self.mockExperience], performedQualification: true, qualificationReason: nil, experiments: nil)))
+            completion(.success(QualifyResponse(experiences: [.decoded(self.mockExperience)], performedQualification: true, qualificationReason: nil, experiments: nil)))
             onPostExpectation.fulfill()
         }
 

--- a/Tests/AppcuesKitTests/Networking/PartialDictionaryDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/PartialDictionaryDecodeTests.swift
@@ -11,14 +11,6 @@ import XCTest
 
 class PartialDictionaryDecodeTests: XCTestCase {
 
-    var encoder: JSONEncoder = {
-        let encoder = JSONEncoder()
-        if #available(iOS 11.0, *) {
-            encoder.outputFormatting = .sortedKeys
-        }
-        return encoder
-    }()
-
     func testDecode() throws {
         // Arrange
         let data = #"""

--- a/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
@@ -1,0 +1,232 @@
+//
+//  QualifyResponseDecodeTests.swift
+//  AppcuesKitTests
+//
+//  Created by James Ellis on 12/2/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import AppcuesKit
+
+class QualifyResponseDecodeTests: XCTestCase {
+
+    // test lossy decoding of the experiences array returned from qualification
+    func testLossyExperienceDecode() throws {
+        // Arrange
+        let data = #"""
+        {
+            "checklists": [],
+            "contents": [],
+            "experiences": [
+                {
+                    "id": "7bba162e-9846-449c-98c7-6891adc882ea",
+                    "name": "missing type on content block",
+                    "type": "mobile",
+                    "traits": [],
+                    "steps": [
+                        {
+                            "id": "19bc7372-ce17-437e-83b6-45ec9999c8cf",
+                            "type": "group",
+                            "actions": {},
+                            "traits": [],
+                            "children": [
+                                {
+                                    "id": "d4d44dc3-160b-42df-b0f8-ac3bc178e12a",
+                                    "type": "modal",
+                                    "content": {
+                                        "id": "e61d6b61-ef92-46c4-9450-9c043cc80e39"
+                                    },
+                                    "traits": [],
+                                    "actions": {}
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+                    "name": "valid 1",
+                    "type": "mobile",
+                    "traits": [],
+                    "steps": [
+                        {
+                            "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+                            "type": "group",
+                            "actions": {},
+                            "traits": [],
+                            "children": [
+                                {
+                                    "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+                                    "type": "modal",
+                                    "content": {
+                                        "type": "spacer",
+                                        "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+                                    },
+                                    "traits": [],
+                                    "actions": {}
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "unknown": true
+                },
+                {
+                    "id": "c77a4ba2-2259-47b6-b380-76dac48f1c25",
+                    "name": "valid 2",
+                    "type": "mobile",
+                    "traits": [],
+                    "steps": [
+                        {
+                            "id": "fdfbc590-a00f-4319-aeb5-af23460b0f71",
+                            "type": "group",
+                            "actions": {},
+                            "traits": [],
+                            "children": [
+                                {
+                                    "id": "e793d69b-c89f-40a1-80b0-9146adb4ada8",
+                                    "type": "modal",
+                                    "content": {
+                                        "type": "spacer",
+                                        "id": "e2306fdd-0f95-4dc5-b5b1-75582cf79a84"
+                                    },
+                                    "traits": [],
+                                    "actions": {}
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "unknown": true
+                },
+                {
+                    "id": "6f0db437-1d1e-4d74-af4d-9cb1257b5d46",
+                    "name": "missing step traits",
+                    "type": "mobile",
+                    "traits": [],
+                    "steps": [
+                        {
+                            "id": "7dce0c8c-590e-43bc-9856-4baa77566ac1",
+                            "type": "group",
+                            "actions": {},
+                            "traits": [],
+                            "children": [
+                                {
+                                    "id": "4e3d103b-0bbb-4449-8766-d0006a1d22e1",
+                                    "type": null,
+                                    "content": {
+                                        "type": "spacer",
+                                        "id": "856fd2f6-cb18-4ade-b834-4b0fcef27915"
+                                    },
+                                    "actions": {},
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "092faf58-f52d-457d-88c5-172d128d2c25",
+                    "name": "valid 3",
+                    "type": "mobile",
+                    "traits": [],
+                    "steps": [
+                        {
+                            "id": "56629029-9478-4db3-90fa-d8bcdf247ed4",
+                            "type": "group",
+                            "actions": {},
+                            "traits": [],
+                            "children": [
+                                {
+                                    "id": "047ca98a-0511-4030-b028-765f4344e5d1",
+                                    "type": "modal",
+                                    "content": {
+                                        "type": "spacer",
+                                        "id": "70a54b3c-7a4d-449a-8d0c-91a0203eafba"
+                                    },
+                                    "traits": [],
+                                    "actions": {}
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "c9c11671-f418-451e-9b4a-33d54ed5299f",
+                    "name": "step type wrong type",
+                    "type": "mobile",
+                    "traits": [],
+                    "steps": [
+                        {
+                            "id": "4e82600a-fe5e-4072-8dd8-3833d8780b7e",
+                            "type": 12,
+                            "actions": {},
+                            "traits": [],
+                            "children": [
+                                {
+                                    "id": "ffe47297-4855-436d-87fa-e521ed211f32",
+                                    "type": "modal",
+                                    "content": {
+                                        "type": "spacer",
+                                        "id": "05fb351d-088c-4cc0-ae1e-7a13dcf2edf5"
+                                    },
+                                    "traits": [],
+                                    "actions": {}
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "performed_qualification": true,
+            "profile": {
+                "_ABGroup": 1
+            },
+            "qualification_reason": "screen_view",
+            "request_id": "814EF333-6C88-4354-985B-9B5FE930F8DB"
+        }
+        """#.data(using: .utf8)!
+
+        // Act
+        let qualifyResponse = try NetworkClient.decoder.decode(QualifyResponse.self, from: data)
+
+        // Assert
+
+        // this example has 8 experiences
+        // 0. invalid experience missing the type on the content block
+        // 1. a valid experience
+        // 2. unknown json object
+        // 3. a valid experience
+        // 4. unknown json object
+        // 5. invalid experience - step type null
+        // 6. a valid experience
+        // 7. invalid experience - step type wrong data type (number instead of string)
+        //
+        // this should result in 6 items actually getting deserialized
+        // 3 valid items - 1, 3 and 6
+        // 3 invalid items but with enough to report error - 0, 5 and 7
+        XCTAssertEqual(6, qualifyResponse.experiences.count)
+        guard case let .failed(item0) = qualifyResponse.experiences[0] else { return XCTFail() }
+        guard case let .decoded(item1) = qualifyResponse.experiences[1] else { return XCTFail() }
+        guard case let .decoded(item3) = qualifyResponse.experiences[2] else { return XCTFail() }
+        guard case let .failed(item5) = qualifyResponse.experiences[3] else { return XCTFail() }
+        guard case let .decoded(item6) = qualifyResponse.experiences[4] else { return XCTFail() }
+        guard case let .failed(item7) = qualifyResponse.experiences[5] else { return XCTFail() }
+
+        XCTAssertEqual("7bba162e-9846-449c-98c7-6891adc882ea", item0.id.appcuesFormatted)
+        XCTAssertEqual("05e78601-d7d8-449f-a074-fe3ae1144366", item1.id.appcuesFormatted)
+        XCTAssertEqual("c77a4ba2-2259-47b6-b380-76dac48f1c25", item3.id.appcuesFormatted)
+        XCTAssertEqual("6f0db437-1d1e-4d74-af4d-9cb1257b5d46", item5.id.appcuesFormatted)
+        XCTAssertEqual("092faf58-f52d-457d-88c5-172d128d2c25", item6.id.appcuesFormatted)
+        XCTAssertEqual("c9c11671-f418-451e-9b4a-33d54ed5299f", item7.id.appcuesFormatted)
+
+
+        XCTAssertTrue(item0.error!.starts(with: "key 'CodingKeys(stringValue: \"type\", intValue: nil)' not found"))
+        XCTAssertTrue(item5.error!.starts(with: "value 'String' not found: Expected String value but found null instead"))
+        XCTAssertTrue(item7.error!.starts(with: "type 'String' mismatch: Expected to decode String but found a number instead"))
+    }
+}


### PR DESCRIPTION
The general concept is very similar to what was done on Android https://github.com/appcues/appcues-android-sdk/pull/278
* `QualifyResponse` now has `[LossyExperience]` instead of `[Experience]`
* There are two possible types - a normal `.decoded(Experience)` and a `.failed(FailedExperience)`
* `FailedExperience` captures minimal info that could hopefully be used to report flow issues for troubleshooting later
* custom deserialization in the `QualifyResponse` does the attempted `Experience` deserialization on each item, error handling and capturing detailed error message, and then fallback handling for failures

an example failure message might look like this for the case of a missing required key
```
key 'CodingKeys(stringValue: "type", intValue: nil)' not found: No value associated with key CodingKeys(stringValue: "type", intValue: nil) ("type"). codingPath: [_JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "steps", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "traits", intValue: nil), _JSONKey(stringValue: "Index 2", intValue: 2)]
```
The generated output from the decoding errors is a bit gnarly, but this can be interpreted as: the key `type` was not found. The path it was expected was: index zero of the `experiences` array, in the `steps` array at index zero, in the `traits` collection at index 2.