### PR TITLE
Update Decorating traits to be removeable when applied at a step level [Traits 2.0]

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -252,6 +252,18 @@ extension ExperienceStateMachine {
 
             package.containerController.lifecycleHandler = machine
 
+            package.pageMonitor.addObserver { [weak machine, weak package] newIndex, oldIndex in
+                do {
+                    try package?.stepDecoratingTraitUpdater(newIndex, oldIndex)
+                    machine?.containerNavigated(from: oldIndex, to: newIndex)
+                } catch {
+                    // Report a fatal error and dismiss the experience
+                    let errorTargetStepIndex = Experience.StepIndex(group: stepIndex.group, item: newIndex)
+                    try? machine?.transition(.reportError(.step(experience, errorTargetStepIndex, "\(error)"), fatal: true))
+                    package?.dismisser({})
+                }
+            }
+
             // This flag tells automatic screen tracking to ignore screens that the SDK is presenting
             objc_setAssociatedObject(package.wrapperController, &UIKitScreenTracker.untrackedScreenKey, true, .OBJC_ASSOCIATION_RETAIN)
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -25,4 +25,8 @@ internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
     func decorate(backdropView: UIView) throws {
         backdropView.backgroundColor = backgroundColor
     }
+
+    func undecorate(backdropView: UIView) throws {
+        backdropView.backgroundColor = nil
+    }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -15,6 +15,8 @@ internal class AppcuesBackgroundContentTrait: StepDecoratingTrait, ContainerDeco
     let level: ExperienceTraitLevel
     let content: ExperienceComponent
 
+    private weak var backgroundViewController: UIViewController?
+
     required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
         self.level = level
 
@@ -39,10 +41,17 @@ internal class AppcuesBackgroundContentTrait: StepDecoratingTrait, ContainerDeco
 
         let emptyViewModel = ExperienceStepViewModel()
 
-        applyBackground(with: emptyViewModel, parent: containerController)
+        backgroundViewController = applyBackground(with: emptyViewModel, parent: containerController)
     }
 
-    private func applyBackground(with viewModel: ExperienceStepViewModel, parent viewController: UIViewController) {
+    func undecorate(containerController: ExperienceContainerViewController) throws {
+        if let backgroundViewController = backgroundViewController {
+            containerController.unembedChildViewController(backgroundViewController)
+        }
+    }
+
+    @discardableResult
+    private func applyBackground(with viewModel: ExperienceStepViewModel, parent viewController: UIViewController) -> UIViewController {
         // Must have the environmentObject to avoid a crash.
         let backgroundContentVC = AppcuesHostingController(rootView: content.view
             .edgesIgnoringSafeArea(.all)
@@ -66,5 +75,7 @@ internal class AppcuesBackgroundContentTrait: StepDecoratingTrait, ContainerDeco
         backgroundContentVC.didMove(toParent: viewController)
 
         viewController.view.clipsToBounds = true
+
+        return backgroundContentVC
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -41,10 +41,6 @@ extension AppcuesCarouselTrait {
 
             // By default modals cannot be interactively dismissed. The `@appcues/skippable` trait overrides this.
             self.isModalInPresentation = true
-
-            pageMonitor.addObserver { [weak self] newIndex, oldIndex in
-                self?.lifecycleHandler?.containerNavigated(from: oldIndex, to: newIndex)
-            }
         }
 
         @available(*, unavailable)

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
@@ -13,7 +13,8 @@ internal class AppcuesPagingDotsTrait: ContainerDecoratingTrait {
 
     let style: ExperienceComponent.Style?
 
-    var containerController: ExperienceContainerViewController?
+    private weak var containerController: ExperienceContainerViewController?
+    private weak var view: UIView?
 
     required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
         self.style = config?["style", decodedAs: ExperienceComponent.Style.self]
@@ -71,6 +72,11 @@ internal class AppcuesPagingDotsTrait: ContainerDecoratingTrait {
         pageControl.currentPage = containerController.pageMonitor.currentPage
 
         self.containerController = containerController
+        self.view = pageWrapView
+    }
+
+    func undecorate(containerController: ExperienceContainerViewController) throws {
+        view?.removeFromSuperview()
     }
 
     @objc

--- a/Sources/AppcuesKit/Presentation/Traits/DefaultContainerViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/DefaultContainerViewController.swift
@@ -33,10 +33,6 @@ internal class DefaultContainerViewController: ExperienceContainerViewController
 
         // By default modals cannot be interactively dismissed. The `@appcues/skippable` trait overrides this.
         self.isModalInPresentation = true
-
-        pageMonitor.addObserver { [weak self] newIndex, oldIndex in
-            self?.lifecycleHandler?.containerNavigated(from: oldIndex, to: newIndex)
-        }
     }
 
     @available(*, unavailable)

--- a/Sources/AppcuesKit/Presentation/Traits/ExperiencePackage.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/ExperiencePackage.swift
@@ -8,27 +8,33 @@
 
 import UIKit
 
-internal struct ExperiencePackage {
+internal class ExperiencePackage {
     // References to the trait instances are held here to ensure they persist the lifetime of the experience being rendered.
     private let traitInstances: [ExperienceTrait]
+    let stepDecoratingTraitUpdater: (Int, Int) throws -> Void
     let steps: [Experience.Step.Child]
     let containerController: ExperienceContainerViewController
     let wrapperController: UIViewController
+    let pageMonitor: PageMonitor
     let presenter: (_ completion: (() -> Void)?) throws -> Void
     let dismisser: (_ completion: (() -> Void)?) -> Void
 
     internal init(
         traitInstances: [ExperienceTrait],
+        stepDecoratingTraitUpdater: @escaping (Int, Int) throws -> Void,
         steps: [Experience.Step.Child],
         containerController: ExperienceContainerViewController,
         wrapperController: UIViewController,
+        pageMonitor: PageMonitor,
         presenter: @escaping ((() -> Void)?) throws -> Void,
         dismisser: @escaping ((() -> Void)?) -> Void
     ) {
         self.traitInstances = traitInstances
+        self.stepDecoratingTraitUpdater = stepDecoratingTraitUpdater
         self.steps = steps
         self.containerController = containerController
         self.wrapperController = wrapperController
+        self.pageMonitor = pageMonitor
         self.presenter = presenter
         self.dismisser = dismisser
     }

--- a/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
@@ -71,11 +71,22 @@ public protocol ContainerCreatingTrait: ExperienceTrait {
 public protocol ContainerDecoratingTrait: ExperienceTrait {
 
     /// Modify a container view controller.
-    /// - Parameter containerController: The `UIViewController` to modify.
+    /// - Parameter containerController: The `ExperienceContainerViewController` to modify.
     ///
     /// If this method cannot properly apply the trait behavior, it may throw an error of type ``TraitError``,
     /// ending the attempt to display the experience.
     func decorate(containerController: ExperienceContainerViewController) throws
+
+    /// Remove the decoratation from a container view controller.
+    /// - Parameter containerController: The `ExperienceContainerViewController` to modify.
+    ///
+    /// A call to ``undecorate(containerController:)`` should remove all modifications performed by ``decorate(containerController:)``.
+    ///
+    /// This method will only be called for traits applied at the step level when navigating between steps in a group.
+    ///
+    /// If this method cannot properly remove the trait behavior, it may throw an error of type ``TraitError``,
+    /// ending presentation of the experience.
+    func undecorate(containerController: ExperienceContainerViewController) throws
 }
 
 /// A trait that modifies the backdrop `UIView` that may be included in the presented experience.
@@ -91,6 +102,17 @@ public protocol BackdropDecoratingTrait: ExperienceTrait {
     /// If this method cannot properly apply the trait behavior, it may throw an error of type ``TraitError``,
     /// ending the attempt to display the experience.
     func decorate(backdropView: UIView) throws
+
+    /// Remove the decoratation from a backdrop view.
+    /// - Parameter backdropView: The `UIView` to modify.
+    ///
+    /// A call to ``undecorate(backdropView:)`` should remove all modifications performed by ``decorate(backdropView:)``.
+    ///
+    /// This method will only be called for traits applied at the step level when navigating between steps in a group.
+    ///
+    /// If this method cannot properly remove the trait behavior, it may throw an error of type ``TraitError``,
+    /// ending presentation of the experience.
+    func undecorate(backdropView: UIView) throws
 }
 
 /// A trait that creates a `UIViewController` that wraps the ``ExperienceContainerViewController``.

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -50,6 +50,7 @@ internal class TraitComposer: TraitComposing {
 
         let stepModelsWithTraits: [(step: Experience.Step.Child, decomposedTraits: DecomposedTraits)] = stepModels.map { stepModel in
             let decomposedStepTraits = DecomposedTraits(traits: traitRegistry.instances(for: stepModel.traits, level: .step))
+            decomposedStepTraits.propagateDecorators(from: decomposedTraits)
             return (stepModel, decomposedStepTraits)
         }
 
@@ -59,9 +60,6 @@ internal class TraitComposer: TraitComposing {
                 viewModel: viewModel,
                 stepState: experience.state(for: experience.steps[stepIndex.group].items[stepIndex.item].id),
                 notificationCenter: notificationCenter)
-            // Apply any StepDecoratingTraits that may be set at the experience or group level
-            try decomposedTraits.stepDecorating.forEach { try $0.decorate(stepController: stepViewController) }
-            // Apply StepDecoratingTraits set at the step level
             try $0.decomposedTraits.stepDecorating.forEach { try $0.decorate(stepController: stepViewController) }
             return stepViewController
         }
@@ -69,13 +67,10 @@ internal class TraitComposer: TraitComposing {
         let pageMonitor = PageMonitor(numberOfPages: stepControllers.count, currentPage: targetPageIndex)
         let containerController = try (decomposedTraits.containerCreating ?? DefaultContainerCreatingTrait())
             .createContainer(for: stepControllers, with: pageMonitor)
-        try decomposedTraits.containerDecorating.forEach { try $0.decorate(containerController: containerController) }
-
         let wrappedContainerViewController = try decomposedTraits.wrapperCreating?.createWrapper(around: containerController) ?? containerController
 
         if let wrapperCreating = decomposedTraits.wrapperCreating {
             let backdropView = UIView()
-            try decomposedTraits.backdropDecorating.forEach { try $0.decorate(backdropView: backdropView) }
             wrapperCreating.addBackdrop(backdropView: backdropView, to: wrappedContainerViewController)
 
             // Apply initial decorators for the target step
@@ -157,6 +152,30 @@ extension TraitComposer {
             containerCreating = newTraits.containerCreating ?? containerCreating
             wrapperCreating = newTraits.wrapperCreating ?? wrapperCreating
             presenting = newTraits.presenting ?? presenting
+        }
+
+        func propagateDecorators(from parentTraits: DecomposedTraits) {
+            var existingStepDecoratingTypes = Set(stepDecorating.map { type(of: $0).type })
+            parentTraits.stepDecorating.reversed().forEach {
+                // If we can insert the type into the existing set of types, then it doesn't exist in the array, so propagate it
+                if existingStepDecoratingTypes.insert(type(of: $0).type).inserted {
+                    stepDecorating.insert($0, at: 0)
+                }
+            }
+
+            var existingContainerDecoratingTypes = Set(containerDecorating.map { type(of: $0).type })
+            parentTraits.containerDecorating.reversed().forEach {
+                if existingContainerDecoratingTypes.insert(type(of: $0).type).inserted {
+                    containerDecorating.insert($0, at: 0)
+                }
+            }
+
+            var existingBackdropDecoratingTypes = Set(backdropDecorating.map { type(of: $0).type })
+            parentTraits.backdropDecorating.reversed().forEach {
+                if existingBackdropDecoratingTypes.insert(type(of: $0).type).inserted {
+                    backdropDecorating.insert($0, at: 0)
+                }
+            }
         }
     }
 

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -414,12 +414,15 @@ class ExperienceRendererTests: XCTestCase {
 private extension ExperienceData {
     @available(iOS 13.0, *)
     func packageWithDelay(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
-        let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()], pageMonitor: PageMonitor(numberOfPages: 1, currentPage: 0))
+        let pageMonitor = PageMonitor(numberOfPages: 1, currentPage: 0)
+        let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()], pageMonitor: pageMonitor)
         return ExperiencePackage(
             traitInstances: [],
+            stepDecoratingTraitUpdater: { new, prev in },
             steps: self.steps[0].items,
             containerController: containerController,
             wrapperController: containerController,
+            pageMonitor: pageMonitor,
             presenter: { completion in
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     presentExpectation?.fulfill()

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -75,6 +75,9 @@ class ExperienceStateMachineTests: XCTestCase {
         // of the completed change. This being properly set is tested in
         // test_stateIsIdling_whenStartExperience_transitionsToRenderingStep
         package.containerController.lifecycleHandler = stateMachine
+        package.pageMonitor.addObserver { newIndex, oldIndex in
+            stateMachine.containerNavigated(from: oldIndex, to: newIndex)
+        }
 
         // Act
         try stateMachine.transition(action)

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -168,12 +168,15 @@ extension ExperienceData {
 
     @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
-        let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()], pageMonitor: PageMonitor(numberOfPages: 1, currentPage: 0))
+        let pageMonitor = PageMonitor(numberOfPages: 1, currentPage: 0)
+        let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()], pageMonitor: pageMonitor)
         return ExperiencePackage(
             traitInstances: [],
+            stepDecoratingTraitUpdater: { new, prev in },
             steps: self.steps[0].items,
             containerController: containerController,
             wrapperController: containerController,
+            pageMonitor: pageMonitor,
             presenter: {
                 containerController.mockIsBeingPresented = true
                 containerController.lifecycleHandler?.containerWillAppear()

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -72,15 +72,11 @@ class TraitComposerTests: XCTestCase {
         traitRegistry.register(trait: TestTrait.self)
         traitRegistry.register(trait: TestPresentingTrait.self)
 
-        // `expectedFulfillmentCount = 2` are for traits that have multiple applied
         let stepDecoratingExpectation = expectation(description: "Step decorate called")
-        stepDecoratingExpectation.expectedFulfillmentCount = 2
         let containerCreatingExpectation = expectation(description: "Create container called")
         let containerDecoratingExpectation = expectation(description: "Container decorate called")
-        containerDecoratingExpectation.expectedFulfillmentCount = 2
         let wrapperCreatingExpectation = expectation(description: "Create wrapper called")
         let backdropDecoratingExpectation = expectation(description: "Backdrop decorate called")
-        backdropDecoratingExpectation.expectedFulfillmentCount = 2
 
         let experience = makeTestExperience(
             stepDecoratingExpectation: stepDecoratingExpectation,
@@ -123,23 +119,38 @@ class TraitComposerTests: XCTestCase {
 
         // Arrange
         traitRegistry.register(trait: TestTrait.self)
+        traitRegistry.register(trait: Test2Trait.self)
         traitRegistry.register(trait: TestPresentingTrait.self)
 
-        let experienceLevelStepDecoratingExpectation = expectation(description: "Step decorate called")
-        // ContainerCreating should be superceded by the more specific groupLevelContainerCreatingExpectation
-        let experienceLevelContainerCreatingExpectation = expectation(description: "Create container called")
+        // No experience level expectations from @test/trait should be applied because the group also has @test/trait
+        let experienceLevelStepDecoratingExpectation = expectation(description: "Experience level step decorate called")
+        experienceLevelStepDecoratingExpectation.isInverted = true
+        let experienceLevelContainerCreatingExpectation = expectation(description: "Experience level create container called")
         experienceLevelContainerCreatingExpectation.isInverted = true
-        let experienceLevelContainerDecoratingExpectation = expectation(description: "Container decorate called")
-        // WrapperCreating should be superceded by the more specific groupLevelWrapperCreatingExpectation
-        let experienceLevelWrapperCreatingExpectation = expectation(description: "Create wrapper called")
+        let experienceLevelContainerDecoratingExpectation = expectation(description: "Experience level container decorate called")
+        experienceLevelContainerDecoratingExpectation.isInverted = true
+        let experienceLevelWrapperCreatingExpectation = expectation(description: "Experience level create wrapper called")
         experienceLevelWrapperCreatingExpectation.isInverted = true
-        let experienceLevelBackdropDecoratingExpectation = expectation(description: "Backdrop decorate called")
+        let experienceLevelBackdropDecoratingExpectation = expectation(description: "Experience level backdrop decorate called")
+        experienceLevelBackdropDecoratingExpectation.isInverted = true
 
-        let groupLevelStepDecoratingExpectation = expectation(description: "Step decorate called")
-        let groupLevelContainerCreatingExpectation = expectation(description: "Create container called")
-        let groupLevelContainerDecoratingExpectation = expectation(description: "Container decorate called")
-        let groupLevelWrapperCreatingExpectation = expectation(description: "Create wrapper called")
-        let groupLevelBackdropDecoratingExpectation = expectation(description: "Backdrop decorate called")
+        // Some experience level expectations from @test/trait-2 should be applied when multiple traits with the same capability are allowed
+        let experienceLevel2StepDecoratingExpectation = expectation(description: "Experience level 2 step decorate called")
+        // ContainerCreating should be superceded by the more specific groupLevelContainerCreatingExpectation
+        let experienceLevel2ContainerCreatingExpectation = expectation(description: "Experience level 2 create container called")
+        experienceLevel2ContainerCreatingExpectation.isInverted = true
+        let experienceLevel2ContainerDecoratingExpectation = expectation(description: "Experience level 2 container decorate called")
+        // WrapperCreating should be superceded by the more specific groupLevelWrapperCreatingExpectation
+        let experienceLevel2WrapperCreatingExpectation = expectation(description: "Experience level 2 create wrapper called")
+        experienceLevel2WrapperCreatingExpectation.isInverted = true
+        let experienceLevel2BackdropDecoratingExpectation = expectation(description: "Experience level 2 backdrop decorate called")
+
+
+        let groupLevelStepDecoratingExpectation = expectation(description: "Group level step decorate called")
+        let groupLevelContainerCreatingExpectation = expectation(description: "Group level create container called")
+        let groupLevelContainerDecoratingExpectation = expectation(description: "Group level container decorate called")
+        let groupLevelWrapperCreatingExpectation = expectation(description: "Group level create wrapper called")
+        let groupLevelBackdropDecoratingExpectation = expectation(description: "Group level backdrop decorate called")
 
 
         let experience = Experience(
@@ -159,6 +170,15 @@ class TraitComposerTests: XCTestCase {
                         "containerDecoratingExpectation": experienceLevelContainerDecoratingExpectation as Any,
                         "wrapperCreatingExpectation": experienceLevelWrapperCreatingExpectation as Any,
                         "backdropDecoratingExpectation": experienceLevelBackdropDecoratingExpectation as Any
+                    ]),
+                Experience.Trait(
+                    type: "@test/trait-2",
+                    config: [
+                        "stepDecoratingExpectation": experienceLevel2StepDecoratingExpectation as Any,
+                        "containerCreatingExpectation": experienceLevel2ContainerCreatingExpectation as Any,
+                        "containerDecoratingExpectation": experienceLevel2ContainerDecoratingExpectation as Any,
+                        "wrapperCreatingExpectation": experienceLevel2WrapperCreatingExpectation as Any,
+                        "backdropDecoratingExpectation": experienceLevel2BackdropDecoratingExpectation as Any
                     ])
             ],
             steps: [
@@ -281,6 +301,74 @@ class TraitComposerTests: XCTestCase {
         }
     }
 
+    func testDecompose() throws {
+        // Arrange
+        let traits: [ExperienceTrait] = [
+            try XCTUnwrap(TestTrait(config: nil, level: .experience)),
+            try XCTUnwrap(TestPresentingTrait(config: nil, level: .experience))
+        ]
+
+        // Act
+        let decomposedTraits = TraitComposer.DecomposedTraits(traits: traits)
+
+        // Assert
+        XCTAssertEqual(decomposedTraits.allTraitInstances.count, 2)
+        XCTAssertEqual(decomposedTraits.stepDecorating.count, 1)
+        XCTAssertNotNil(decomposedTraits.containerCreating)
+        XCTAssertEqual(decomposedTraits.containerDecorating.count, 1)
+        XCTAssertEqual(decomposedTraits.backdropDecorating.count, 1)
+        XCTAssertNotNil(decomposedTraits.wrapperCreating)
+        XCTAssertNotNil(decomposedTraits.presenting)
+    }
+
+    func testAppendDecomposedTraits() throws {
+        // Arrange
+        let experienceTraits: [ExperienceTrait] = [
+            try XCTUnwrap(TestTrait(config: nil, level: .experience)),
+            try XCTUnwrap(TestPresentingTrait(config: nil, level: .experience))
+        ]
+        let groupTrait = try XCTUnwrap(TestTrait(config: nil, level: .experience))
+        let decomposedTraits = TraitComposer.DecomposedTraits(traits: experienceTraits)
+
+        // Act
+        decomposedTraits.append(contentsOf: TraitComposer.DecomposedTraits(traits: [groupTrait]))
+
+        // Assert
+        XCTAssertEqual(decomposedTraits.allTraitInstances.count, 3)
+        XCTAssertEqual(decomposedTraits.stepDecorating.count, 2)
+        XCTAssertTrue(decomposedTraits.containerCreating === groupTrait, "appended trait takes precedence over existing level")
+        XCTAssertEqual(decomposedTraits.containerDecorating.count, 2)
+        XCTAssertEqual(decomposedTraits.backdropDecorating.count, 2)
+        XCTAssertTrue(decomposedTraits.wrapperCreating === groupTrait, "appended trait takes precedence over existing level")
+        XCTAssertNotNil(decomposedTraits.presenting)
+    }
+
+    func testPropagateDecomposedTraits() throws {
+        // Arrange
+        let experienceTraits: [ExperienceTrait] = [
+            try XCTUnwrap(Test2Trait(config: nil, level: .experience)),
+            try XCTUnwrap(Test3Trait(config: nil, level: .group))
+        ]
+        let decomposedTraits = TraitComposer.DecomposedTraits(traits: experienceTraits)
+        let stepTrait = try XCTUnwrap(TestTrait(config: nil, level: .experience))
+        let decomposedStepTraits = TraitComposer.DecomposedTraits(traits: [stepTrait])
+
+        // Act
+        decomposedStepTraits.propagateDecorators(from: decomposedTraits)
+
+        // Assert
+        XCTAssertEqual(decomposedStepTraits.allTraitInstances.count, 1)
+        XCTAssertEqual(decomposedStepTraits.stepDecorating.count, 3)
+        XCTAssertEqual(decomposedStepTraits.stepDecorating.map({ type(of: $0).type }), ["@test/trait-2", "@test/trait-3", "@test/trait"])
+        XCTAssertNotNil(decomposedStepTraits.containerCreating)
+        XCTAssertEqual(decomposedStepTraits.containerDecorating.count, 3)
+        XCTAssertEqual(decomposedStepTraits.containerDecorating.map({ type(of: $0).type }), ["@test/trait-2", "@test/trait-3", "@test/trait"])
+        XCTAssertEqual(decomposedStepTraits.backdropDecorating.count, 3)
+        XCTAssertEqual(decomposedStepTraits.backdropDecorating.map({ type(of: $0).type }), ["@test/trait-2", "@test/trait-3", "@test/trait"])
+        XCTAssertNotNil(decomposedStepTraits.containerCreating)
+        XCTAssertNil(decomposedStepTraits.presenting)
+    }
+
     // MARK: - Helpers
 
     private func makeTestExperience(
@@ -362,8 +450,16 @@ private extension Experience.Step.Child {
 
 @available(iOS 13.0, *)
 extension TraitComposerTests {
+    class Test2Trait: TestTrait {
+        override class var type: String { "@test/trait-2" }
+    }
+
+    class Test3Trait: TestTrait {
+        override class var type: String { "@test/trait-3" }
+    }
+
     class TestTrait: StepDecoratingTrait, ContainerCreatingTrait, ContainerDecoratingTrait, WrapperCreatingTrait, BackdropDecoratingTrait {
-        static let type = "@test/trait"
+        class var type: String { "@test/trait" }
 
         let groupID: String?
 
@@ -410,6 +506,10 @@ extension TraitComposerTests {
             containerDecoratingExpectation?.fulfill()
         }
 
+        func undecorate(containerController: AppcuesKit.ExperienceContainerViewController) throws {
+            // no-op
+        }
+
         // WrapperCreatingTrait
 
         func createWrapper(around containerController: ExperienceContainerViewController) throws -> UIViewController {
@@ -425,6 +525,10 @@ extension TraitComposerTests {
 
         func decorate(backdropView: UIView) throws {
             backdropDecoratingExpectation?.fulfill()
+        }
+
+        func undecorate(backdropView: UIView) throws {
+            // no-op
         }
     }
 


### PR DESCRIPTION
This PR adds `undecorate` methods to `ContainerDecoratingTrait` and `BackdropDecoratingTrait` (a breaking change from 1.x) and updates TraitComposer to call these methods at the right time. It also implements the propagation of experience-level and group-level decorating traits to the step-level so that they can be decorated/undecorated as expected.

The remaining changes are to facilitate proper error reporting from the decorate/undecorate sequence. Prior to this PR, all traits were applied immediately in the `TraitComposer.package()` method, so we could handle errors right away. Now, decorations that throw errors are applied as the user navigates through a step group. The best way to handle this is to apply the decorations in the state machine where we can easily log the error events and transition to dismiss the experience.

As part of this, I moved the `containerNavigated` call from the `ExperienceContainerViewController` implementations (carousel and default) to the state machine `PageMonitor` observer block (otherwise we could get unwanted step events alongside the step error). This also has the double benefit of simplifying the code needed to implement a custom `ExperienceContainerViewController`.
