### PR TITLE
Log flow issue on experience that failed decoding

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -118,17 +118,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
         if let experienceRenderer = container?.resolve(ExperienceRendering.self) {
             let experiments = qualifyResponse.experiments ?? []
             let qualifiedExperienceData: [ExperienceData] = qualifyResponse.experiences.map { item in
-                var error: String?
-                let experience: Experience
-
-                switch item {
-                case let .decoded(success):
-                    experience = success
-                case let .failed(failure):
-                    experience = failure.skeletonExperience
-                    error = failure.error
-                }
-
+                let (experience, error) = item.parsed
                 let experiment = experiments.first { $0.experienceID == experience.id }
                 return ExperienceData(experience,
                                       priority: qualifyResponse.renderPriority,

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -171,15 +171,18 @@ extension Experience.Action: Decodable {
 
 }
 
-// utility to quickly extract the list of valid Experiences from an array of
-// LossyExperience values
-extension Array where Element == LossyExperience {
-    func parsed() -> [Experience] {
-        return self.compactMap {
-            if case let .decoded(experience) = $0 {
-                return experience
-            }
-            return nil
-        }
+extension FailedExperience {
+    // This is a synthetically generated Experience from the known values of the FailedExperience that
+    // did not parse fully from JSON. It is only used for error reporting purposes, generating a flow issue
+    // to help diagnose the parsing error.
+    var skeletonExperience: Experience {
+        Experience(id: id,
+                   name: name ?? "",
+                   type: type ?? "",
+                   publishedAt: publishedAt,
+                   traits: [],
+                   steps: [],
+                   redirectURL: nil,
+                   nextContentID: nil)
     }
 }

--- a/Sources/AppcuesKit/Data/Networking/DecodingError+Custom.swift
+++ b/Sources/AppcuesKit/Data/Networking/DecodingError+Custom.swift
@@ -10,17 +10,20 @@ import Foundation
 
 extension DecodingError {
     var decodingErrorMessage: String? {
+        let message: String
         switch self {
         case let DecodingError.dataCorrupted(context):
-            return "\(context)"
+            message = "\(context)"
         case let DecodingError.keyNotFound(key, context):
-            return "key '\(key)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
+            message = "key '\(key)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
         case let DecodingError.valueNotFound(value, context):
-            return "value '\(value)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
+            message = "value '\(value)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
         case let DecodingError.typeMismatch(type, context):
-            return "type '\(type)' mismatch: \(context.debugDescription) codingPath: \(context.codingPath)"
+            message = "type '\(type)' mismatch: \(context.debugDescription) codingPath: \(context.codingPath)"
         @unknown default:
-            return "error: \(self)"
+            message = "error: \(self)"
         }
+
+        return "Error parsing Experience JSON data: \(message)"
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -133,6 +133,11 @@ extension ExperienceStateMachine.State: CustomStringConvertible {
 @available(iOS 13.0, *)
 extension ExperienceStateMachine.Transition {
     static func fromIdlingToBeginningExperience(_ experience: ExperienceData) -> Self {
+        // handle errors that occurred prior to starting the experience - such as flow deserialization issues
+        if let error = experience.error, !error.isEmpty {
+            return .init(toState: nil, sideEffect: .error(.experience(experience, error), reset: true))
+        }
+
         guard !experience.steps.isEmpty else {
             return .init(toState: nil, sideEffect: .error(.experience(experience, "Experience has 0 steps"), reset: true))
         }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -16,18 +16,21 @@ internal class ExperienceData {
     let published: Bool
     let experiment: Experiment?
     let requestID: UUID?
+    let error: String?
     private let formState: FormState
 
     internal init(_ experience: Experience,
                   priority: RenderPriority = .normal,
                   published: Bool = true,
                   experiment: Experiment? = nil,
-                  requestID: UUID? = nil) {
+                  requestID: UUID? = nil,
+                  error: String? = nil) {
         self.model = experience
         self.priority = priority
         self.published = published
         self.experiment = experiment
         self.requestID = requestID
+        self.error = error
         self.formState = FormState(experience: experience)
     }
 

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -58,7 +58,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.parsed.0.name)
             resultCallbackExpectation.fulfill()
         }
 
@@ -123,7 +123,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.parsed.0.name)
             resultCallbackExpectation2.fulfill()
 
         }
@@ -179,7 +179,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.parsed.0.name)
             XCTAssertEqual(0, self.mockStorage.count) // all cleared out
             resultCallbackExpectation2.fulfill()
 
@@ -287,7 +287,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.first?.parsed.0.name)
             XCTAssertEqual(0, self.mockStorage.count) // all cleared out
             resultCallbackExpectation2.fulfill()
 
@@ -363,16 +363,5 @@ extension XCTestCase {
         }
         // We use a buffer here to avoid flakiness with Timer on CI
         wait(for: [waitExpectation], timeout: duration + 0.5)
-    }
-}
-
-extension Array where Element == LossyExperience {
-    func decoded() -> [Experience] {
-        return self.compactMap {
-            if case let .decoded(experience) = $0 {
-                return experience
-            }
-            return nil
-        }
     }
 }

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -58,7 +58,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
             resultCallbackExpectation.fulfill()
         }
 
@@ -123,7 +123,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
             resultCallbackExpectation2.fulfill()
 
         }
@@ -179,7 +179,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
             XCTAssertEqual(0, self.mockStorage.count) // all cleared out
             resultCallbackExpectation2.fulfill()
 
@@ -287,7 +287,7 @@ class ActivityProcessorTests: XCTestCase {
             guard case let .success(taco) = result else { return XCTFail() }
             XCTAssertEqual(true, taco.performedQualification)
             XCTAssertEqual(1, taco.experiences.count)
-            XCTAssertEqual(self.mockExperience.name, taco.experiences.parsed().first?.name)
+            XCTAssertEqual(self.mockExperience.name, taco.experiences.decoded().first?.name)
             XCTAssertEqual(0, self.mockStorage.count) // all cleared out
             resultCallbackExpectation2.fulfill()
 
@@ -363,5 +363,16 @@ extension XCTestCase {
         }
         // We use a buffer here to avoid flakiness with Timer on CI
         wait(for: [waitExpectation], timeout: duration + 0.5)
+    }
+}
+
+extension Array where Element == LossyExperience {
+    func decoded() -> [Experience] {
+        return self.compactMap {
+            if case let .decoded(experience) = $0 {
+                return experience
+            }
+            return nil
+        }
     }
 }

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -246,6 +246,21 @@ class ExperienceStateMachineTests: XCTestCase {
         XCTAssertEqual(stateMachine.state, initialState)
     }
 
+    func test_stateIsIdling_whenStartFailedExperience_noTransition() throws {
+        // Arrange
+        let failedExperience = FailedExperience(id: UUID(), name: "Invalid experience", type: "mobile", publishedAt: 1632142800000, error: "could not decode")
+        let initialState: State = .idling
+        let experienceData = ExperienceData(failedExperience.skeletonExperience, error: failedExperience.error)
+        let action: Action = .startExperience(experienceData)
+        let stateMachine = givenState(is: initialState)
+
+        // Act
+        try stateMachine.transition(action)
+
+        // Assert
+        XCTAssertEqual(stateMachine.state, initialState)
+    }
+
     func test_stateIsIdling_whenStartExperienceDelegateBlocks_noTransition() throws {
         // Arrange
         let experience = ExperienceData.mock

--- a/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
@@ -225,8 +225,8 @@ class QualifyResponseDecodeTests: XCTestCase {
         XCTAssertEqual("c9c11671-f418-451e-9b4a-33d54ed5299f", item7.id.appcuesFormatted)
 
 
-        XCTAssertTrue(item0.error!.starts(with: "key 'CodingKeys(stringValue: \"type\", intValue: nil)' not found"))
-        XCTAssertTrue(item5.error!.starts(with: "value 'String' not found: Expected String value but found null instead"))
-        XCTAssertTrue(item7.error!.starts(with: "type 'String' mismatch: Expected to decode String but found a number instead"))
+        XCTAssertTrue(item0.error!.starts(with: "Error parsing Experience JSON data: key 'CodingKeys(stringValue: \"type\", intValue: nil)' not found"))
+        XCTAssertTrue(item5.error!.starts(with: "Error parsing Experience JSON data: value 'String' not found: Expected String value but found null instead"))
+        XCTAssertTrue(item7.error!.starts(with: "Error parsing Experience JSON data: type 'String' mismatch: Expected to decode String but found a number instead"))
     }
 }


### PR DESCRIPTION
Use the info from the `FailedExperience` (minimal decode) to construct a fake `Experience` object, with an error message, solely for the purpose of recording a flow issue to diagnose the decoding failure.

Also shows in debugger - in this case, two experiences qualified. The first item failed to decode and logged error. The second item was rendered.
![Screenshot 2022-12-05 at 12 22 21 PM](https://user-images.githubusercontent.com/19266448/205707604-144acf8e-6056-4ba6-a470-9d0bf2e86ae9.png)
