### PR TITLE
🐛 Fix  wrong step state passed to steps that aren’t the first in a group

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -87,7 +87,7 @@ internal class TraitComposer: TraitComposing {
             let viewModel = ExperienceStepViewModel(step: step, actionRegistry: actionRegistry)
             let stepViewController = ExperienceStepViewController(
                 viewModel: viewModel,
-                stepState: experience.state(for: experience.steps[stepIndex.group].items[stepIndex.item].id),
+                stepState: experience.state(for: step.id),
                 notificationCenter: notificationCenter)
             try decorators.forEach { try $0.decorate(stepController: stepViewController) }
             return stepViewController


### PR DESCRIPTION
A bug introduced in #241—every step in the group was being given the `StepState` for the first step rather than its owns step.