### PR TITLE
Allow navigate actions on first step for non-qualifying experience triggers

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -193,7 +193,7 @@ public class Appcues: NSObject {
             return
         }
 
-        experienceLoader.load(experienceID: experienceID, published: true) { result in
+        experienceLoader.load(experienceID: experienceID, published: true, trigger: .showCall) { result in
             switch result {
             case .success:
                 completion?(true, nil)

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -121,7 +121,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                 let (experience, error) = item.parsed
                 let experiment = experiments.first { $0.experienceID == experience.id }
                 return ExperienceData(experience,
-                                      trigger: .qualification(reason: qualifyResponse.qualificationReason?.rawValue),
+                                      trigger: .qualification(reason: qualifyResponse.qualificationReason),
                                       priority: qualifyResponse.renderPriority,
                                       published: true,
                                       experiment: experiment,

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -121,6 +121,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                 let (experience, error) = item.parsed
                 let experiment = experiments.first { $0.experienceID == experience.id }
                 return ExperienceData(experience,
+                                      trigger: .qualification(reason: qualifyResponse.qualificationReason?.rawValue),
                                       priority: qualifyResponse.renderPriority,
                                       published: true,
                                       experiment: experiment,

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -127,7 +127,8 @@ extension Experience {
         }
 
         if let nextContentID = nextContentID {
-            actions.append(AppcuesLaunchExperienceAction(experienceID: nextContentID))
+            actions.append(AppcuesLaunchExperienceAction(experienceID: nextContentID,
+                                                         trigger: .experienceCompletionAction(fromExperienceID: self.id)))
         }
 
         return actions

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -13,20 +13,41 @@ internal class AppcuesLaunchExperienceAction: ExperienceAction {
     static let type = "@appcues/launch-experience"
 
     let experienceID: String
+    let trigger: ExperienceTrigger?
 
     required init?(config: [String: Any]?) {
         if let experienceID = config?["experienceID"] as? String {
             self.experienceID = experienceID
+            self.trigger = nil
         } else {
             return nil
         }
     }
 
-    init(experienceID: String) {
+    init(experienceID: String, trigger: ExperienceTrigger) {
         self.experienceID = experienceID
+
+        // This is used when a flow is triggered as a post flow action from another flow.
+        // The trigger value is set during the StateMachine processing of the post-flow actions.
+        self.trigger = trigger
     }
 
     func execute(inContext appcues: Appcues, completion: @escaping ActionRegistry.Completion) {
-        appcues.show(experienceID: experienceID) { _, _  in completion() }
+        let experienceLoading = appcues.container.resolve(ExperienceLoading.self)
+
+        // If no trigger value is passedin, we know it was not triggered by a post-flow action
+        // and we can use the standard `.launchExperienceAction` case, for a normal link within a flow
+        // that launches another flow from a button, for example.
+        let trigger = self.trigger ?? launchExperienceTrigger(appcues)
+
+        experienceLoading.load(experienceID: experienceID, published: true, trigger: trigger) { _  in
+            completion()
+        }
+    }
+
+    private func launchExperienceTrigger(_ appcues: Appcues) -> ExperienceTrigger {
+        let experienceRendering = appcues.container.resolve(ExperienceRendering.self)
+        let currentExperienceId = experienceRendering.getCurrentExperienceData()?.id
+        return .launchExperienceAction(fromExperienceID: currentExperienceId)
     }
 }

--- a/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
@@ -100,9 +100,15 @@ internal class DeepLinkHandler: DeepLinkHandling {
     private func handle(action: Action) {
         switch action {
         case .preview(let experienceID):
-            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID, published: false, completion: nil)
+            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID,
+                                                            published: false,
+                                                            trigger: .preview,
+                                                            completion: nil)
         case .show(let experienceID):
-            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID, published: true, completion: nil)
+            container?.resolve(ExperienceLoading.self).load(experienceID: experienceID,
+                                                            published: true,
+                                                            trigger: .deepLink,
+                                                            completion: nil)
         case .debugger(let destination):
             container?.resolve(UIDebugging.self).show(destination: destination)
         case .verifyInstall(let token):

--- a/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @available(iOS 13.0, *)
 internal protocol ExperienceLoading: AnyObject {
-    func load(experienceID: String, published: Bool, completion: ((Result<Void, Error>) -> Void)?)
+    func load(experienceID: String, published: Bool, trigger: ExperienceTrigger, completion: ((Result<Void, Error>) -> Void)?)
 }
 
 @available(iOS 13.0, *)
@@ -33,7 +33,7 @@ internal class ExperienceLoader: ExperienceLoading {
         notificationCenter.addObserver(self, selector: #selector(refreshPreview), name: .shakeToRefresh, object: nil)
     }
 
-    func load(experienceID: String, published: Bool, completion: ((Result<Void, Error>) -> Void)?) {
+    func load(experienceID: String, published: Bool, trigger: ExperienceTrigger, completion: ((Result<Void, Error>) -> Void)?) {
 
         let endpoint = published ?
             APIEndpoint.content(experienceID: experienceID) :
@@ -45,7 +45,7 @@ internal class ExperienceLoader: ExperienceLoading {
             switch result {
             case .success(let experience):
                 self?.experienceRenderer.show(
-                    experience: ExperienceData(experience, priority: .normal, published: published),
+                    experience: ExperienceData(experience, trigger: trigger, priority: .normal, published: published),
                     completion: completion)
             case .failure(let error):
                 self?.config.logger.error("Loading experience %{public}s failed with error %{public}s", experienceID, "\(error)")
@@ -60,6 +60,6 @@ internal class ExperienceLoader: ExperienceLoading {
     private func refreshPreview(notification: Notification) {
         guard let experienceID = lastPreviewExperienceID else { return }
 
-        load(experienceID: experienceID, published: false, completion: nil)
+        load(experienceID: experienceID, published: false, trigger: .preview, completion: nil)
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -153,16 +153,12 @@ extension ExperienceStateMachine.Transition {
         do {
             let package = try traitComposer.package(experience: experience, stepIndex: stepIndex)
 
-            // for pre-step navigation actions - only allow these to execute if this experience is being launched for some
-            // other reason than qualification (i.e. deep links, preview, manual show). For any qualified experience, the initial
-            // starting state of the experience is determined solely by flow settings determining the trigger
-            // (i.e. trigger on certain screen).
             let navigationActions: [Experience.Action]
-            if case .qualification = experience.trigger {
-                navigationActions = []
-            } else {
+            if experience.trigger.shouldNavigateBeforeRender {
                 let stepGroup = experience.steps[stepIndex.group]
                 navigationActions = stepGroup.actions[stepGroup.id.appcuesFormatted]?.filter { $0.trigger == "navigate" } ?? []
+            } else {
+                navigationActions = []
             }
 
             return .init(

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
@@ -9,10 +9,23 @@
 import Foundation
 
 internal enum ExperienceTrigger {
-    case qualification(reason: String?)
+    case qualification(reason: QualifyResponse.QualificationReason?)
     case experienceCompletionAction(fromExperienceID: UUID?)
     case launchExperienceAction(fromExperienceID: UUID?)
     case showCall
     case deepLink
     case preview
+
+    // for pre-step navigation actions - only allow these to execute if this experience is being launched for some
+    // other reason than qualification (i.e. deep links, preview, manual show). For any qualified experience, the initial
+    // starting state of the experience is determined solely by flow settings determining the trigger
+    // (i.e. trigger on certain screen).
+    var shouldNavigateBeforeRender: Bool {
+        switch self {
+        case .qualification:
+            return false
+        case .experienceCompletionAction, .launchExperienceAction, .showCall, .deepLink, .preview:
+            return true
+        }
+    }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
@@ -1,0 +1,18 @@
+//
+//  ExperienceTrigger.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 12/8/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal enum ExperienceTrigger {
+    case qualification(reason: String?)
+    case experienceCompletionAction(fromExperienceID: UUID?)
+    case launchExperienceAction(fromExperienceID: UUID?)
+    case showCall
+    case deepLink
+    case preview
+}

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -17,15 +17,18 @@ internal class ExperienceData {
     let experiment: Experiment?
     let requestID: UUID?
     let error: String?
+    let trigger: ExperienceTrigger
     private let formState: FormState
 
     internal init(_ experience: Experience,
+                  trigger: ExperienceTrigger,
                   priority: RenderPriority = .normal,
                   published: Bool = true,
                   experiment: Experiment? = nil,
                   requestID: UUID? = nil,
                   error: String? = nil) {
         self.model = experience
+        self.trigger = trigger
         self.priority = priority
         self.published = published
         self.experiment = experiment

--- a/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
@@ -35,8 +35,9 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var loadCount = 0
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTAssertEqual(contentID, "123")
+            guard case .launchExperienceAction = trigger else { return XCTFail() }
             loadCount += 1
             completion?(.success(()))
         }
@@ -54,8 +55,9 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var loadCount = 0
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTAssertEqual(contentID, "123")
+            guard case .launchExperienceAction = trigger else { return XCTFail() }
             loadCount += 1
             completion?(.failure(AppcuesError.noActiveSession))
         }

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -142,9 +142,10 @@ class AppcuesTests: XCTestCase {
         appcues.sessionID = UUID()
         var completionCount = 0
         var experienceShownCount = 0
-        appcues.experienceLoader.onLoad = { experienceID, published, completion in
+        appcues.experienceLoader.onLoad = { experienceID, published, trigger, completion in
             XCTAssertEqual(true, published)
             XCTAssertEqual("1234", experienceID)
+            guard case .showCall = trigger else { return XCTFail() }
             experienceShownCount += 1
             completion?(.success(()))
         }
@@ -166,7 +167,7 @@ class AppcuesTests: XCTestCase {
         appcues.sessionID = nil
         var completionCount = 0
         var experienceShownCount = 0
-        appcues.experienceLoader.onLoad = { experienceID, published, completion in
+        appcues.experienceLoader.onLoad = { experienceID, published, trigger, completion in
             experienceShownCount += 1
             completion?(.failure(AppcuesError.noActiveSession))
         }

--- a/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
+++ b/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
@@ -45,9 +45,10 @@ class DeepLinkHandlerTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "appcues-abc://sdk/experience_preview/f0edab83-5257-47a5-81fc-80389d14905b"))
 
         var loaderCalled = false
-        appcues.experienceLoader.onLoad = { id, published, completion in
+        appcues.experienceLoader.onLoad = { id, published, trigger, completion in
             XCTAssertEqual(id, "f0edab83-5257-47a5-81fc-80389d14905b")
             XCTAssertFalse(published)
+            guard case .preview = trigger else { return XCTFail() }
             loaderCalled = true
             completion?(.success(()))
         }
@@ -66,9 +67,10 @@ class DeepLinkHandlerTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "appcues-abc://sdk/experience_content/f0edab83-5257-47a5-81fc-80389d14905b"))
 
         var loaderCalled = false
-        appcues.experienceLoader.onLoad = { id, published, completion in
+        appcues.experienceLoader.onLoad = { id, published, trigger, completion in
             XCTAssertEqual(id, "f0edab83-5257-47a5-81fc-80389d14905b")
             XCTAssertTrue(published)
+            guard case .deepLink = trigger else { return XCTFail() }
             loaderCalled = true
             completion?(.success(()))
         }

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -32,13 +32,14 @@ class ExperienceLoaderTests: XCTestCase {
         appcues.experienceRenderer.onShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
             XCTAssertTrue(experience.published)
+            guard case .showCall = experience.trigger else { return XCTFail() }
             completion?(.success(()))
         }
 
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: true) { result in
+        experienceLoader.load(experienceID: "123", published: true, trigger: .showCall) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -60,13 +61,14 @@ class ExperienceLoaderTests: XCTestCase {
         appcues.experienceRenderer.onShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
             XCTAssertFalse(experience.published)
+            guard case .preview = experience.trigger else { return XCTFail() }
             completion?(.success(()))
         }
 
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: false) { result in
+        experienceLoader.load(experienceID: "123", published: false, trigger: .preview) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -85,7 +87,7 @@ class ExperienceLoaderTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: true) { result in
+        experienceLoader.load(experienceID: "123", published: true, trigger: .showCall) { result in
             if case .failure = result {
                 completionExpectation.fulfill()
             }
@@ -100,7 +102,7 @@ class ExperienceLoaderTests: XCTestCase {
         let reloadExpectation = expectation(description: "Data loaded called")
 
         // Load the initial preview
-        experienceLoader.load(experienceID: "123", published: false, completion: nil)
+        experienceLoader.load(experienceID: "123", published: false, trigger: .preview, completion: nil)
 
         appcues.networking.onGet = { endpoint in
             XCTAssertEqual(
@@ -125,9 +127,9 @@ class ExperienceLoaderTests: XCTestCase {
         reloadExpectation.isInverted = true
 
         // Load the initial preview
-        experienceLoader.load(experienceID: "123", published: false, completion: nil)
+        experienceLoader.load(experienceID: "123", published: false, trigger: .preview, completion: nil)
         // Load a published experience
-        experienceLoader.load(experienceID: "abc", published: true, completion: nil)
+        experienceLoader.load(experienceID: "abc", published: true, trigger: .preview, completion: nil)
 
         appcues.networking.onGet = { endpoint in
             reloadExpectation.fulfill()

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -35,7 +35,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -60,7 +60,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -68,7 +68,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .normal, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -94,7 +94,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -103,7 +103,7 @@ class ExperienceRendererTests: XCTestCase {
         // NOTE: No waiting for initial .show() to complete like the test case above does.
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .normal, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -124,7 +124,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -132,7 +132,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation, presentExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             print(result)
             if case .failure(ExperienceStateMachine.ExperienceError.experienceAlreadyActive) = result {
                 failureExpectation.fulfill()
@@ -158,7 +158,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: false)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: false)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -191,8 +191,8 @@ class ExperienceRendererTests: XCTestCase {
 
         // Act
         experienceRenderer.show(qualifiedExperiences: [
-            ExperienceData(brokenExperience.model, priority: .low),
-            ExperienceData(validExperience.model, priority: .low)]) { result in
+            ExperienceData(brokenExperience.model, trigger: .qualification(reason: nil), priority: .low),
+            ExperienceData(validExperience.model, trigger: .qualification(reason: nil), priority: .low)]) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -211,7 +211,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         var preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Now that we've shown the first step, set the expectation for the 2nd step transition that we're testing
@@ -239,7 +239,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -265,13 +265,13 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(firstExperienceInstance.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(firstExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
         }
 
-        experienceRenderer.show(experience: ExperienceData(secondExperienceInstance.model, priority: .low, published: true)) { result in
+        experienceRenderer.show(experience: ExperienceData(secondExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case let .failure(error) = result {
                 XCTAssertEqual(
                     error as! ExperienceStateMachine.ExperienceError,
@@ -299,7 +299,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -323,7 +323,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
             if case .failure = result {
                 failureExpectation.fulfill()
             }
@@ -344,7 +344,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment)) { result in
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -378,7 +378,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -409,7 +409,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, priority: .low, published: true, experiment: experiment), completion: nil)
+        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -189,7 +189,7 @@ class ExperienceStateMachineTests: XCTestCase {
         let action: Action = .endExperience(markComplete: true)
         let stateMachine = givenState(is: initialState)
 
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTAssertEqual(contentID, ExperienceData.mock.nextContentID)
             XCTAssertTrue(published)
             nextContentLoadedExpectation.fulfill()
@@ -218,7 +218,7 @@ class ExperienceStateMachineTests: XCTestCase {
         let action: Action = .endExperience(markComplete: false)
         let stateMachine = givenState(is: initialState)
 
-        appcues.experienceLoader.onLoad = { contentID, published, completion in
+        appcues.experienceLoader.onLoad = { contentID, published, trigger, completion in
             XCTFail("no next content should be shown")
         }
 
@@ -286,7 +286,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Arrange
         let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
         let initialState: State = .idling
-        let action: Action = .startExperience(ExperienceData(experience))
+        let action: Action = .startExperience(ExperienceData(experience, trigger: .showCall))
         let stateMachine = givenState(is: initialState)
 
         // Act
@@ -300,7 +300,7 @@ class ExperienceStateMachineTests: XCTestCase {
         // Arrange
         let failedExperience = FailedExperience(id: UUID(), name: "Invalid experience", type: "mobile", publishedAt: 1632142800000, error: "could not decode")
         let initialState: State = .idling
-        let experienceData = ExperienceData(failedExperience.skeletonExperience, error: failedExperience.error)
+        let experienceData = ExperienceData(failedExperience.skeletonExperience, trigger: .showCall, error: failedExperience.error)
         let action: Action = .startExperience(experienceData)
         let stateMachine = givenState(is: initialState)
 

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -104,9 +104,9 @@ class MockStorage: DataStoring {
 
 class MockExperienceLoader: ExperienceLoading {
 
-    var onLoad: ((String, Bool, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func load(experienceID: String, published: Bool, completion: ((Result<Void, Error>) -> Void)?) {
-        onLoad?(experienceID, published, completion)
+    var onLoad: ((String, Bool, ExperienceTrigger, ((Result<Void, Error>) -> Void)?) -> Void)?
+    func load(experienceID: String, published: Bool, trigger: ExperienceTrigger, completion: ((Result<Void, Error>) -> Void)?) {
+        onLoad?(experienceID, published, trigger, completion)
     }
 }
 

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -122,7 +122,8 @@ extension Experience {
                     fixedID: "fb529214-3c78-4d6d-ba93-b55d22497ca1",
                     children: [
                         Step.Child(fixedID: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
-                    ]
+                    ],
+                    actions: ["fb529214-3c78-4d6d-ba93-b55d22497ca1" : actions]
                 ),
                 Experience.Step(
                     fixedID: "149f335f-15f6-4d8a-9e38-29a4ca435fd2",
@@ -191,8 +192,8 @@ extension ExperienceData {
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
         ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ), trigger: .showCall)
     }
-    static func mockWithStepActions(actions: [Experience.Action]) -> ExperienceData {
-        ExperienceData(.mockWithStepActions(actions: actions), trigger: .showCall)
+    static func mockWithStepActions(actions: [Experience.Action], trigger: ExperienceTrigger) -> ExperienceData {
+        ExperienceData(.mockWithStepActions(actions: actions), trigger: trigger)
     }
 
     @available(iOS 13.0, *)

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -186,13 +186,13 @@ extension Experience.Step.Child {
 }
 
 extension ExperienceData {
-    static var mock: ExperienceData { ExperienceData(.mock) }
-    static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock) }
+    static var mock: ExperienceData { ExperienceData(.mock, trigger: .showCall) }
+    static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock, trigger: .showCall) }
     static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
-        ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ))
+        ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ), trigger: .showCall)
     }
     static func mockWithStepActions(actions: [Experience.Action]) -> ExperienceData {
-        ExperienceData(.mockWithStepActions(actions: actions))
+        ExperienceData(.mockWithStepActions(actions: actions), trigger: .showCall)
     }
 
     @available(iOS 13.0, *)

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -59,7 +59,7 @@ class TraitComposerTests: XCTestCase {
             nextContentID: nil)
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -90,7 +90,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: backdropDecoratingExpectation)
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -112,7 +112,7 @@ class TraitComposerTests: XCTestCase {
             backdropDecoratingExpectation: expectation(description: "Backdrop decorate called"))
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 1, item: 0))
+        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 1, item: 0))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -128,7 +128,7 @@ class TraitComposerTests: XCTestCase {
         let experience = makeTestExperience()
 
         // Act/Assert
-        XCTAssertThrowsError(try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0)))
+        XCTAssertThrowsError(try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0)))
     }
 
     func testPackagePresenter() throws {
@@ -161,7 +161,7 @@ class TraitComposerTests: XCTestCase {
 
 
         // Act
-        let package = try traitComposer.package(experience: ExperienceData(experience), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
 
         try package.presenter(nil)
         package.dismisser(nil)
@@ -195,7 +195,7 @@ class TraitComposerTests: XCTestCase {
             ],
             redirectURL: nil,
             nextContentID: nil)
-        let experienceData = ExperienceData(experience)
+        let experienceData = ExperienceData(experience, trigger: .showCall)
 
         // Act
         XCTAssertThrowsError(try traitComposer.package(experience: experienceData, stepIndex: Experience.StepIndex(group: 0, item: 0))) { error in


### PR DESCRIPTION
Stacks on other step navigation work in #283 

Analogous to what was done on Android side in https://github.com/appcues/appcues-android-sdk/pull/281

This PR introduces the concept of ExperienceTrigger, which defines the currently six ways an Experience can be triggered:

* builder preview
* qualification
* deep link
* show function call
* launch experience action
* post-flow completion action

This context is now stored on the `ExperienceData` object via passing through at call sites as appropriate. This allows us to detect when an Experience is being launched from a method other than the standard qualification flow, and enable pre-step navigation actions to occur if so. Qualified flows are unchanged - as the location in the app they trigger upon is based entirely on the flow settings defined in Studio, and no redirection is done on launch in those cases.

This will enable use cases like redirecting to the right page prior to showing the experience, when using the builder preview, or a deep link to a flow.

Here is an example where the app is on the Events tab, and a deep link to preview a flow with the first step targeting the Profile tab results in the app switching to the correct tab and showing the flow.

https://user-images.githubusercontent.com/19266448/206551578-8f8794de-5e00-4aeb-a420-46f84ddb0349.mov

