### PR TITLE
Enforce single instance of each trait type at each level

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -51,6 +51,44 @@ internal struct FailedExperience: Decodable {
     }
 }
 
+// a helper that deserializes a collection of traits and also enforces that
+// no trait types are duplicated within the collection
+internal struct TraitCollection: Decodable {
+    var traits: [Experience.Trait]
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+
+        var traits: [Experience.Trait] = []
+        var traitTypes = Set<String>()
+        var duplicates = Set<String>()
+
+        if let count = container.count {
+            traits.reserveCapacity(count)
+        }
+
+        while !container.isAtEnd {
+            let trait = try container.decode(Experience.Trait.self)
+            if traitTypes.insert(trait.type).inserted {
+                // normal case, capture the decoded trait for our resulting array
+                traits.append(trait)
+            } else {
+                // a dupe was found and this will end up causing a decoding error below
+                duplicates.insert(trait.type)
+            }
+        }
+
+        if !duplicates.isEmpty {
+            let message = "multiple traits of same type are not supported: \(duplicates.joined(separator: ","))"
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: decoder.codingPath,
+                                      debugDescription: message))
+        }
+
+        self.traits = traits
+    }
+}
+
 internal struct Experience {
 
     @dynamicMemberLookup
@@ -115,6 +153,18 @@ extension Experience: Decodable {
         case redirectURL = "redirectUrl"
         case nextContentID = "nextContentId"
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        type = try container.decode(String.self, forKey: .type)
+        publishedAt = try? container.decode(Int.self, forKey: .publishedAt)
+        traits = try container.decode(TraitCollection.self, forKey: .traits).traits
+        steps = try container.decode([Step].self, forKey: .steps)
+        redirectURL = try? container.decode(URL.self, forKey: .redirectURL)
+        nextContentID = try? container.decode(String.self, forKey: .nextContentID)
+    }
 }
 
 extension Experience {
@@ -141,6 +191,36 @@ extension Experience.Step: Decodable {
         let children: [Child]
         let traits: [Experience.Trait]
         let actions: [String: [Experience.Action]]
+
+        private enum CodingKeys: CodingKey {
+            case id
+            case type
+            case children
+            case traits
+            case actions
+        }
+
+        // additional constructor used in tests
+        init(id: UUID,
+             type: String,
+             children: [Child],
+             traits: [Experience.Trait],
+             actions: [String: [Experience.Action]]) {
+            self.id = id
+            self.type = type
+            self.children = children
+            self.traits = traits
+            self.actions = actions
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            type = try container.decode(String.self, forKey: .type)
+            children = try container.decode([Child].self, forKey: .children)
+            traits = try container.decode(TraitCollection.self, forKey: .traits).traits
+            actions = try container.decode([String: [Experience.Action]].self, forKey: .actions)
+        }
     }
 
     struct Child: StepModel, Decodable {
@@ -149,6 +229,37 @@ extension Experience.Step: Decodable {
         let content: ExperienceComponent
         let traits: [Experience.Trait]
         let actions: [String: [Experience.Action]]
+
+        private enum CodingKeys: CodingKey {
+            case id
+            case type
+            case content
+            case traits
+            case actions
+        }
+
+        // additional constructor required for ExperienceStepViewModel usage in background content case
+        // and used in tests
+        init(id: UUID,
+             type: String,
+             content: ExperienceComponent,
+             traits: [Experience.Trait],
+             actions: [String: [Experience.Action]]) {
+            self.id = id
+            self.type = type
+            self.content = content
+            self.traits = traits
+            self.actions = actions
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            type = try container.decode(String.self, forKey: .type)
+            content = try container.decode(ExperienceComponent.self, forKey: .content)
+            traits = try container.decode(TraitCollection.self, forKey: .traits).traits
+            actions = try container.decode([String: [Experience.Action]].self, forKey: .actions)
+        }
     }
 
     init(from decoder: Decoder) throws {

--- a/Tests/AppcuesKitTests/Networking/ExperienceDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/ExperienceDecodeTests.swift
@@ -1,0 +1,259 @@
+//
+//  ExperienceDecodeTests.swift
+//  AppcuesKitTests
+//
+//  Created by James Ellis on 12/9/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import AppcuesKit
+
+class ExperienceDecodeTests: XCTestCase {
+
+    func testValid() throws {
+        // Arrange
+        let data = #"""
+        {
+            "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+            "name": "basic valid experience",
+            "type": "mobile",
+            "traits": [],
+            "steps": [
+                {
+                    "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+                    "type": "group",
+                    "actions": {},
+                    "traits": [
+                        {
+                            "type": "group-trait",
+                            "config": {
+                                "key": "value"
+                            }
+                        }
+                    ],
+                    "children": [
+                        {
+                            "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+                            "type": "modal",
+                            "content": {
+                                "type": "spacer",
+                                "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+                            },
+                            "traits": [
+                                {
+                                    "type": "step-trait",
+                                    "config": {
+                                        "prop": 1
+                                    }
+                                }
+                            ],
+                            "actions": {
+                                "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4": [
+                                    {
+                                        "on": "tap",
+                                        "type": "action-type",
+                                        "config": {
+                                            "actionProp": true
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        """#.data(using: .utf8)!
+
+        // Act
+        let experience = try? NetworkClient.decoder.decode(Experience.self, from: data)
+
+        // Assert
+        XCTAssertNotNil(experience)
+    }
+
+    func testDuplicateStepTraitDecode() throws {
+        // Arrange
+        let data = #"""
+        {
+            "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+            "name": "duplicate step trait",
+            "type": "mobile",
+            "traits": [
+                {
+                    "type": "experience-trait"
+                }
+            ],
+            "steps": [
+                {
+                    "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+                    "type": "group",
+                    "actions": {},
+                    "traits": [
+                        {
+                            "type": "group-trait"
+                        }
+                    ],
+                    "children": [
+                        {
+                            "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+                            "type": "modal",
+                            "content": {
+                                "type": "spacer",
+                                "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+                            },
+                            "traits": [
+                                {
+                                    "type": "step-trait"
+                                },
+                                {
+                                    "type": "step-trait"
+                                }
+                            ],
+                            "actions": {}
+                        }
+                    ]
+                }
+            ]
+        }
+        """#.data(using: .utf8)!
+
+        // Act
+        var experience: Experience?
+        var error: String?
+        do {
+            experience = try NetworkClient.decoder.decode(Experience.self, from: data)
+        } catch let DecodingError.dataCorrupted(context) {
+            error = "\(context)"
+        }
+
+        // Assert
+        XCTAssertNil(experience)
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error!.contains("multiple traits of same type are not supported: step-trait"))
+    }
+
+    func testDuplicateGroupTraitDecode() throws {
+        // Arrange
+        let data = #"""
+        {
+            "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+            "name": "duplicate step trait",
+            "type": "mobile",
+            "traits": [
+                {
+                    "type": "experience-trait"
+                }
+            ],
+            "steps": [
+                {
+                    "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+                    "type": "group",
+                    "actions": {},
+                    "traits": [
+                        {
+                            "type": "group-trait"
+                        },
+                        {
+                            "type": "group-trait"
+                        }
+                    ],
+                    "children": [
+                        {
+                            "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+                            "type": "modal",
+                            "content": {
+                                "type": "spacer",
+                                "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+                            },
+                            "traits": [
+                                {
+                                    "type": "step-trait"
+                                }
+                            ],
+                            "actions": {}
+                        }
+                    ]
+                }
+            ]
+        }
+        """#.data(using: .utf8)!
+
+        // Act
+        var experience: Experience?
+        var error: String?
+        do {
+            experience = try NetworkClient.decoder.decode(Experience.self, from: data)
+        } catch let DecodingError.dataCorrupted(context) {
+            error = "\(context)"
+        }
+
+        // Assert
+        XCTAssertNil(experience)
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error!.contains("multiple traits of same type are not supported: group-trait"))
+    }
+
+    func testDuplicateExperienceTraitDecode() throws {
+        // Arrange
+        let data = #"""
+        {
+            "id": "05e78601-d7d8-449f-a074-fe3ae1144366",
+            "name": "duplicate experience trait",
+            "type": "mobile",
+            "traits": [
+                {
+                    "type": "experience-trait"
+                },
+                {
+                    "type": "experience-trait"
+                }
+            ],
+            "steps": [
+                {
+                    "id": "f7edb07c-5f96-4440-9b70-3bdd0b7675b0",
+                    "type": "group",
+                    "actions": {},
+                    "traits": [
+                        {
+                            "type": "group-trait"
+                        }
+                    ],
+                    "children": [
+                        {
+                            "id": "68bb5cc4-99b4-4f5c-a787-930ba921fc05",
+                            "type": "modal",
+                            "content": {
+                                "type": "spacer",
+                                "id": "1f9d1c11-525f-4f1c-afc1-d91b97c6a7d4"
+                            },
+                            "traits": [
+                                {
+                                    "type": "step-trait"
+                                }
+                            ],
+                            "actions": {}
+                        }
+                    ]
+                }
+            ]
+        }
+        """#.data(using: .utf8)!
+
+        // Act
+        var experience: Experience?
+        var error: String?
+        do {
+            experience = try NetworkClient.decoder.decode(Experience.self, from: data)
+        } catch let DecodingError.dataCorrupted(context) {
+            error = "\(context)"
+        }
+
+        // Assert
+        XCTAssertNil(experience)
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error!.contains("multiple traits of same type are not supported: experience-trait"))
+    }
+}

--- a/Tests/AppcuesKitTests/Networking/ExperienceDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/ExperienceDecodeTests.swift
@@ -131,8 +131,8 @@ class ExperienceDecodeTests: XCTestCase {
 
         // Assert
         XCTAssertNil(experience)
-        XCTAssertNotNil(error)
-        XCTAssertTrue(error!.contains("multiple traits of same type are not supported: step-trait"))
+        let unwrappedError = try XCTUnwrap(error)
+        XCTAssertTrue(unwrappedError.contains("multiple traits of same type are not supported: step-trait"))
     }
 
     func testDuplicateGroupTraitDecode() throws {
@@ -192,8 +192,8 @@ class ExperienceDecodeTests: XCTestCase {
 
         // Assert
         XCTAssertNil(experience)
-        XCTAssertNotNil(error)
-        XCTAssertTrue(error!.contains("multiple traits of same type are not supported: group-trait"))
+        let unwrappedError = try XCTUnwrap(error)
+        XCTAssertTrue(unwrappedError.contains("multiple traits of same type are not supported: group-trait"))
     }
 
     func testDuplicateExperienceTraitDecode() throws {
@@ -253,7 +253,7 @@ class ExperienceDecodeTests: XCTestCase {
 
         // Assert
         XCTAssertNil(experience)
-        XCTAssertNotNil(error)
-        XCTAssertTrue(error!.contains("multiple traits of same type are not supported: experience-trait"))
+        let unwrappedError = try XCTUnwrap(error)
+        XCTAssertTrue(unwrappedError.contains("multiple traits of same type are not supported: experience-trait"))
     }
 }


### PR DESCRIPTION
targeting `traits-2.0`

This is part of the 2.0 work where we've made the decision to enforce that a certain trait type, i.e. `@appcues/backdrop`, can only have a single instance at any given level of the experience (typically group or step level definitions).

* Added custom decoding in `TraitCollection` object that detects duplicate trait `type` keys at any given level, and throws a `DecodingError` if encountered.
* Updated to use in `Experience`, `Experience.Step.Group` and `Experience.Step.Child` decoding
* Tests to validate each error case and normal non-error case

If the error is detected, it will result in an Experience error like shown here
![Screenshot 2022-12-09 at 10 38 41 AM](https://user-images.githubusercontent.com/19266448/206738825-58ee67e6-a95b-406b-977a-3383c3508732.png)
