### PR TITLE
Fix Debugger expanded view layout on iPad

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -49,6 +49,7 @@ internal enum DebugUI {
                 .navigationBarTitle(Text("Debugger"))
                 .navigationBarHidden(true)
             }
+            .navigationViewStyle(StackNavigationViewStyle())
         }
     }
 


### PR DESCRIPTION
Side note, noticed that `NavigationView` is on the way out, in favor of `NavigationStack` and `NavigationSplitView`, but that is iOS 16+ minimum. https://developer.apple.com/documentation/swiftui/migrating-to-new-navigation-types

| after | before |
| ---- | ---- |
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2022-12-12 at 10 13 26](https://user-images.githubusercontent.com/19266448/207082907-d6953939-6e3e-43f1-9fbf-486eb0286c24.png)  | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2022-12-12 at 10 06 54](https://user-images.githubusercontent.com/19266448/207083015-25f61964-a2e1-4921-8238-95f473b23bf1.png) |

