### PR TITLE
Update how config values from the JSON model are provided in Trait and Action init

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -115,13 +115,15 @@ internal struct Experience {
 
     struct Trait {
         let type: String
-        let config: [String: Any]?
+        // Partially decode config so that it can be easily accessed by specific Traits with more type info.
+        let config: [String: KeyedDecodingContainer<JSONCodingKeys>]?
     }
 
     struct Action {
         let trigger: String
         let type: String
-        let config: [String: Any]?
+        // Partially decode config so that it can be easily accessed by specific Actions with more type info.
+        let config: [String: KeyedDecodingContainer<JSONCodingKeys>]?
     }
 
     let id: UUID
@@ -284,7 +286,7 @@ extension Experience.Trait: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         type = try container.decode(String.self, forKey: .type)
-        config = (try? container.partialDictionaryDecode([String: Any].self, forKey: .config)) ?? [:]
+        config = (try? container.partialDictionaryDecode(forKey: .config)) ?? [:]
     }
 }
 
@@ -300,7 +302,7 @@ extension Experience.Action: Decodable {
 
         trigger = try container.decode(String.self, forKey: .trigger)
         type = try container.decode(String.self, forKey: .type)
-        config = (try? container.decode([String: Any].self, forKey: .config)) ?? [:]
+        config = (try? container.partialDictionaryDecode(forKey: .config)) ?? [:]
     }
 
 }

--- a/Sources/AppcuesKit/Data/Networking/DecodingExperienceConfig.swift
+++ b/Sources/AppcuesKit/Data/Networking/DecodingExperienceConfig.swift
@@ -1,0 +1,51 @@
+//
+//  DecodingExperienceConfig.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-12-12.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+
+/// Object that stores the configuration options provided in ``Experience.Trait`` and ``Experience.Action`` models.
+public class DecodingExperienceConfig: NSObject {
+    // this is a class only for @objc compatibility
+
+    private let properties: [String: KeyedDecodingContainer<JSONCodingKeys>]
+
+    init(_ properties: [String: KeyedDecodingContainer<JSONCodingKeys>]?) {
+        self.properties = properties ?? [:]
+    }
+
+    /// Accesses the value associated with the given key for reading.
+    ///
+    /// The value will be decoded from the configuration to the expected type.
+    public subscript<T: Decodable>(_ key: String) -> T? {
+        guard let container = properties[key], let key = JSONCodingKeys(stringValue: key) else { return nil }
+
+        return try? container.decode(T.self, forKey: key)
+    }
+}
+
+extension DecodingExperienceConfig {
+    // Map the properties for the @appcues/update-profile action
+    var safeValues: [String: Any] {
+        properties.reduce(into: [:]) { dict, pair in
+            guard let key = JSONCodingKeys(stringValue: pair.key) else { return }
+            let container = pair.value
+
+            if let boolValue = try? container.decode(Bool.self, forKey: key) {
+                dict[key.stringValue] = boolValue
+            } else if let stringValue = try? container.decode(String.self, forKey: key) {
+                dict[key.stringValue] = stringValue
+            } else if let intValue = try? container.decode(Int.self, forKey: key) {
+                dict[key.stringValue] = intValue
+            } else if let doubleValue = try? container.decode(Double.self, forKey: key) {
+                dict[key.stringValue] = doubleValue
+            } else {
+                // not a supported type
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Data/Networking/KeyedDecodingContainer+PartialDictionaryDecode.swift
+++ b/Sources/AppcuesKit/Data/Networking/KeyedDecodingContainer+PartialDictionaryDecode.swift
@@ -10,51 +10,17 @@ import Foundation
 
 extension KeyedDecodingContainer {
 
-    /// Partially decode a JSON dictionary to primitive values, while leaving nested objects to be decoded to proper model types later on.
-    ///
-    /// Decodes `String`, `Bool`, `Int`, and `Double` to their primitive values.
-    /// Anything else is mapped as a `KeyedDecodingContainer` and left to be decoded elsewhere where more type info may be known.
-    ///
-    /// **Example Usage**
-    /// ```swift
-    /// if let rawData = config?["key"] as? KeyedDecodingContainer<JSONCodingKeys>,
-    ///    let key = JSONCodingKeys(stringValue: "key"),
-    ///    let mappedModel = try? rawData.decode(MyModel.self, forKey: key) {
-    ///     // do something with mappedModel
-    /// }
-    /// ```
-    func partialDictionaryDecode(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any] {
-        let container = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
-        return try container.partialDictionaryDecode(type)
-    }
-
-    func partialDictionaryDecode(_ type: [String: Any].Type) throws -> [String: Any] {
-        var dictionary = [String: Any]()
-
-        for key in allKeys {
-            if let boolValue = try? decode(Bool.self, forKey: key) {
-                dictionary[key.stringValue] = boolValue
-            } else if let stringValue = try? decode(String.self, forKey: key) {
-                dictionary[key.stringValue] = stringValue
-            } else if let intValue = try? decode(Int.self, forKey: key) {
-                dictionary[key.stringValue] = intValue
-            } else if let doubleValue = try? decode(Double.self, forKey: key) {
-                dictionary[key.stringValue] = doubleValue
-            } else {
-                dictionary[key.stringValue] = self
-            }
-        }
-        return dictionary
+    /// Partially decode a JSON dictionary, leaving nested objects to be decoded to proper model types later on
+    /// when more type info may be known.
+    func partialDictionaryDecode(forKey key: K) throws -> [String: KeyedDecodingContainer<JSONCodingKeys>] {
+        try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key).partialDictionaryDecode()
     }
 }
 
-public extension Dictionary where Key == String, Value == Any {
-
-    /// Designed for use in Appcues `ExperienceTrait` implementations where the `config` dictionary stores partially decoded containers.
-    subscript<T: Decodable>(_ key: Key, decodedAs type: T.Type) -> T? {
-        guard let container = self[key] as? KeyedDecodingContainer<JSONCodingKeys>,
-              let key = JSONCodingKeys(stringValue: key) else { return nil }
-
-        return try? container.decode(T.self, forKey: key)
+extension KeyedDecodingContainer where K == JSONCodingKeys {
+    func partialDictionaryDecode() throws -> [String: KeyedDecodingContainer<JSONCodingKeys>] {
+        allKeys.reduce(into: [:]) { dict, key in
+            dict[key.stringValue] = self
+        }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -70,7 +70,7 @@ internal class ActionRegistry {
     /// Enqueue an experience action data model to be executed.
     func enqueue(actionModels: [Experience.Action], interactionType: String, viewDescription: String?) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(config: $0.config)
+            actions[$0.type]?.init(config: DecodingExperienceConfig($0.config))
         }
 
         // As a heuristic, take the last action that's `MetadataSettingAction`, since that's most likely

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
@@ -16,8 +16,8 @@ internal class AppcuesCloseAction: ExperienceAction {
 
     let markComplete: Bool
 
-    required init?(config: [String: Any]?) {
-        markComplete = config?["markComplete"] as? Bool ?? false
+    required init?(config: DecodingExperienceConfig) {
+        markComplete = config["markComplete"] ?? false
     }
 
     func execute(inContext appcues: Appcues, completion: @escaping ActionRegistry.Completion) {

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
@@ -14,13 +14,13 @@ internal class AppcuesContinueAction: ExperienceAction {
 
     let stepReference: StepReference
 
-    required init?(config: [String: Any]?) {
-        if let index = config?["index"] as? Int {
+    required init?(config: DecodingExperienceConfig) {
+        if let index: Int = config["index"] {
             stepReference = .index(index)
-        } else if let offset = config?["offset"] as? Int {
+        } else if let offset: Int = config["offset"] {
             stepReference = .offset(offset)
-        } else if let stepID = UUID(uuidString: config?["stepID"] as? String ?? "") {
-            stepReference = .stepID(stepID)
+        } else if let stepID: String = config["stepID"], let uuid = UUID(uuidString: stepID) {
+            stepReference = .stepID(uuid)
         } else {
             // Default to continuing to next step
             stepReference = .offset(1)

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -14,8 +14,8 @@ internal class AppcuesLaunchExperienceAction: ExperienceAction {
 
     let experienceID: String
 
-    required init?(config: [String: Any]?) {
-        if let experienceID = config?["experienceID"] as? String {
+    required init?(config: DecodingExperienceConfig) {
+        if let experienceID: String = config["experienceID"] {
             self.experienceID = experienceID
         } else {
             return nil

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -18,10 +18,10 @@ internal class AppcuesLinkAction: ExperienceAction {
     let url: URL
     let openExternally: Bool
 
-    required init?(config: [String: Any]?) {
-        if let url = URL(string: config?["url"] as? String ?? "") {
+    required init?(config: DecodingExperienceConfig) {
+        if let url = URL(string: config["url"] ?? "") {
             self.url = url
-            self.openExternally = (config?["openExternally"] as? Bool) ?? false
+            self.openExternally = config["openExternally"] ?? false
         } else {
             return nil
         }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
@@ -19,7 +19,7 @@ internal class AppcuesStepInteractionAction: ExperienceAction {
     let category: String
     let destination: String
 
-    required init?(config: [String: Any]?) {
+    required init?(config: DecodingExperienceConfig) {
         // An internal-only action, so can't be initialized from an Experience.Action model.
         return nil
     }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -14,8 +14,8 @@ internal class AppcuesSubmitFormAction: ExperienceAction, ExperienceActionQueueT
 
     let skipValidation: Bool
 
-    required init?(config: [String: Any]?) {
-        self.skipValidation = config?["skipValidation"] as? Bool ?? false
+    required init?(config: DecodingExperienceConfig) {
+        self.skipValidation = config["skipValidation"] ?? false
     }
 
     func execute(inContext appcues: Appcues, completion: ActionRegistry.Completion) {

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
@@ -14,8 +14,8 @@ internal class AppcuesTrackAction: ExperienceAction {
 
     let eventName: String
 
-    required init?(config: [String: Any]?) {
-        if let eventName = config?["eventName"] as? String {
+    required init?(config: DecodingExperienceConfig) {
+        if let eventName: String = config["eventName"] {
             self.eventName = eventName
         } else {
             return nil

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesUpdateProfileAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesUpdateProfileAction.swift
@@ -14,8 +14,9 @@ internal class AppcuesUpdateProfileAction: ExperienceAction {
 
     let properties: [String: Any]
 
-    required init?(config: [String: Any]?) {
-        if let properties = config {
+    required init?(config: DecodingExperienceConfig) {
+        let properties = config.safeValues
+        if !properties.isEmpty {
             self.properties = properties
         } else {
             return nil

--- a/Sources/AppcuesKit/Presentation/Actions/ExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ExperienceAction.swift
@@ -20,7 +20,7 @@ public protocol ExperienceAction {
     /// Initializer from an `Experience.Action` data model.
     ///
     /// This initializer should verify the config has any required properties and return `nil` if not.
-    init?(config: [String: Any]?)
+    init?(config: DecodingExperienceConfig)
 
     /// Execute the action.
     /// - Parameter appcues: The `Appcues` instance that displayed the experience triggering the action.

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -12,11 +12,11 @@ import UIKit
 internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
     static var type: String = "@appcues/backdrop"
 
-    let backgroundColor: UIColor?
+    let backgroundColor: UIColor
 
-    required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
-        if let dynamicColor = config?["backgroundColor", decodedAs: ExperienceComponent.Style.DynamicColor.self] {
-            self.backgroundColor = UIColor(dynamicColor: dynamicColor)
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
+        if let backgroundColor = UIColor(dynamicColor: config["backgroundColor"]) {
+            self.backgroundColor = backgroundColor
         } else {
             return nil
         }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -17,10 +17,10 @@ internal class AppcuesBackgroundContentTrait: StepDecoratingTrait, ContainerDeco
 
     private weak var backgroundViewController: UIViewController?
 
-    required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
         self.level = level
 
-        if let content = config?["content", decodedAs: ExperienceComponent.self] {
+        if let content: ExperienceComponent = config["content"] {
             self.content = content
         } else {
             return nil

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -12,7 +12,7 @@ import UIKit
 internal class AppcuesCarouselTrait: ContainerCreatingTrait {
     static let type = "@appcues/carousel"
 
-    required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
     }
 
     func createContainer(for stepControllers: [UIViewController], with pageMonitor: PageMonitor) throws -> ExperienceContainerViewController {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -15,14 +15,14 @@ internal class AppcuesModalTrait: StepDecoratingTrait, WrapperCreatingTrait, Pre
     let presentationStyle: PresentationStyle
     let modalStyle: ExperienceComponent.Style?
 
-    required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
-        if let presentationStyle = PresentationStyle(rawValue: config?["presentationStyle"] as? String ?? "") {
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
+        if let presentationStyle: PresentationStyle = config["presentationStyle"] {
             self.presentationStyle = presentationStyle
         } else {
             return nil
         }
 
-        self.modalStyle = config?["style", decodedAs: ExperienceComponent.Style.self]
+        self.modalStyle = config["style"]
     }
 
     func decorate(stepController: UIViewController) throws {
@@ -79,7 +79,7 @@ internal class AppcuesModalTrait: StepDecoratingTrait, WrapperCreatingTrait, Pre
 
 @available(iOS 13.0, *)
 extension AppcuesModalTrait {
-    enum PresentationStyle: String {
+    enum PresentationStyle: String, Decodable {
         case full
         case dialog
         case sheet

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
@@ -16,8 +16,8 @@ internal class AppcuesPagingDotsTrait: ContainerDecoratingTrait {
     private weak var containerController: ExperienceContainerViewController?
     private weak var view: UIView?
 
-    required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
-        self.style = config?["style", decodedAs: ExperienceComponent.Style.self]
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
+        self.style = config["style"]
     }
 
     func decorate(containerController: ExperienceContainerViewController) throws {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -16,7 +16,7 @@ internal class AppcuesSkippableTrait: ContainerDecoratingTrait, BackdropDecorati
     private weak var view: UIViewController.CloseButton?
     private var gestureRecognizer: UITapGestureRecognizer?
 
-    required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
     }
 
     func decorate(containerController: ExperienceContainerViewController) throws {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStickyContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStickyContentTrait.swift
@@ -15,8 +15,8 @@ internal class AppcuesStickyContentTrait: StepDecoratingTrait {
     let edge: Edge
     let content: ExperienceComponent
 
-    required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
-        if let edge = Edge(config?["edge"] as? String), let content = config?["content", decodedAs: ExperienceComponent.self] {
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
+        if let edge = Edge(config["edge"]), let content: ExperienceComponent = config["content"] {
             self.edge = edge
             self.content = content
         } else {

--- a/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
@@ -33,7 +33,7 @@ public protocol ExperienceTrait {
     /// Initializer from an `Experience.Trait` data model.
     ///
     /// This initializer should verify the config has any required properties and return `nil` if not.
-    init?(config: [String: Any]?, level: ExperienceTraitLevel)
+    init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel)
 }
 
 /// A trait that modifies the `UIViewController` that encapsulates the contents of a specific step in the experience.

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -186,7 +186,7 @@ extension TraitComposer {
         let groupID: String? = nil
 
         init() {}
-        required init?(config: [String: Any]?, level: ExperienceTraitLevel) {}
+        required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {}
 
         func createContainer(for stepControllers: [UIViewController], with pageMonitor: PageMonitor) throws -> ExperienceContainerViewController {
             DefaultContainerViewController(stepControllers: stepControllers, pageMonitor: pageMonitor)

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -38,7 +38,7 @@ internal class TraitRegistry {
 
     func instances(for models: [Experience.Trait], level: ExperienceTraitLevel) -> [ExperienceTrait] {
         models.compactMap { traitModel in
-            traits[traitModel.type]?.init(config: traitModel.config, level: level)
+            traits[traitModel.type]?.init(config: DecodingExperienceConfig(traitModel.config), level: level)
         }
     }
 }

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -26,7 +26,7 @@ class ActionRegistryTests: XCTestCase {
         let actionModel = Experience.Action(
             trigger: "tap",
             type: TestAction.type,
-            config: ["executionExpectation": executionExpectation]
+            config: ["executionExpectation": executionExpectation].toDecodableDict()
         )
 
         // Act
@@ -47,7 +47,7 @@ class ActionRegistryTests: XCTestCase {
         let actionModel = Experience.Action(
             trigger: "tap",
             type: "@unknown/action",
-            config: ["executionExpectation": executionExpectation]
+            config: ["executionExpectation": executionExpectation].toDecodableDict()
         )
 
         // Act
@@ -73,7 +73,7 @@ class ActionRegistryTests: XCTestCase {
             config: [
                 "executionExpectation": executionExpectation,
                 "executionExpectation2": executionExpectation2
-            ]
+            ].toDecodableDict()
         )
 
         // Act
@@ -96,7 +96,7 @@ class ActionRegistryTests: XCTestCase {
         let actionModel = Experience.Action(
             trigger: "tap",
             type: TestAction.type,
-            config: ["executionExpectation": executionExpectation]
+            config: ["executionExpectation": executionExpectation].toDecodableDict()
         )
         actionRegistry.register(action: TestAction.self)
 
@@ -118,12 +118,12 @@ class ActionRegistryTests: XCTestCase {
         let actionModel = Experience.Action(
             trigger: "tap",
             type: TestAction.type,
-            config: ["executionExpectation": executionExpectation]
+            config: ["executionExpectation": executionExpectation].toDecodableDict()
         )
         let delayedActionModel = Experience.Action(
             trigger: "tap",
             type: TestAction.type,
-            config: ["executionExpectation": executionExpectation, "delay": 1]
+            config: ["executionExpectation": executionExpectation, "delay": 1.0].toDecodableDict()
         )
         actionRegistry.register(action: TestAction.self)
 
@@ -140,7 +140,7 @@ class ActionRegistryTests: XCTestCase {
             viewDescription: "Another Button")
 
         // Assert
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 2)
     }
 
     func testQueueTransforming() throws {
@@ -150,12 +150,12 @@ class ActionRegistryTests: XCTestCase {
         let actionModel = Experience.Action(
             trigger: "tap",
             type: TestAction.type,
-            config: ["executionExpectation": executionExpectation]
+            config: ["executionExpectation": executionExpectation].toDecodableDict()
         )
         let actionModel2 = Experience.Action(
             trigger: "tap",
             type: TestAction.type,
-            config: ["executionExpectation": executionExpectation, "removeSubsequent": true]
+            config: ["executionExpectation": executionExpectation, "removeSubsequent": true].toDecodableDict()
         )
         actionRegistry.register(action: TestAction.self)
 
@@ -181,10 +181,11 @@ private extension ActionRegistryTests {
         let delay: TimeInterval?
         let removeSubsequent: Bool
 
-        required init?(config: [String: Any]?) {
-            executionExpectation = config?["executionExpectation"] as? XCTestExpectation
-            delay = config?["delay"] as? TimeInterval
-            removeSubsequent = config?["removeSubsequent"] as? Bool ?? false
+        required init?(config: DecodingExperienceConfig) {
+            let decodableExecutionExpectation: DecodableExpectation? = config["executionExpectation"]
+            executionExpectation = decodableExecutionExpectation?.expectation
+            delay = config["delay"]
+            removeSubsequent = config["removeSubsequent"] ?? false
         }
 
         func execute(inContext appcues: Appcues, completion: @escaping () -> Void) {
@@ -210,8 +211,9 @@ private extension ActionRegistryTests {
 
         var executionExpectation2: XCTestExpectation?
 
-        required init?(config: [String: Any]?) {
-            executionExpectation2 = config?["executionExpectation2"] as? XCTestExpectation
+        required init?(config: DecodingExperienceConfig) {
+            let decodableExecutionExpectation2: DecodableExpectation? = config["executionExpectation2"]
+            executionExpectation2 = decodableExecutionExpectation2?.expectation
         }
 
         func execute(inContext appcues: Appcues, completion: @escaping () -> Void) {

--- a/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
@@ -20,7 +20,7 @@ class AppcuesCloseActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesCloseAction(config: nil)
+        let action = AppcuesCloseAction(config: DecodingExperienceConfig(nil))
 
         // Assert
         XCTAssertEqual(AppcuesCloseAction.type, "@appcues/close")
@@ -36,7 +36,7 @@ class AppcuesCloseActionTests: XCTestCase {
             dismissCount += 1
             completion?(.success(()))
         }
-        let action = AppcuesCloseAction(config: nil)
+        let action = AppcuesCloseAction(config: DecodingExperienceConfig(nil))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })
@@ -55,7 +55,7 @@ class AppcuesCloseActionTests: XCTestCase {
             dismissCount += 1
             completion?(.success(()))
         }
-        let action = AppcuesCloseAction(config: ["markComplete": true])
+        let action = AppcuesCloseAction(config: DecodingExperienceConfig(["markComplete": true]))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })

--- a/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
@@ -20,10 +20,10 @@ class AppcuesContinueActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let indexAction = AppcuesContinueAction(config: ["index": 1])
-        let offsetAction = AppcuesContinueAction(config: ["offset": -1])
-        let stepIDAction = AppcuesContinueAction(config: ["stepID": "8ebcb374-0eff-45a5-9d62-ffee52d8a57b"])
-        let defaultAction = AppcuesContinueAction(config: nil)
+        let indexAction = AppcuesContinueAction(config: DecodingExperienceConfig(["index": 1]))
+        let offsetAction = AppcuesContinueAction(config: DecodingExperienceConfig(["offset": -1]))
+        let stepIDAction = AppcuesContinueAction(config: DecodingExperienceConfig(["stepID": "8ebcb374-0eff-45a5-9d62-ffee52d8a57b"]))
+        let defaultAction = AppcuesContinueAction(config: DecodingExperienceConfig(nil))
 
 
         // Assert
@@ -49,7 +49,7 @@ class AppcuesContinueActionTests: XCTestCase {
             }
             completion?()
         }
-        let action = AppcuesContinueAction(config: nil)
+        let action = AppcuesContinueAction(config: DecodingExperienceConfig(nil))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })

--- a/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
@@ -21,8 +21,8 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesLaunchExperienceAction(config: ["experienceID": "123"])
-        let failedAction = AppcuesLaunchExperienceAction(config: [:])
+        let action = AppcuesLaunchExperienceAction(config: DecodingExperienceConfig(["experienceID": "123"]))
+        let failedAction = AppcuesLaunchExperienceAction(config: DecodingExperienceConfig([:]))
 
         // Assert
         XCTAssertEqual(AppcuesLaunchExperienceAction.type, "@appcues/launch-experience")
@@ -40,7 +40,7 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
             loadCount += 1
             completion?(.success(()))
         }
-        let action = AppcuesLaunchExperienceAction(config: ["experienceID": "123"])
+        let action = AppcuesLaunchExperienceAction(config: DecodingExperienceConfig(["experienceID": "123"]))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })
@@ -59,7 +59,7 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
             loadCount += 1
             completion?(.failure(AppcuesError.noActiveSession))
         }
-        let action = AppcuesLaunchExperienceAction(config: ["experienceID": "123"])
+        let action = AppcuesLaunchExperienceAction(config: DecodingExperienceConfig(["experienceID": "123"]))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -21,8 +21,8 @@ class AppcuesLinkActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesLinkAction(config: ["url": "https://appcues.com"])
-        let failedAction = AppcuesLinkAction(config: [:])
+        let action = AppcuesLinkAction(config: DecodingExperienceConfig(["url": "https://appcues.com"]))
+        let failedAction = AppcuesLinkAction(config: DecodingExperienceConfig([:]))
 
         // Assert
         XCTAssertEqual(AppcuesLinkAction.type, "@appcues/link")
@@ -41,7 +41,7 @@ class AppcuesLinkActionTests: XCTestCase {
             XCTAssertTrue(vc is SFSafariViewController)
             presentCount += 1
         }
-        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": false])
+        let action = AppcuesLinkAction(config: DecodingExperienceConfig(["url": "https://appcues.com", "openExternally": false]))
         action?.urlOpener = mockURLOpener
 
         // Act
@@ -61,7 +61,7 @@ class AppcuesLinkActionTests: XCTestCase {
             XCTAssertEqual(url.absoluteString, "https://appcues.com")
             openCount += 1
         }
-        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": true])
+        let action = AppcuesLinkAction(config: DecodingExperienceConfig(["url": "https://appcues.com", "openExternally": true]))
         action?.urlOpener = mockURLOpener
 
         // Act
@@ -81,7 +81,7 @@ class AppcuesLinkActionTests: XCTestCase {
             XCTAssertEqual(url.absoluteString, "deeplink://test")
             openCount += 1
         }
-        let action = AppcuesLinkAction(config: ["url": "deeplink://test", "openExternally": false])
+        let action = AppcuesLinkAction(config: DecodingExperienceConfig(["url": "deeplink://test", "openExternally": false]))
         action?.urlOpener = mockURLOpener
 
         // Act
@@ -105,7 +105,7 @@ class AppcuesLinkActionTests: XCTestCase {
         mockURLOpener.onOpen = { url in
             XCTFail("Shouldn't be called since the URL should be handled by the universal link")
         }
-        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": true])
+        let action = AppcuesLinkAction(config: DecodingExperienceConfig(["url": "https://appcues.com", "openExternally": true]))
         action?.urlOpener = mockURLOpener
 
         // Act
@@ -129,7 +129,7 @@ class AppcuesLinkActionTests: XCTestCase {
             XCTAssertEqual(url.absoluteString, "https://appcues.com")
             openCount += 1
         }
-        let action = AppcuesLinkAction(config: ["url": "https://appcues.com", "openExternally": true])
+        let action = AppcuesLinkAction(config: DecodingExperienceConfig(["url": "https://appcues.com", "openExternally": true]))
         action?.urlOpener = mockURLOpener
         let config = Appcues.Config(accountID: "00000", applicationID: "abc").enableUniversalLinks(false)
         let appcuesDisabledUniversalLinks = MockAppcues(config: config)

--- a/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
@@ -20,7 +20,7 @@ class AppcuesSubmitFormActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesSubmitFormAction(config: nil)
+        let action = AppcuesSubmitFormAction(config: DecodingExperienceConfig(nil))
 
         // Assert
         XCTAssertEqual(AppcuesSubmitFormAction.type, "@appcues/submit-form")
@@ -58,7 +58,7 @@ class AppcuesSubmitFormActionTests: XCTestCase {
             updates.append(trackingUpdate)
         }
 
-        let action = AppcuesSubmitFormAction(config: nil)
+        let action = AppcuesSubmitFormAction(config: DecodingExperienceConfig(nil))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })
@@ -100,10 +100,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
             .initial
         }
 
-        let action0 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
-        let action = try XCTUnwrap(AppcuesSubmitFormAction(config: nil))
-        let action1 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
-        let action2 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let action0 = try XCTUnwrap(AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"])))
+        let action = try XCTUnwrap(AppcuesSubmitFormAction(config: DecodingExperienceConfig(nil)))
+        let action1 = try XCTUnwrap(AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"])))
+        let action2 = try XCTUnwrap(AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"])))
         let initialQueue: [ExperienceAction] = [action0, action, action1, action2]
 
         // Act
@@ -123,10 +123,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
             .initial
         }
 
-        let action0 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
-        let action = try XCTUnwrap(AppcuesSubmitFormAction(config: ["skipValidation": true]))
-        let action1 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
-        let action2 = try XCTUnwrap(AppcuesTrackAction(config: ["eventName": "My Custom Event"]))
+        let action0 = try XCTUnwrap(AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"])))
+        let action = try XCTUnwrap(AppcuesSubmitFormAction(config: DecodingExperienceConfig(["skipValidation": true])))
+        let action1 = try XCTUnwrap(AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"])))
+        let action2 = try XCTUnwrap(AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"])))
         let initialQueue: [ExperienceAction] = [action0, action, action1, action2]
 
         // Act
@@ -154,7 +154,7 @@ class AppcuesSubmitFormActionTests: XCTestCase {
             updates.append(trackingUpdate)
         }
 
-        let action = AppcuesSubmitFormAction(config: nil)
+        let action = AppcuesSubmitFormAction(config: DecodingExperienceConfig(nil))
 
         // Act
         action?.execute(inContext: appcues, completion: { })

--- a/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
@@ -20,8 +20,8 @@ class AppcuesTrackActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesTrackAction(config: ["eventName": "My Custom Event"])
-        let failedAction = AppcuesTrackAction(config: [:])
+        let action = AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"]))
+        let failedAction = AppcuesTrackAction(config: DecodingExperienceConfig([:]))
 
         // Assert
         XCTAssertEqual(AppcuesTrackAction.type, "@appcues/track")
@@ -39,7 +39,7 @@ class AppcuesTrackActionTests: XCTestCase {
             XCTAssertNil(trackingUpdate.properties)
             trackCount += 1
         }
-        let action = AppcuesTrackAction(config: ["eventName": "My Custom Event"])
+        let action = AppcuesTrackAction(config: DecodingExperienceConfig(["eventName": "My Custom Event"]))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })

--- a/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
@@ -20,8 +20,8 @@ class AppcuesUpdateProfileActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesUpdateProfileAction(config: ["profile_attribute": "value"])
-        let failedAction = AppcuesUpdateProfileAction(config: nil)
+        let action = AppcuesUpdateProfileAction(config: DecodingExperienceConfig(["profile_attribute": "value"]))
+        let failedAction = AppcuesUpdateProfileAction(config: DecodingExperienceConfig(nil))
 
         // Assert
         XCTAssertEqual(AppcuesUpdateProfileAction.type, "@appcues/update-profile")
@@ -36,12 +36,18 @@ class AppcuesUpdateProfileActionTests: XCTestCase {
         var identifyCount = 0
         appcues.onIdentify = { userID, properties in
             XCTAssertEqual(userID, "user-id")
-            XCTAssertEqual(properties?.count, 1)
+            XCTAssertEqual(properties?.count, 3)
             XCTAssertEqual(properties?["profile_attribute"] as? String, "value")
+            XCTAssertEqual(properties?["int_value"] as? Int, 5)
+            XCTAssertEqual(properties?["bool_value"] as? Bool, false)
 
             identifyCount += 1
         }
-        let action = AppcuesUpdateProfileAction(config: ["profile_attribute": "value"])
+        let action = AppcuesUpdateProfileAction(config: DecodingExperienceConfig([
+            "profile_attribute": "value",
+            "int_value": 5,
+            "bool_value": false
+        ]))
 
         // Act
         action?.execute(inContext: appcues, completion: { completionCount += 1 })

--- a/Tests/AppcuesKitTests/Actions/StepInteractionActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/StepInteractionActionTests.swift
@@ -31,11 +31,11 @@ class StepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/continue",
-                    config: ["offset": 1]),
+                    config: ["offset": 1].toDecodableDict()),
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/track",
-                    config: ["eventName": "Some event"])
+                    config: ["eventName": "Some event"].toDecodableDict())
             ],
             interactionType: "Button Tapped",
             viewDescription: "My Button")
@@ -64,11 +64,11 @@ class StepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/continue",
-                    config: ["offset": -1]),
+                    config: ["offset": -1].toDecodableDict()),
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/track",
-                    config: ["eventName": "Some event"])
+                    config: ["eventName": "Some event"].toDecodableDict())
             ],
             interactionType: "Button Tapped",
             viewDescription: "My Button")
@@ -97,11 +97,11 @@ class StepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/close",
-                    config: ["markComplete":"true"]),
+                    config: ["markComplete": true].toDecodableDict()),
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/link",
-                    config: ["url": "https://appcues.com"])
+                    config: ["url": "https://appcues.com"].toDecodableDict())
             ],
             interactionType: "Button Tapped",
             viewDescription: "My Button")
@@ -130,11 +130,11 @@ class StepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/link",
-                    config: ["url": "myapp://deeplink"]),
+                    config: ["url": "myapp://deeplink"].toDecodableDict()),
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/launch-experience",
-                    config: ["experienceID": "c1d5336f-6416-4805-9e82-4073c9b8cdb8"])
+                    config: ["experienceID": "c1d5336f-6416-4805-9e82-4073c9b8cdb8"].toDecodableDict())
             ],
             interactionType: "Button Tapped",
             viewDescription: "My Button")
@@ -163,7 +163,7 @@ class StepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/close",
-                    config: ["markComplete": true])
+                    config: ["markComplete": true].toDecodableDict())
             ],
             interactionType: "Button Tapped",
             viewDescription: "My Button")
@@ -192,7 +192,7 @@ class StepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/continue",
-                    config: ["stepID": "c1ba5af5-df15-4e38-834b-c7c33ee91e44"])
+                    config: ["stepID": "c1ba5af5-df15-4e38-834b-c7c33ee91e44"].toDecodableDict())
             ],
             interactionType: "Button Tapped",
             viewDescription: "My Button")

--- a/Tests/AppcuesKitTests/DecodingExperienceConfig+Testable.swift
+++ b/Tests/AppcuesKitTests/DecodingExperienceConfig+Testable.swift
@@ -1,0 +1,174 @@
+//
+//  DecodingExperienceConfig+Testable.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2022-12-12.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import AppcuesKit
+
+// Allows initializing a DecodingExperienceConfig from a test with a plain dictionary
+extension DecodingExperienceConfig {
+    convenience init(_ testDict: [String: Any]?) {
+        self.init(testDict?.toDecodableDict())
+    }
+}
+
+extension Dictionary where Key == String, Value == Any {
+
+    // Convert an arbitrary dictionary to a format that matches what `DecodingExperienceConfig` expects
+    func toDecodableDict() -> [String: KeyedDecodingContainer<JSONCodingKeys>] {
+        self.reduce(into: [:]) { dict, pair in
+            if let expectation = pair.value as? XCTestExpectation {
+                // special case
+                dict[pair.key] = KeyedDecodingContainer(FakeDecodingContainer(DecodableExpectation(expectation: expectation)))
+            } else {
+                dict[pair.key] = KeyedDecodingContainer(FakeDecodingContainer(pair.value))
+            }
+        }
+    }
+}
+
+
+// XCTestExpectation isn't Decodable, so fake it with this wrapper that stores the expectation in a static var to "decode" from
+struct DecodableExpectation: Decodable {
+    private static var expectationStore: [UUID: XCTestExpectation] = [:]
+
+    let expectation: XCTestExpectation
+    private let expectationID: UUID
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+        self.expectationID = UUID()
+        Self.expectationStore[expectationID] = expectation
+    }
+
+    enum CodingKeys: CodingKey {
+        case expectationID
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.expectationID = try container.decode(UUID.self, forKey: .expectationID)
+        if let expectation = Self.expectationStore[expectationID] {
+            self.expectation = expectation
+        } else {
+            throw DecodingError.valueNotFound(XCTestExpectation.self, .init(codingPath: [], debugDescription: "cant find expectation"))
+        }
+    }
+}
+
+// A "fake" Decoder that stores and returns values from test configs. Most methods are unimplemented since they're unused in tests,
+// but they can be implemented if needed.
+private struct FakeDecodingContainer: KeyedDecodingContainerProtocol {
+    typealias Key = JSONCodingKeys
+
+    let value: Any
+
+    var codingPath: [CodingKey] = []
+    var allKeys: [JSONCodingKeys] = []
+
+    init(_ value: Any) {
+        self.value = value
+    }
+
+    func contains(_ key: JSONCodingKeys) -> Bool {
+        fatalError("unimplemented")
+    }
+
+    func decodeNil(forKey key: JSONCodingKeys) throws -> Bool {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: Bool.Type, forKey key: JSONCodingKeys) throws -> Bool {
+        guard let castValue = value as? Bool else {
+            throw DecodingError.typeMismatch(type, .init(codingPath: codingPath, debugDescription: "uh oh"))
+        }
+        return castValue
+    }
+
+    func decode(_ type: String.Type, forKey key: JSONCodingKeys) throws -> String {
+        guard let castValue = value as? String else {
+            throw DecodingError.typeMismatch(type, .init(codingPath: codingPath, debugDescription: "uh oh"))
+        }
+        return castValue
+    }
+
+    func decode(_ type: Double.Type, forKey key: JSONCodingKeys) throws -> Double {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: Float.Type, forKey key: JSONCodingKeys) throws -> Float {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: Int.Type, forKey key: JSONCodingKeys) throws -> Int {
+        guard let castValue = value as? Int else {
+            throw DecodingError.typeMismatch(type, .init(codingPath: codingPath, debugDescription: "uh oh"))
+        }
+        return castValue
+    }
+
+    func decode(_ type: Int8.Type, forKey key: JSONCodingKeys) throws -> Int8 {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: Int16.Type, forKey key: JSONCodingKeys) throws -> Int16 {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: Int32.Type, forKey key: JSONCodingKeys) throws -> Int32 {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: Int64.Type, forKey key: JSONCodingKeys) throws -> Int64 {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: UInt.Type, forKey key: JSONCodingKeys) throws -> UInt {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: UInt8.Type, forKey key: JSONCodingKeys) throws -> UInt8 {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: UInt16.Type, forKey key: JSONCodingKeys) throws -> UInt16 {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: UInt32.Type, forKey key: JSONCodingKeys) throws -> UInt32 {
+        fatalError("unimplemented")
+    }
+
+    func decode(_ type: UInt64.Type, forKey key: JSONCodingKeys) throws -> UInt64 {
+        fatalError("unimplemented")
+    }
+
+    func decode<T>(_ type: T.Type, forKey key: JSONCodingKeys) throws -> T where T : Decodable {
+        guard let castValue = value as? T else {
+            fatalError("uh oh \(type): \(value)")
+        }
+        return castValue
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: JSONCodingKeys) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        fatalError("unimplemented")
+    }
+
+    func nestedUnkeyedContainer(forKey key: JSONCodingKeys) throws -> UnkeyedDecodingContainer {
+        fatalError("unimplemented")
+    }
+
+    func superDecoder() throws -> Decoder {
+        fatalError("unimplemented")
+    }
+
+    func superDecoder(forKey key: JSONCodingKeys) throws -> Decoder {
+        fatalError("unimplemented")
+    }
+}

--- a/Tests/AppcuesKitTests/Networking/PartialDictionaryDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/PartialDictionaryDecodeTests.swift
@@ -74,8 +74,9 @@ class PartialDictionaryDecodeTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(trait.type, "@appcues/sticky-content")
-        let config = try XCTUnwrap(trait.config)
-        XCTAssertEqual(config["edge"] as? String, "bottom")
-        XCTAssertNotNil(config["content", decodedAs: ExperienceComponent.self])
+        let config = DecodingExperienceConfig(trait.config)
+        XCTAssertEqual(config["edge"], "bottom")
+        let content: ExperienceComponent = try XCTUnwrap(config["content"])
+        XCTAssertNotNil(content)
     }
 }

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -45,12 +45,12 @@ class TraitComposerTests: XCTestCase {
                 Experience.Trait(
                     type: "@test/trait",
                     config: [
-                        "stepDecoratingExpectation": stepDecoratingExpectation as Any,
-                        "containerCreatingExpectation": containerCreatingExpectation as Any,
-                        "containerDecoratingExpectation": containerDecoratingExpectation as Any,
-                        "wrapperCreatingExpectation": wrapperCreatingExpectation as Any,
-                        "backdropDecoratingExpectation": backdropDecoratingExpectation as Any
-                    ])
+                        "stepDecoratingExpectation": stepDecoratingExpectation,
+                        "containerCreatingExpectation": containerCreatingExpectation,
+                        "containerDecoratingExpectation": containerDecoratingExpectation,
+                        "wrapperCreatingExpectation": wrapperCreatingExpectation,
+                        "backdropDecoratingExpectation": backdropDecoratingExpectation
+                    ].toDecodableDict())
             ],
             steps: [
                 .child(Experience.Step.Child(traits: []))
@@ -165,21 +165,21 @@ class TraitComposerTests: XCTestCase {
                 Experience.Trait(
                     type: "@test/trait",
                     config: [
-                        "stepDecoratingExpectation": experienceLevelStepDecoratingExpectation as Any,
-                        "containerCreatingExpectation": experienceLevelContainerCreatingExpectation as Any,
-                        "containerDecoratingExpectation": experienceLevelContainerDecoratingExpectation as Any,
-                        "wrapperCreatingExpectation": experienceLevelWrapperCreatingExpectation as Any,
-                        "backdropDecoratingExpectation": experienceLevelBackdropDecoratingExpectation as Any
-                    ]),
+                        "stepDecoratingExpectation": experienceLevelStepDecoratingExpectation,
+                        "containerCreatingExpectation": experienceLevelContainerCreatingExpectation,
+                        "containerDecoratingExpectation": experienceLevelContainerDecoratingExpectation,
+                        "wrapperCreatingExpectation": experienceLevelWrapperCreatingExpectation,
+                        "backdropDecoratingExpectation": experienceLevelBackdropDecoratingExpectation
+                    ].toDecodableDict()),
                 Experience.Trait(
                     type: "@test/trait-2",
                     config: [
-                        "stepDecoratingExpectation": experienceLevel2StepDecoratingExpectation as Any,
-                        "containerCreatingExpectation": experienceLevel2ContainerCreatingExpectation as Any,
-                        "containerDecoratingExpectation": experienceLevel2ContainerDecoratingExpectation as Any,
-                        "wrapperCreatingExpectation": experienceLevel2WrapperCreatingExpectation as Any,
-                        "backdropDecoratingExpectation": experienceLevel2BackdropDecoratingExpectation as Any
-                    ])
+                        "stepDecoratingExpectation": experienceLevel2StepDecoratingExpectation,
+                        "containerCreatingExpectation": experienceLevel2ContainerCreatingExpectation,
+                        "containerDecoratingExpectation": experienceLevel2ContainerDecoratingExpectation,
+                        "wrapperCreatingExpectation": experienceLevel2WrapperCreatingExpectation,
+                        "backdropDecoratingExpectation": experienceLevel2BackdropDecoratingExpectation
+                    ].toDecodableDict())
             ],
             steps: [
                 .group(Experience.Step.Group(
@@ -192,12 +192,12 @@ class TraitComposerTests: XCTestCase {
                         Experience.Trait(
                             type: "@test/trait",
                             config: [
-                                "stepDecoratingExpectation": groupLevelStepDecoratingExpectation as Any,
-                                "containerCreatingExpectation": groupLevelContainerCreatingExpectation as Any,
-                                "containerDecoratingExpectation": groupLevelContainerDecoratingExpectation as Any,
-                                "wrapperCreatingExpectation": groupLevelWrapperCreatingExpectation as Any,
-                                "backdropDecoratingExpectation": groupLevelBackdropDecoratingExpectation as Any
-                            ])
+                                "stepDecoratingExpectation": groupLevelStepDecoratingExpectation,
+                                "containerCreatingExpectation": groupLevelContainerCreatingExpectation,
+                                "containerDecoratingExpectation": groupLevelContainerDecoratingExpectation,
+                                "wrapperCreatingExpectation": groupLevelWrapperCreatingExpectation,
+                                "backdropDecoratingExpectation": groupLevelBackdropDecoratingExpectation
+                            ].toDecodableDict())
                     ],
                     actions: [:]
                 ))
@@ -245,7 +245,7 @@ class TraitComposerTests: XCTestCase {
                     config: [
                         "presentExpectation": presentExpectation,
                         "removeExpectation": removeExpectation
-                    ]),
+                    ].toDecodableDict()),
             ],
             steps: [
                 .child(Experience.Step.Child(traits: []))
@@ -265,7 +265,7 @@ class TraitComposerTests: XCTestCase {
     }
 
     func testDefaultContainerCreatingTrait() throws {
-        let traitInstance = try XCTUnwrap(TraitComposer.DefaultContainerCreatingTrait(config: [:], level: .group))
+        let traitInstance = try XCTUnwrap(TraitComposer.DefaultContainerCreatingTrait(config: DecodingExperienceConfig([:]), level: .group))
         let pageMonitor = PageMonitor(numberOfPages: 0, currentPage: 0)
         let container = try traitInstance.createContainer(for: [], with: pageMonitor)
         XCTAssertTrue(container is DefaultContainerViewController)
@@ -304,8 +304,8 @@ class TraitComposerTests: XCTestCase {
     func testDecompose() throws {
         // Arrange
         let traits: [ExperienceTrait] = [
-            try XCTUnwrap(TestTrait(config: nil, level: .experience)),
-            try XCTUnwrap(TestPresentingTrait(config: nil, level: .experience))
+            try XCTUnwrap(TestTrait(config: DecodingExperienceConfig(nil), level: .experience)),
+            try XCTUnwrap(TestPresentingTrait(config: DecodingExperienceConfig(nil), level: .experience))
         ]
 
         // Act
@@ -324,10 +324,10 @@ class TraitComposerTests: XCTestCase {
     func testAppendDecomposedTraits() throws {
         // Arrange
         let experienceTraits: [ExperienceTrait] = [
-            try XCTUnwrap(TestTrait(config: nil, level: .experience)),
-            try XCTUnwrap(TestPresentingTrait(config: nil, level: .experience))
+            try XCTUnwrap(TestTrait(config: DecodingExperienceConfig(nil), level: .experience)),
+            try XCTUnwrap(TestPresentingTrait(config: DecodingExperienceConfig(nil), level: .experience))
         ]
-        let groupTrait = try XCTUnwrap(TestTrait(config: nil, level: .experience))
+        let groupTrait = try XCTUnwrap(TestTrait(config: DecodingExperienceConfig(nil), level: .experience))
         let decomposedTraits = TraitComposer.DecomposedTraits(traits: experienceTraits)
 
         // Act
@@ -346,11 +346,11 @@ class TraitComposerTests: XCTestCase {
     func testPropagateDecomposedTraits() throws {
         // Arrange
         let experienceTraits: [ExperienceTrait] = [
-            try XCTUnwrap(Test2Trait(config: nil, level: .experience)),
-            try XCTUnwrap(Test3Trait(config: nil, level: .group))
+            try XCTUnwrap(Test2Trait(config: DecodingExperienceConfig(nil), level: .experience)),
+            try XCTUnwrap(Test3Trait(config: DecodingExperienceConfig(nil), level: .group))
         ]
         let decomposedTraits = TraitComposer.DecomposedTraits(traits: experienceTraits)
-        let stepTrait = try XCTUnwrap(TestTrait(config: nil, level: .experience))
+        let stepTrait = try XCTUnwrap(TestTrait(config: DecodingExperienceConfig(nil), level: .experience))
         let decomposedStepTraits = TraitComposer.DecomposedTraits(traits: [stepTrait])
 
         // Act
@@ -403,7 +403,7 @@ class TraitComposerTests: XCTestCase {
                                 "containerDecoratingExpectation": containerDecoratingExpectation as Any,
                                 "wrapperCreatingExpectation": wrapperCreatingExpectation as Any,
                                 "backdropDecoratingExpectation": backdropDecoratingExpectation as Any
-                            ]),
+                            ].toDecodableDict()),
                         Experience.Trait(
                             type: "@test/trait",
                             config: [
@@ -412,7 +412,7 @@ class TraitComposerTests: XCTestCase {
                                 "containerDecoratingExpectation": containerDecoratingExpectation as Any,
                                 "wrapperCreatingExpectation": wrapperCreatingExpectation as Any,
                                 "backdropDecoratingExpectation": backdropDecoratingExpectation as Any
-                            ])
+                            ].toDecodableDict())
                     ],
                     actions: [:]
                 )),
@@ -428,7 +428,7 @@ class TraitComposerTests: XCTestCase {
                             "containerDecoratingExpectation": containerDecoratingExpectation as Any,
                             "wrapperCreatingExpectation": wrapperCreatingExpectation as Any,
                             "backdropDecoratingExpectation": backdropDecoratingExpectation as Any
-                        ])
+                        ].toDecodableDict())
                 ]))
             ],
             redirectURL: nil,
@@ -473,18 +473,19 @@ extension TraitComposerTests {
 
         var backdropDecoratingExpectation: XCTestExpectation?
 
-        required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
-            self.groupID = config?["groupID"] as? String
+        required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
+            self.groupID = config["groupID"]
 
-            stepDecoratingExpectation = config?["stepDecoratingExpectation"] as? XCTestExpectation
-
-            containerCreatingExpectation = config?["containerCreatingExpectation"] as? XCTestExpectation
-
-            containerDecoratingExpectation = config?["containerDecoratingExpectation"] as? XCTestExpectation
-
-            wrapperCreatingExpectation = config?["wrapperCreatingExpectation"] as? XCTestExpectation
-
-            backdropDecoratingExpectation = config?["backdropDecoratingExpectation"] as? XCTestExpectation
+            let decodableStepDecoratingExpectation: DecodableExpectation? = config["stepDecoratingExpectation"]
+            stepDecoratingExpectation = decodableStepDecoratingExpectation?.expectation
+            let decodableContainerCreatingExpectation: DecodableExpectation? = config["containerCreatingExpectation"]
+            containerCreatingExpectation = decodableContainerCreatingExpectation?.expectation
+            let decodableContainerDecoratingExpectation: DecodableExpectation? = config["containerDecoratingExpectation"]
+            containerDecoratingExpectation = decodableContainerDecoratingExpectation?.expectation
+            let decodableWrapperCreatingExpectation: DecodableExpectation? = config["wrapperCreatingExpectation"]
+            wrapperCreatingExpectation = decodableWrapperCreatingExpectation?.expectation
+            let decodableBackdropDecoratingExpectation: DecodableExpectation? = config["backdropDecoratingExpectation"]
+            backdropDecoratingExpectation = decodableBackdropDecoratingExpectation?.expectation
         }
 
         // StepDecoratingTrait
@@ -540,11 +541,13 @@ extension TraitComposerTests {
         var presentExpectation: XCTestExpectation?
         var removeExpectation: XCTestExpectation?
 
-        required init?(config: [String: Any]?, level: ExperienceTraitLevel) {
-            self.groupID = config?["groupID"] as? String
+        required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
+            self.groupID = config["groupID"]
 
-            presentExpectation = config?["presentExpectation"] as? XCTestExpectation
-            removeExpectation = config?["removeExpectation"] as? XCTestExpectation
+            let decodablePresentExpectation: DecodableExpectation? = config["presentExpectation"]
+            presentExpectation = decodablePresentExpectation?.expectation
+            let decodableRemoveExpectation: DecodableExpectation? = config["removeExpectation"]
+            removeExpectation = decodableRemoveExpectation?.expectation
         }
 
         func present(viewController: UIViewController, completion: (() -> Void)?) throws {

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -64,8 +64,6 @@ private extension TraitRegistryTests {
     class TestTrait: ExperienceTrait {
         static let type = "@test/trait"
 
-        var groupID: String?
-
-        required init?(config: [String: Any]?, level: ExperienceTraitLevel) {}
+        required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {}
     }
 }


### PR DESCRIPTION
There's an irritating annoyance with our current trait inits: Currently it's `init?(config: [String: Any]?, level: ExperienceTraitLevel)` where the config dictionary decodes some types (String, Bool, Int, Double) and the rest are left in a coding container where we can do the clever like `config?["content", decodedAs: ExperienceComponent.self]`.

The problem is for our new `@appcues/backdrop-keyhole` we have a `cornerRadius` property which should be a Double (since 2.5 is a perfectly acceptable value), but often will have whole number values (eg 10). The decoding will make this different types depending on if there’s a decimal which is quite annoying because the trait init needs to handle both options despite the fact it knows that it should always decode as a Double. And from the perspective of a custom trait implementation, this is entirely non-standard behaviour and would be quite confusing to understand.

This PR changes it where we don't automatically decode anything and leave it all up to the trait where the type info is fully known.

Also we don't actually do the partial dictionary decode for actions—only traits—so this PR makes both consistent.

I'm not entirely happy with the `DecodingExperienceConfig` name, so definitely open to ideas for that.

### Benefits:
- This is more performant since we don't try decoding every key to a bunch of types that it’ll never be.
- It's also nicer where a trait wants to decode to a Decodable enum (like the new `@appcues/step-transition-animation` trait), but the value has already been decoded to a string (I have the ugly `self.easing = Easing(rawValue: config?["easing"] as? String ?? "")` when it could be `self.easing = config["easing"]` with some clever type inference).
- A custom trait doesn't need to know that a `String` should be accessed differently from a `CustomType` because it's all the same now.

This is a :boom: breaking change for traits 2.0, but the end result would be much cleaner in the trait implementations and would require less explanation in the documentation about how “some values are already decoded for you”.

## Testing

The tests are actually the trickiest part of this change. They rely extensively on the `config: [String: Any]` init to configure test cases and even pass `XCTestExpectation` objects into custom traits. I wanted to keep the tests as simple as possible, and I managed to do that by created a way to convert a `[String: Any]` to the `[String: KeyedDecodingContainer<JSONCodingKeys>]` dictionary that the `DecodingExperienceConfig` now requires. There's a few complex pieces here:

1. An extension on `DecodingExperienceConfig` that takes a `[String: Any]` and converts it using `.toDecodableDict()`
2. `toDecodableDict()` creates a `FakeDecodingContainer: KeyedDecodingContainerProtocol` that just stores the value and returns it when "decoding" (rather than trying to encode and decode, since there's no guarantee all types are Encodable)
3. All the types do need to be `Decodable` and `XCTestExpectatation` isn't, so I created the new `DecodableExpectation` type that wraps an expectation and encodes just a simple `UUID` that then can be decoded and looked up in a static dictionary to get the original expectation back. Don't worry, I'd only ever consider this sort of wild hack in a test case 😅 

Consequently, most of the test changes are just wrapping the existing `[String: Any]` dictionaries in `DecodingExperienceConfig(...)`. And anything that's testing with `Experience.Action` uses `toDecodableDict()` directly.