### PR TITLE
Add leadingFill option for rating components

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -229,6 +229,8 @@ extension ExperienceComponent {
         let accentColor: Style.DynamicColor?
         let pickerStyle: Style?
         let attributeName: String?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let leadingFill: Bool?
 
         let style: Style?
 

--- a/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
@@ -185,6 +185,7 @@ extension ExperienceComponent.OptionSelectModel {
             accentColor: nil,
             pickerStyle: nil,
             attributeName: nil,
+            leadingFill: nil,
             style: nil
         )
     }


### PR DESCRIPTION
This is the iOS implementation of the [proposed spec change](https://github.com/appcues/appcues-mobile-experience-spec/pull/121/files#diff-b4d74ced281deda59b98f155a0fd068ac0bcaa79d3c9fb67cf91023a80f664f4R457-R460) to add `leadingFill` on the `optionSelect` component.

It is only supported for single select components, with `hidden` controlPosition (ratings use cases)

This would apply in cases like the star rating block being built now.

![Screenshot 2022-12-14 at 9 04 39 AM](https://user-images.githubusercontent.com/19266448/207667222-68994097-f2a7-4b98-8b26-cb2932f192c9.png)
