### PR TITLE
Add TraitMetadataDelegate to manage properties across trait instances and update backdrop trait to animate

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -12,6 +12,8 @@ import UIKit
 internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
     static var type: String = "@appcues/backdrop"
 
+    weak var metadataDelegate: TraitMetadataDelegate?
+
     let backgroundColor: UIColor
 
     required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
@@ -23,10 +25,24 @@ internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
     }
 
     func decorate(backdropView: UIView) throws {
-        backdropView.backgroundColor = backgroundColor
+        guard let metadataDelegate = metadataDelegate else {
+            backdropView.backgroundColor = backgroundColor
+            return
+        }
+
+        metadataDelegate.set(["backdropBackgroundColor": backgroundColor])
+
+        metadataDelegate.registerHandler(for: Self.type, animating: true) { metadata in
+            backdropView.backgroundColor = metadata["backdropBackgroundColor"]
+        }
     }
 
     func undecorate(backdropView: UIView) throws {
-        backdropView.backgroundColor = nil
+        guard let metadataDelegate = metadataDelegate else {
+            backdropView.backgroundColor = nil
+            return
+        }
+
+        metadataDelegate.unset(keys: [ "backdropBackgroundColor" ])
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -12,6 +12,8 @@ import SwiftUI
 internal class AppcuesBackgroundContentTrait: StepDecoratingTrait, ContainerDecoratingTrait {
     static let type = "@appcues/background-content"
 
+    weak var metadataDelegate: TraitMetadataDelegate?
+
     let level: ExperienceTraitLevel
     let content: ExperienceComponent
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -12,6 +12,8 @@ import UIKit
 internal class AppcuesCarouselTrait: ContainerCreatingTrait {
     static let type = "@appcues/carousel"
 
+    weak var metadataDelegate: TraitMetadataDelegate?
+
     required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -12,6 +12,8 @@ import UIKit
 internal class AppcuesModalTrait: StepDecoratingTrait, WrapperCreatingTrait, PresentingTrait {
     static let type = "@appcues/modal"
 
+    weak var metadataDelegate: TraitMetadataDelegate?
+
     let presentationStyle: PresentationStyle
     let modalStyle: ExperienceComponent.Style?
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
@@ -11,6 +11,8 @@ import UIKit
 internal class AppcuesPagingDotsTrait: ContainerDecoratingTrait {
     static let type = "@appcues/paging-dots"
 
+    weak var metadataDelegate: TraitMetadataDelegate?
+
     let style: ExperienceComponent.Style?
 
     private weak var containerController: ExperienceContainerViewController?

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -12,6 +12,8 @@ import UIKit
 internal class AppcuesSkippableTrait: ContainerDecoratingTrait, BackdropDecoratingTrait {
     static var type: String = "@appcues/skippable"
 
+    weak var metadataDelegate: TraitMetadataDelegate?
+
     private weak var containerController: UIViewController?
     private weak var view: UIViewController.CloseButton?
     private var gestureRecognizer: UITapGestureRecognizer?

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
@@ -14,8 +14,8 @@ internal class AppcuesStepTransitionAnimationTrait: ContainerDecoratingTrait {
 
     weak var metadataDelegate: TraitMetadataDelegate?
 
-    let duration: TimeInterval
-    let easing: Easing
+    private let duration: TimeInterval
+    private let easing: Easing
 
     required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
         self.duration = config["duration"] ?? 0.3

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
@@ -1,0 +1,68 @@
+//
+//  AppcuesStepTransitionAnimationTrait.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-12-06.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal class AppcuesStepTransitionAnimationTrait: ContainerDecoratingTrait {
+
+    static var type: String = "@appcues/step-transition-animation"
+
+    weak var metadataDelegate: TraitMetadataDelegate?
+
+    let duration: TimeInterval
+    let easing: Easing
+
+    required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {
+        self.duration = config["duration"] ?? 0.3
+        self.easing = config["easing"] ?? .linear
+    }
+
+    func decorate(containerController: ExperienceContainerViewController) throws {
+        metadataDelegate?.set([
+            "animationDuration": duration,
+            "animationEasing": easing
+        ])
+    }
+
+    func undecorate(containerController: ExperienceContainerViewController) throws {
+        metadataDelegate?.unset(keys: [ "animationDuration", "animationEasing" ])
+    }
+}
+
+extension AppcuesStepTransitionAnimationTrait {
+
+    enum Easing: String, Decodable {
+        case linear, easeIn, easeOut, easeInOut
+
+        var curve: UIView.AnimationOptions {
+            switch self {
+            case .linear:
+                return .curveLinear
+            case .easeIn:
+                return .curveEaseIn
+            case .easeOut:
+                return .curveEaseOut
+            case .easeInOut:
+                return .curveEaseInOut
+            }
+        }
+
+        var timingFunction: CAMediaTimingFunctionName {
+            switch self {
+            case .linear:
+                return .linear
+            case .easeIn:
+                return .easeIn
+            case .easeOut:
+                return .easeOut
+            case .easeInOut:
+                return .easeInEaseOut
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStickyContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStickyContentTrait.swift
@@ -12,6 +12,8 @@ import SwiftUI
 internal class AppcuesStickyContentTrait: StepDecoratingTrait {
     static let type = "@appcues/sticky-content"
 
+    weak var metadataDelegate: TraitMetadataDelegate?
+
     let edge: Edge
     let content: ExperienceComponent
 

--- a/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
@@ -30,6 +30,8 @@ public protocol ExperienceTrait {
     /// Must be unique and should be formatted `@org/name` (e.g. `@appcues/modal`).
     static var type: String { get }
 
+    weak var metadataDelegate: TraitMetadataDelegate? { get set }
+
     /// Initializer from an `Experience.Trait` data model.
     ///
     /// This initializer should verify the config has any required properties and return `nil` if not.

--- a/Sources/AppcuesKit/Presentation/Traits/TraitMetadataDelegate.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitMetadataDelegate.swift
@@ -1,0 +1,102 @@
+//
+//  TraitMetadataDelegate.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2022-12-06.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import UIKit
+
+/// Methods for managing data to be shared across trait instances.
+@objc
+public class TraitMetadataDelegate: NSObject {
+    private var metadata: [String: Any?] = [:]
+    private var previousMetadata: [String: Any?] = [:]
+
+    private var subscribers: [String: (TraitMetadata) -> Void] = [:]
+    private var viewAnimatingSubscribers: [String: (TraitMetadata) -> Void] = [:]
+
+    public func set(_ newDict: [String: Any?]) {
+        metadata = metadata.merging(newDict)
+    }
+
+    public func unset(keys: [String]) {
+        keys.forEach {
+            metadata.removeValue(forKey: $0)
+        }
+    }
+
+    // Updates are automatically published after a step change.
+    // This can be used to manually publish updates in other cases.
+    public func publish() {
+        let traitMetadata = TraitMetadata(newData: metadata, previousData: previousMetadata)
+
+        subscribers.forEach { _, observer in observer(traitMetadata) }
+
+        traitMetadata.viewAnimation {
+            self.viewAnimatingSubscribers.forEach { _, block in block(traitMetadata) }
+        }
+
+        previousMetadata = metadata
+    }
+
+    public func registerHandler(for key: String, animating: Bool, observer: @escaping (TraitMetadata) -> Void) {
+        if animating {
+            viewAnimatingSubscribers[key] = observer
+        } else {
+            subscribers[key] = observer
+        }
+    }
+
+    public func removeHandler(for key: String) {
+        subscribers.removeValue(forKey: key)
+        viewAnimatingSubscribers.removeValue(forKey: key)
+    }
+
+}
+
+public class TraitMetadata: NSObject {
+    private let newData: [String: Any?]
+    private let previousData: [String: Any?]
+
+    internal init(newData: [String: Any?], previousData: [String: Any?]) {
+        self.newData = newData
+        self.previousData = previousData
+    }
+
+    func viewAnimation(_ block: @escaping () -> Void) {
+        guard let duration = newData["animationDuration"] as? TimeInterval,
+                let easing = newData["animationEasing"] as? AppcuesStepTransitionAnimationTrait.Easing else {
+            block()
+            return
+        }
+        UIView.animate(withDuration: duration, delay: 0, options: easing.curve) {
+            block()
+        }
+    }
+
+    func basicAnimation(keyPath: String?) -> CABasicAnimation? {
+        guard let duration = newData["animationDuration"] as? TimeInterval,
+              let easing = newData["animationEasing"] as? AppcuesStepTransitionAnimationTrait.Easing else {
+            return nil
+        }
+
+        let animation = CABasicAnimation(keyPath: keyPath)
+        animation.duration = duration
+        animation.timingFunction = CAMediaTimingFunction(name: easing.timingFunction)
+        return animation
+    }
+
+    public subscript<T>(_ key: String) -> T? {
+        newData[key] as? T
+    }
+
+    public subscript<T>(previous key: String) -> T? {
+        previousData[key] as? T
+    }
+
+    public subscript<T>(pair key: String) -> (new: T?, previous: T?) {
+        (newData[key] as? T, previousData[key] as? T)
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Traits/TraitMetadataDelegate.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitMetadataDelegate.swift
@@ -14,7 +14,7 @@ public class TraitMetadataDelegate: NSObject {
     private var metadata: [String: Any?] = [:]
     private var previousMetadata: [String: Any?] = [:]
 
-    private var subscribers: [String: (TraitMetadata) -> Void] = [:]
+    private var nonAnimatingSubscribers: [String: (TraitMetadata) -> Void] = [:]
     private var viewAnimatingSubscribers: [String: (TraitMetadata) -> Void] = [:]
 
     public func set(_ newDict: [String: Any?]) {
@@ -32,7 +32,7 @@ public class TraitMetadataDelegate: NSObject {
     public func publish() {
         let traitMetadata = TraitMetadata(newData: metadata, previousData: previousMetadata)
 
-        subscribers.forEach { _, observer in observer(traitMetadata) }
+        nonAnimatingSubscribers.forEach { _, observer in observer(traitMetadata) }
 
         traitMetadata.viewAnimation {
             self.viewAnimatingSubscribers.forEach { _, block in block(traitMetadata) }
@@ -45,12 +45,12 @@ public class TraitMetadataDelegate: NSObject {
         if animating {
             viewAnimatingSubscribers[key] = observer
         } else {
-            subscribers[key] = observer
+            nonAnimatingSubscribers[key] = observer
         }
     }
 
     public func removeHandler(for key: String) {
-        subscribers.removeValue(forKey: key)
+        nonAnimatingSubscribers.removeValue(forKey: key)
         viewAnimatingSubscribers.removeValue(forKey: key)
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -14,6 +14,7 @@ internal class TraitRegistry {
 
     init(container: DIContainer) {
         // Register default traits
+        register(trait: AppcuesStepTransitionAnimationTrait.self)
         register(trait: AppcuesModalTrait.self)
         register(trait: AppcuesCarouselTrait.self)
         register(trait: AppcuesStickyContentTrait.self)

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -461,6 +461,8 @@ extension TraitComposerTests {
     class TestTrait: StepDecoratingTrait, ContainerCreatingTrait, ContainerDecoratingTrait, WrapperCreatingTrait, BackdropDecoratingTrait {
         class var type: String { "@test/trait" }
 
+        weak var metadataDelegate: AppcuesKit.TraitMetadataDelegate?
+
         let groupID: String?
 
         var stepDecoratingExpectation: XCTestExpectation?
@@ -535,6 +537,8 @@ extension TraitComposerTests {
 
     class TestPresentingTrait: PresentingTrait {
         static let type = "@test/presenting"
+
+        weak var metadataDelegate: AppcuesKit.TraitMetadataDelegate?
 
         let groupID: String?
 

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -64,6 +64,8 @@ private extension TraitRegistryTests {
     class TestTrait: ExperienceTrait {
         static let type = "@test/trait"
 
+        weak var metadataDelegate: AppcuesKit.TraitMetadataDelegate?
+
         required init?(config: DecodingExperienceConfig, level: ExperienceTraitLevel) {}
     }
 }


### PR DESCRIPTION
We've talked about this change a lot, but here's the summary of specifically where I've landed. It's actually pretty simple, which is definitely a win!

1. A `TraitMetadata` object that stores the current and previous metadata values. The previous values are important to allow certain transitions.
2. Every trait has a `TraitMetadataDelegate` that can be used to:
    1. set a metadata value for reading by other traits
    2. get a metadata value via a handler block. The `type` provided in the block allows a trait to ensure only one instance handles the metadata (rather than, for example, having 2 backdrop traits each trying to animate to the new metadata value). The handler provides a nice wrapper for animating using the metadata values from `@appcues/step-transition-animation`.
    3. Publish a new metadata value on demand. The `TraitComposer` will handle calling publish on a step change, but if a trait knows a change needs to happen otherwise, it can call `publish()` itself
3. The `@appcues/backdrop` trait animates its color change (with a fallback in case the metadata delegate isn't set). I'm intending this to be the general pattern a trait should 
4. The new `@appcues/step-transition-animation` trait. This just provides metadata values that other traits can use to animate. (Note the nice, tidy `init` thanks to `DecodingExperienceConfig`). This is a `ContainerDecoratingTrait` despite not needing the `containerController` reference. I went with this over a new `StepTransitionHandlingTrait` ([ref](https://appcues.slack.com/archives/C031RLGS4F8/p1670527616504029?thread_ts=1670508074.385699&cid=C031RLGS4F8)) that I had previously considered, since this is the only trait that I'm aware of that will not need a reference to either the backdrop or container. In general it feels like an antipattern to have traits that do _nothing_ else, so I don't want to build that as a specific feature of the trait system.

https://user-images.githubusercontent.com/845681/207924236-f8bef97f-b060-4de7-b015-863227625380.mp4

## Next  Steps
1. There's a handful of missing docs on new `public` stuff. Will flesh that out.
2. PRs for the `@appcues/backdrop-keyhole` and `@appcues/target-rectangle`.
3. Create proper specs for all these new traits.