### PR TITLE
Adjust how border is applied to match CSS border-box style

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/AppcuesStyle.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesStyle.swift
@@ -12,6 +12,7 @@ import SwiftUI
 internal struct AppcuesStyle {
     let padding: EdgeInsets
     let margin: EdgeInsets
+    let borderInset: EdgeInsets
     let height: CGFloat?
     let width: CGFloat?
     let fillWidth: Bool
@@ -33,7 +34,7 @@ internal struct AppcuesStyle {
     let borderColor: Color?
     let borderWidth: CGFloat?
 
-    init(from model: ExperienceComponent.Style?) {
+    init(from model: ExperienceComponent.Style?, contentMode: ContentMode? = nil, aspectRatio: CGFloat? = nil) {
         self.padding = EdgeInsets(
             top: model?.paddingTop ?? 0,
             leading: model?.paddingLeading ?? 0,
@@ -74,5 +75,27 @@ internal struct AppcuesStyle {
         self.cornerRadius = CGFloat(model?.cornerRadius)
         self.borderColor = Color(dynamicColor: model?.borderColor)
         self.borderWidth = CGFloat(model?.borderWidth)
+
+
+        // Border insets should only be applied on fixed size views - so for those with a
+        // fixed height, for instance, apply a top and bottom inset. For those with a
+        // fixed width, apply leading and trailing inset (or sometimes both).
+        // This is factored in the base style object created above. If size is not constrained,
+        // then any border is applied on top of the intrinsic size of the view - growing the
+        // overall view frame as needed.
+        //
+        // For images, they may also have one dimension defined and the other defined
+        // using an aspect ratio - so we have to handle that special case here and use a custom
+        // borderInset
+        let willApplyAspectRatio = contentMode != nil && aspectRatio != nil
+        let hasWidth = self.width != nil || self.fillWidth
+        let hasHeight = self.height != nil
+        let borderInsetSize: CGFloat = self.borderWidth ?? 0.0
+
+        self.borderInset = EdgeInsets(
+            top: hasHeight || (hasWidth && willApplyAspectRatio) ? borderInsetSize : 0,
+            leading: hasWidth || (hasHeight && willApplyAspectRatio) ? borderInsetSize : 0,
+            bottom: hasHeight || (hasWidth && willApplyAspectRatio) ? borderInsetSize : 0,
+            trailing: hasWidth || (hasHeight && willApplyAspectRatio) ? borderInsetSize : 0)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
@@ -21,6 +21,8 @@ internal struct AppcuesButton: View {
             // handle tap in `.setupActions`
         } label: {
             model.content.view
+                // allocate space for any border that will be applied below
+                .padding(style.borderInset)
                 // If the button has a set width instead of sizing according to the content,
                 // the content may need to be aligned within the the expanded space.
                 // The `if` check is necessary since `maxWidth: .infinity` would blow things up
@@ -37,6 +39,7 @@ internal struct AppcuesButton: View {
         }
         .applyForegroundStyle(style)
         .applyBackgroundStyle(style)
+        .applyBorderStyle(style)
         .applyExternalLayout(style)
         .setupActions(on: viewModel, for: model)
     }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
@@ -17,12 +17,18 @@ internal struct AppcuesImage: View {
     @Environment(\.imageCache) var imageCache: SessionImageCache
 
     var body: some View {
-        let style = AppcuesStyle(from: model.style)
+        let contentMode = ContentMode(string: model.contentMode)
+
+        // special case for images - need to pass the content mode and aspectRatio values so we can properly
+        // set the borderInsets to use for this view
+        let style = AppcuesStyle(from: model.style, contentMode: contentMode, aspectRatio: model.intrinsicSize?.aspectRatio)
 
         content(placeholder: style.backgroundColor)
             .ifLet(model.accessibilityLabel) { view, val in
                 view.accessibility(label: Text(val))
             }
+            // allocate space for any border that will be applied below
+            .padding(style.borderInset)
             .setupActions(on: viewModel, for: model)
             .applyForegroundStyle(style)
             // set the aspect ratio before applying frame sizing
@@ -30,9 +36,11 @@ internal struct AppcuesImage: View {
                 view.aspectRatio(model.intrinsicSize?.aspectRatio, contentMode: val)
             }
             .applyInternalLayout(style)
+
             // clip before adding shadows
             .clipped()
             .applyBackgroundStyle(style)
+            .applyBorderStyle(style)
             .applyExternalLayout(style)
     }
 


### PR DESCRIPTION
This change reverts and revises what was previously done in #274 , in favor of another approach that will hopefully more closely match the desired outcome of borders being applied in the same way as the CSS border-box style. The issue was around how the border was applied on fixed size elements - and to fix this, the border needs to be applied after the view frame is sized.

When a view does not have any fixed size, just sizing to the intrinsic content size of a label or image, for instance, this inset is _not_ used, and the border just applies on top of the content to increase the overall intrinsic size of the view.

The approach here introduces a new concept of `borderInset`, which gets applied on fixed size height or width elements in a way that reserves some space for a border to be injected later, then sizes the item, then applies the border back into the reserved space to give the desired size with border.

Images and buttons required a little special handling due to how those views are structured. In particular, images using aspectRatio modifiers need to also factor this in when considering whether a view has a fixed size.

The tests and explanation of updates to verify this fix are here https://github.com/appcues/appcues-mobile-experience-spec/pull/123