### PR TITLE
Update form components to handle label horizontalAlignment

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -20,7 +20,16 @@ internal struct AppcuesOptionSelect: View {
         let errorTintColor = stepState.shouldShowError(for: model.id) ? Color(dynamicColor: model.errorLabel?.style?.foregroundColor) : nil
 
         VStack(alignment: style.horizontalAlignment, spacing: 0) {
-            TintedTextView(model: model.label, tintColor: errorTintColor)
+            HStack {
+                // nil-coalesce to .leading so a non-specified value defaults to leading-aligned
+                if HorizontalAlignment(string: model.label.style?.horizontalAlignment) ?? .leading != .leading {
+                    Spacer()
+                }
+                TintedTextView(model: model.label, tintColor: errorTintColor)
+                if HorizontalAlignment(string: model.label.style?.horizontalAlignment) != .trailing {
+                    Spacer()
+                }
+            }
 
             switch (model.selectMode, model.displayFormat) {
             case (.single, .picker):
@@ -45,7 +54,15 @@ internal struct AppcuesOptionSelect: View {
             }
 
             if stepState.shouldShowError(for: model.id), let errorLabel = model.errorLabel {
-                AppcuesText(model: errorLabel)
+                HStack {
+                    if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) ?? .leading != .leading {
+                        Spacer()
+                    }
+                    AppcuesText(model: errorLabel)
+                    if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) != .trailing {
+                        Spacer()
+                    }
+                }
             }
         }
         .setupActions(on: viewModel, for: model)

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
@@ -27,7 +27,16 @@ internal struct AppcuesTextInput: View {
         let errorTintColor = stepState.shouldShowError(for: model.id) ? Color(dynamicColor: model.errorLabel?.style?.foregroundColor) : nil
 
         VStack(alignment: style.horizontalAlignment, spacing: 0) {
-            TintedTextView(model: model.label, tintColor: errorTintColor)
+            HStack {
+                // nil-coalesce to .leading so a non-specified value defaults to leading-aligned
+                if HorizontalAlignment(string: model.label.style?.horizontalAlignment) ?? .leading != .leading {
+                    Spacer()
+                }
+                TintedTextView(model: model.label, tintColor: errorTintColor)
+                if HorizontalAlignment(string: model.label.style?.horizontalAlignment) != .trailing {
+                    Spacer()
+                }
+            }
 
             let binding = stepState.formBinding(for: model.id)
 
@@ -38,7 +47,15 @@ internal struct AppcuesTextInput: View {
                 .overlay(errorBorder(errorTintColor, textFieldStyle))
 
             if stepState.shouldShowError(for: model.id), let errorLabel = model.errorLabel {
-                AppcuesText(model: errorLabel)
+                HStack {
+                    if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) ?? .leading != .leading {
+                        Spacer()
+                    }
+                    AppcuesText(model: errorLabel)
+                    if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) != .trailing {
+                        Spacer()
+                    }
+                }
             }
         }
         .setupActions(on: viewModel, for: model)

--- a/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
@@ -33,7 +33,7 @@ internal struct EqualWidthStack<Content: View>: View {
                 content
             }
             // maxWidth instead of width to allow the width to shrink after a resize or rotation.
-            .frame(maxWidth: stackWidth / CGFloat(itemCount))
+            .frame(maxWidth: stackWidth / CGFloat(max(1, itemCount)))
             // Ensure the context never escapes the designated frame.
             .clipped()
         }


### PR DESCRIPTION
Updating the option select **(edit: and text)** component layout to:
1. Always take the full width available (the `HStack` causes this)
2. Visually apply the `optionSelect.style.horizontalAlignment` to the options (L22, but it didn't change)
3. Apply the `optionSelect.label.style.horizontalAlignment` to the question label (previous it was ignored, will default to leading if no value is specified)
4. Apply the `optionSelect.errorLabel.style.horizontalAlignment` to the error label (previous it was ignored, will default to leading if no value is specified)

Consequently, the question label, options, and error can all be horizontally aligned independently of each other.

|Fixed|Broken|
|-|-|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-03 at 13 03 43](https://user-images.githubusercontent.com/845681/210415182-1f141452-e89e-425d-b2fe-dbd2172b91b2.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-03 at 13 08 11](https://user-images.githubusercontent.com/845681/210415867-bd402dce-c7fb-4c23-aa29-71f0658b8d0b.png)|

I also fixed a potential SwiftUI error I noticed when copy/pasting stuff around an example experience: an empty equal width horizontal stack would try to divide by 0. SwiftUI is smart enough not to crash ("Invalid frame dimension (negative or non-finite)"), but it would case an undefined behaviour.