### PR TITLE
Update survey component horizontal spacing

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -23,11 +23,11 @@ internal struct AppcuesOptionSelect: View {
             HStack {
                 // nil-coalesce to .leading so a non-specified value defaults to leading-aligned
                 if HorizontalAlignment(string: model.label.style?.horizontalAlignment) ?? .leading != .leading {
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
                 TintedTextView(model: model.label, tintColor: errorTintColor)
                 if HorizontalAlignment(string: model.label.style?.horizontalAlignment) != .trailing {
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
             }
 
@@ -56,11 +56,11 @@ internal struct AppcuesOptionSelect: View {
             if stepState.shouldShowError(for: model.id), let errorLabel = model.errorLabel {
                 HStack {
                     if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) ?? .leading != .leading {
-                        Spacer()
+                        Spacer(minLength: 0)
                     }
                     AppcuesText(model: errorLabel)
                     if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) != .trailing {
-                        Spacer()
+                        Spacer(minLength: 0)
                     }
                 }
             }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
@@ -30,11 +30,11 @@ internal struct AppcuesTextInput: View {
             HStack {
                 // nil-coalesce to .leading so a non-specified value defaults to leading-aligned
                 if HorizontalAlignment(string: model.label.style?.horizontalAlignment) ?? .leading != .leading {
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
                 TintedTextView(model: model.label, tintColor: errorTintColor)
                 if HorizontalAlignment(string: model.label.style?.horizontalAlignment) != .trailing {
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
             }
 
@@ -49,11 +49,11 @@ internal struct AppcuesTextInput: View {
             if stepState.shouldShowError(for: model.id), let errorLabel = model.errorLabel {
                 HStack {
                     if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) ?? .leading != .leading {
-                        Spacer()
+                        Spacer(minLength: 0)
                     }
                     AppcuesText(model: errorLabel)
                     if HorizontalAlignment(string: errorLabel.style?.horizontalAlignment) != .trailing {
-                        Spacer()
+                        Spacer(minLength: 0)
                     }
                 }
             }


### PR DESCRIPTION
Noticed I got this wrong when doing the snapshot test.

The default value (8) means we’d get additional spacing which could in some cases cause text to wrap prematurely when we really just want to use the `Spacer` for alignment purposes.