### PR TITLE
Add support for multiple text styles in a single primitive

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -292,7 +292,7 @@ extension ExperienceComponent {
         let text: String
 
         /// Note: not all style properties can be applied to a `TextSpan`.
-        let style: Style
+        let style: Style?
     }
 }
 

--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -126,6 +126,8 @@ extension ExperienceComponent {
         let id: UUID
         let text: String
 
+        let spans: [TextSpan]?
+
         let style: Style?
 
         var textDescription: String? { text }
@@ -284,6 +286,13 @@ extension ExperienceComponent {
     struct IntrinsicSize: Decodable {
         let width: Double
         let height: Double
+    }
+
+    struct TextSpan: Decodable {
+        let text: String
+
+        /// Note: not all style properties can be applied to a `TextSpan`.
+        let style: Style
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -28,32 +28,30 @@ internal struct AppcuesText: View {
 @available(iOS 13.0, *)
 extension Text {
     init(textModel: ExperienceComponent.TextModel) {
-        if let spans = textModel.spans {
-            self.init("")
+        self.init("")
 
-            // Note: a ViewBuilder approach here doesn't work because the requirement that we operate strictly on `Text`
-            // and not `some View` for concatenation to work. Therefore we work with the struct directly.
-            spans.forEach { span in
-                var text = Text(span.text)
+        // Note: a ViewBuilder approach here doesn't work because the requirement that we operate strictly on `Text`
+        // and not `some View` for concatenation to work. Therefore we work with the struct directly.
+        textModel.spans.forEach { span in
+            var text = Text(span.text)
 
-                if let font = Font(name: span.style?.fontName, size: span.style?.fontSize ?? UIFont.labelFontSize) {
-                    text = text.font(font)
-                }
-
-                if let foregroundColor = Color(dynamicColor: span.style?.foregroundColor) {
-                    text = text.foregroundColor(foregroundColor)
-                }
-
-                if let kerning = span.style?.letterSpacing {
-                    text = text.kerning(kerning)
-                }
-
-                // A shorthand operator with `Text` doesn't compile
-                // swiftlint:disable:next shorthand_operator
-                self = self + text
+            if let font = Font(
+                name: span.style?.fontName ?? textModel.style?.fontName,
+                size: span.style?.fontSize ?? textModel.style?.fontSize ?? UIFont.labelFontSize) {
+                text = text.font(font)
             }
-        } else {
-            self.init(textModel.text)
+
+            if let foregroundColor = Color(dynamicColor: span.style?.foregroundColor) {
+                text = text.foregroundColor(foregroundColor)
+            }
+
+            if let kerning = span.style?.letterSpacing {
+                text = text.kerning(kerning)
+            }
+
+            // A shorthand operator with `Text` doesn't compile
+            // swiftlint:disable:next shorthand_operator
+            self = self + text
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -34,18 +34,17 @@ extension Text {
             // Note: a ViewBuilder approach here doesn't work because the requirement that we operate strictly on `Text`
             // and not `some View` for concatenation to work. Therefore we work with the struct directly.
             spans.forEach { span in
-                let style = AppcuesStyle(from: span.style)
                 var text = Text(span.text)
 
-                if let font = style.font {
+                if let font = Font(name: span.style?.fontName, size: span.style?.fontSize ?? UIFont.labelFontSize) {
                     text = text.font(font)
                 }
 
-                if let foregroundColor = style.foregroundColor {
+                if let foregroundColor = Color(dynamicColor: span.style?.foregroundColor) {
                     text = text.foregroundColor(foregroundColor)
                 }
 
-                if let kerning = style.letterSpacing {
+                if let kerning = span.style?.letterSpacing {
                     text = text.kerning(kerning)
                 }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -17,10 +17,44 @@ internal struct AppcuesText: View {
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 
-        Text(model.text)
+        Text(textModel: model)
             .applyTextStyle(style, model: model)
             .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
             .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+@available(iOS 13.0, *)
+extension Text {
+    init(textModel: ExperienceComponent.TextModel) {
+        if let spans = textModel.spans {
+            self.init("")
+
+            // Note: a ViewBuilder approach here doesn't work because the requirement that we operate strictly on `Text`
+            // and not `some View` for concatenation to work. Therefore we work with the struct directly.
+            spans.forEach { span in
+                let style = AppcuesStyle(from: span.style)
+                var text = Text(span.text)
+
+                if let font = style.font {
+                    text = text.font(font)
+                }
+
+                if let foregroundColor = style.foregroundColor {
+                    text = text.foregroundColor(foregroundColor)
+                }
+
+                if let kerning = style.letterSpacing {
+                    text = text.kerning(kerning)
+                }
+
+                // A shorthand operator with `Text` doesn't compile
+                // swiftlint:disable:next shorthand_operator
+                self = self + text
+            }
+        } else {
+            self.init(textModel.text)
+        }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -18,7 +18,7 @@ internal struct TintedTextView: View {
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 
-        Text(model.text)
+        Text(textModel: model)
             .applyTextStyle(style, model: model)
             .setupActions(on: viewModel, for: model)
             .ifLet(tintColor) { view, val in


### PR DESCRIPTION
The updated text model requires at least one of `spans` or `text`. If both are present, `spans` is preferred. If neither are present, it's a decoding error. The custom decoder enforces this efficiently.

`text` will continue to be provided by the mobile builder for backwards compatibility with previous SDK versions, but making `text` optional here, allows us to eventually remove it in favour of only `spans` in the future if we're able to remove support for SDK versions that don't include this change.

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-05 at 11 10 05](https://user-images.githubusercontent.com/845681/210826948-fd8c532f-6c8d-4255-9251-1f35f4433ca7.png)

```json
{
    "type": "button",
    "id": "b947f397-80bd-4dc2-8264-850333609558",
    "content": {
        "type": "text",
        "id": "00591d74-20b6-4377-af5f-c67571d67e27",
        "text": "Next",
        "style": {
            "fontSize": 17,
            "foregroundColor": { "light": "#ffffff" }
        },
        "spans": [
            {
                "text": "N",
                "style": {
                    "fontName": "American Typewriter",
                    "fontSize": 24,
                    "letterSpacing": 6,
                    "foregroundColor": {"light": "#E9F7FF"}
                }
            },
            {
                "text": "e",
                "style": {
                    "fontName": "Avenir-BlackOblique",
                    "fontSize": 32,
                    "foregroundColor": {"light": "#FFEDF3"}
                }
            },
            {
                "text": "x",
                "style": {
                    "fontName": "Baskerville",
                    "fontSize": 26,
                    "foregroundColor": {"light": "#E9F7FF"}
                }
            },
            {
                "text": "t",
                "style": {
                    "fontName": "Copperplate",
                    "fontSize": 40,
                    "foregroundColor": {"light": "#F5F7FA"}
                }
            }
        ]
    },
    "style": {
        "marginBottom": 16,
        "paddingTop": 12,
        "paddingLeading": 24,
        "paddingBottom": 12,
        "paddingTrailing": 24,
        "backgroundColor": { "light": "#5C5CFF" },
        "cornerRadius": 6
    }
}
```