### PR TITLE
Fix swift package compilation issue with tests reference iOS 13+ types

### DIFF
--- a/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
@@ -89,6 +89,7 @@ class AnalyticsBroadcasterTests: XCTestCase {
         XCTAssertEqual(delegate.lastIsInternal, false)
     }
 
+    @available(iOS 13.0, *) // ExperienceData.StepState is 13+
     func testBroadcastSanitizesStepState() throws {
         // Arrange
         let expectedFormItem = ExperienceData.FormItem(model: ExperienceComponent.TextInputModel(

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -98,24 +98,10 @@ extension Dictionary where Key == String, Value == Any {
         }
         XCTAssertEqual(Set(self.keys), Set(other.keys), file: file, line: line)
         self.keys.forEach { key in
-            if #available(iOS 13.0, *) {
-                // can reference ExperienceData.StepState on 13+
-                switch(self[key], other[key]) {
-                case let (val1 as String, val2 as String):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as NSNumber, val2 as NSNumber):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as [Any], val2 as [Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                case let (val1 as [String: Any], val2 as [String: Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                default:
-                    XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").", file: file, line: line)
-                }
+            // special case since ExperienceData is 13+
+            if #available(iOS 13.0, *), let val1 = self[key] as? ExperienceData.StepState, let val2 = other[key] as? ExperienceData.StepState {
+                XCTAssertEqual(val1, val2, file: file, line: line)
             } else {
-                // cannot reference ExperienceData.StepState
                 switch(self[key], other[key]) {
                 case let (val1 as String, val2 as String):
                     XCTAssertEqual(val1, val2, file: file, line: line)
@@ -143,24 +129,9 @@ extension Array where Element == Any {
         XCTAssertEqual(self.count, other.count, file: file, line: line)
 
         zip(self, other).forEach { (selfVal, otherVal) in
-            if #available(iOS 13.0, *) {
-                // can reference ExperienceData.StepState on 13+
-                switch(selfVal, otherVal) {
-                case let (val1 as String, val2 as String):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as NSNumber, val2 as NSNumber):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as [Any], val2 as [Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                case let (val1 as [String: Any], val2 as [String: Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                default:
-                    XCTFail("\(selfVal) does not match \(otherVal).", file: file, line: line)
-                }
+            if #available(iOS 13.0, *), let val1 = selfVal as? ExperienceData.StepState, let val2 = otherVal as? ExperienceData.StepState {
+                XCTAssertEqual(val1, val2, file: file, line: line)
             } else {
-                // cannot reference ExperienceData.StepState
                 switch(selfVal, otherVal) {
                 case let (val1 as String, val2 as String):
                     XCTAssertEqual(val1, val2, file: file, line: line)

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -98,19 +98,36 @@ extension Dictionary where Key == String, Value == Any {
         }
         XCTAssertEqual(Set(self.keys), Set(other.keys), file: file, line: line)
         self.keys.forEach { key in
-            switch(self[key], other[key]) {
-            case let (val1 as String, val2 as String):
-                XCTAssertEqual(val1, val2, file: file, line: line)
-            case let (val1 as NSNumber, val2 as NSNumber):
-                XCTAssertEqual(val1, val2, file: file, line: line)
-            case let (val1 as [Any], val2 as [Any]):
-                val1.verifyPropertiesMatch(val2, file: file, line: line)
-            case let (val1 as [String: Any], val2 as [String: Any]):
-                val1.verifyPropertiesMatch(val2, file: file, line: line)
-            case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
-                XCTAssertEqual(val1, val2, file: file, line: line)
-            default:
-                XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").", file: file, line: line)
+            if #available(iOS 13.0, *) {
+                // can reference ExperienceData.StepState on 13+
+                switch(self[key], other[key]) {
+                case let (val1 as String, val2 as String):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as NSNumber, val2 as NSNumber):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as [Any], val2 as [Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                case let (val1 as [String: Any], val2 as [String: Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                default:
+                    XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").", file: file, line: line)
+                }
+            } else {
+                // cannot reference ExperienceData.StepState
+                switch(self[key], other[key]) {
+                case let (val1 as String, val2 as String):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as NSNumber, val2 as NSNumber):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as [Any], val2 as [Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                case let (val1 as [String: Any], val2 as [String: Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                default:
+                    XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").", file: file, line: line)
+                }
             }
         }
     }
@@ -126,19 +143,36 @@ extension Array where Element == Any {
         XCTAssertEqual(self.count, other.count, file: file, line: line)
 
         zip(self, other).forEach { (selfVal, otherVal) in
-            switch(selfVal, otherVal) {
-            case let (val1 as String, val2 as String):
-                XCTAssertEqual(val1, val2, file: file, line: line)
-            case let (val1 as NSNumber, val2 as NSNumber):
-                XCTAssertEqual(val1, val2, file: file, line: line)
-            case let (val1 as [Any], val2 as [Any]):
-                val1.verifyPropertiesMatch(val2, file: file, line: line)
-            case let (val1 as [String: Any], val2 as [String: Any]):
-                val1.verifyPropertiesMatch(val2, file: file, line: line)
-            case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
-                XCTAssertEqual(val1, val2, file: file, line: line)
-            default:
-                XCTFail("\(selfVal) does not match \(otherVal).", file: file, line: line)
+            if #available(iOS 13.0, *) {
+                // can reference ExperienceData.StepState on 13+
+                switch(selfVal, otherVal) {
+                case let (val1 as String, val2 as String):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as NSNumber, val2 as NSNumber):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as [Any], val2 as [Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                case let (val1 as [String: Any], val2 as [String: Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                default:
+                    XCTFail("\(selfVal) does not match \(otherVal).", file: file, line: line)
+                }
+            } else {
+                // cannot reference ExperienceData.StepState
+                switch(selfVal, otherVal) {
+                case let (val1 as String, val2 as String):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as NSNumber, val2 as NSNumber):
+                    XCTAssertEqual(val1, val2, file: file, line: line)
+                case let (val1 as [Any], val2 as [Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                case let (val1 as [String: Any], val2 as [String: Any]):
+                    val1.verifyPropertiesMatch(val2, file: file, line: line)
+                default:
+                    XCTFail("\(selfVal) does not match \(otherVal).", file: file, line: line)
+                }
             }
         }
     }

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -417,6 +417,7 @@ class ExperienceRendererTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, *)
 private extension ExperienceData {
     @available(iOS 13.0, *)
     func packageWithDelay(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -33,10 +33,10 @@ class MockAppcues: Appcues {
             container.register(DeepLinkHandling.self, value: deepLinkHandler)
             container.register(UIDebugging.self, value: debugger)
             container.register(ExperienceLoading.self, value: experienceLoader)
-            container.register(ExperienceRendering.self, value: experienceRenderer)
+            container.register(ExperienceRendering.self, value: MockExperienceRenderer())
             container.registerLazy(TraitRegistry.self, initializer: TraitRegistry.init)
             container.registerLazy(ActionRegistry.self, initializer: ActionRegistry.init)
-            container.register(TraitComposing.self, value: traitComposer)
+            container.register(TraitComposing.self, value: MockTraitComposer())
         }
 
         // dependencies that are not mocked
@@ -55,15 +55,27 @@ class MockAppcues: Appcues {
     var analyticsPublisher = MockAnalyticsPublisher()
     var storage = MockStorage()
     var experienceLoader = MockExperienceLoader()
-    var experienceRenderer = MockExperienceRenderer()
     var sessionMonitor = MockSessionMonitor()
     var activityProcessor = MockActivityProcessor()
     var debugger = MockDebugger()
     var deepLinkHandler = MockDeepLinkHandler()
-    var traitComposer = MockTraitComposer()
     var activityStorage = MockActivityStorage()
     var networking = MockNetworking()
     var analyticsTracker = MockAnalyticsTracker()
+
+    // must wrap in @available since MockExperienceRenderer has a stored property with
+    // type ExperienceData in it, which is 13+
+    @available(iOS 13.0, *)
+    var experienceRenderer: MockExperienceRenderer {
+        return container.resolve(ExperienceRendering.self) as! MockExperienceRenderer
+    }
+
+    // must wrap in @available since MockTraitComposer has a stored property with
+    // type ExperienceData in it, which is 13+
+    @available(iOS 13.0, *)
+    var traitComposer: MockTraitComposer {
+        return container.resolve(TraitComposing.self) as! MockTraitComposer
+    }
 }
 
 class MockAnalyticsPublisher: AnalyticsPublishing {
@@ -110,6 +122,7 @@ class MockExperienceLoader: ExperienceLoading {
     }
 }
 
+@available(iOS 13.0, *) // due to reference to ExperienceData
 class MockExperienceRenderer: ExperienceRendering {
 
     var onShowExperience: ((ExperienceData, ((Result<Void, Error>) -> Void)?) -> Void)?
@@ -186,6 +199,7 @@ class MockDeepLinkHandler: DeepLinkHandling {
     }
 }
 
+@available(iOS 13.0, *) // due to reference to ExperienceData
 class MockTraitComposer: TraitComposing {
 
     var onPackage: ((ExperienceData, Experience.StepIndex) throws -> ExperiencePackage)?

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -186,6 +186,7 @@ extension Experience.Step.Child {
 
 }
 
+@available(iOS 13.0, *)
 extension ExperienceData {
     static var mock: ExperienceData { ExperienceData(.mock, trigger: .showCall) }
     static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock, trigger: .showCall) }
@@ -196,12 +197,10 @@ extension ExperienceData {
         ExperienceData(.mockWithStepActions(actions: actions), trigger: trigger)
     }
 
-    @available(iOS 13.0, *)
     func package(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
         package(onPresent: { presentExpectation?.fulfill() }, onDismiss: { dismissExpectation?.fulfill()} )
     }
 
-    @available(iOS 13.0, *)
     func package(onPresent: @escaping (() -> Void), onDismiss: @escaping (() -> Void)) -> ExperiencePackage {
         let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()])
         return ExperiencePackage(


### PR DESCRIPTION
Should patch up the build issue reported here https://swiftpackageindex.com/appcues/appcues-ios-sdk/builds, and restore our badge display.