### PR TITLE
Add initial screen capture model and populate from current UIWindow

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -126,7 +126,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
     }
 }
 
-private extension UIUserInterfaceIdiom {
+extension UIUserInterfaceIdiom {
     var analyticsName: String {
         if self == .pad {
             return "tablet"

--- a/Sources/AppcuesKit/Data/Extensions/UIViewController+Tracking.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UIViewController+Tracking.swift
@@ -29,6 +29,14 @@ extension Notification {
 
 extension UIViewController {
 
+    internal var displayName: String {
+        var name = String(describing: self.classForCoder)
+        if name != "ViewController" {
+            name = name.replacingOccurrences(of: "ViewController", with: "")
+        }
+        return name
+    }
+
     internal func captureScreen() {
         guard let top = UIApplication.shared.topViewController() else { return }
 
@@ -36,15 +44,10 @@ extension UIViewController {
         let untracked = objc_getAssociatedObject(self, &UIKitScreenTracker.untrackedScreenKey) as? Bool ?? false
         guard !untracked else { return }
 
-        var name = String(describing: top.self.classForCoder)
-        if name != "ViewController" {
-            name = name.replacingOccurrences(of: "ViewController", with: "")
-        }
-
         // communicate the tracked screen back to AnalyticsTracker
         NotificationCenter.appcues.post(name: .appcuesTrackedScreen,
                                         object: self,
-                                        userInfo: Notification.toInfo(name))
+                                        userInfo: Notification.toInfo(top.displayName))
     }
 
     @objc

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -83,7 +83,6 @@ extension DebugViewController: FloatingViewDelegate {
             debugView.setPanelInterface(open: !isCurrentlyOpen, animated: true, programatically: false)
             debugView.fleetingLogView.clear()
         case .screenCapture:
-            // this is where we'll initiate the screen capture and pass back to the DebugViewDelegate
             delegate?.debugView(did: .screenCapture)
         }
     }

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
@@ -1,0 +1,85 @@
+//
+//  Capture.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 1/11/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal struct Capture: Identifiable {
+
+    struct View: Encodable {
+        let id = UUID()
+        // swiftlint:disable:next identifier_name
+        let x: CGFloat
+        // swiftlint:disable:next identifier_name
+        let y: CGFloat
+        let width: CGFloat
+        let height: CGFloat
+        let type: String
+        let selector: ElementSelector?
+        let children: [View]?
+    }
+
+    let id = UUID()
+    let applicationId: String
+    let displayName: String
+    let applicationVersion = Bundle.main.version
+    let screenShotImageUrl: URL?
+    let deviceModel = UIDevice.current.modelName
+    let deviceWidth = UIScreen.main.bounds.size.width
+    let deviceHeight = UIScreen.main.bounds.size.height
+    let deviceOrientation = UIDevice.current.orientation.isLandscape ? "landscape" : "portrait"
+    let deviceType = UIDevice.current.userInterfaceIdiom.analyticsName
+    let bundlePackageId = Bundle.main.identifier
+    let operatingSystem = "ios"
+    let applicationName = Bundle.main.displayName
+    let applicationBuild = Bundle.main.build
+    let sdkVersion = __appcues_version
+    let sdkName = "appcues-ios"
+    let osVersion = UIDevice.current.systemVersion
+    let layout: View
+
+    // the plan is for this to be sent to a separate endpoint to upload the image, then
+    // get back a URL to that image to use for `screenshotImageUrl` in the capture model
+    // sent to Appcues
+    let screenshot: Data
+}
+
+extension Capture: Encodable {
+    // to exclude screenshot from encoding
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case applicationId
+        case displayName
+        case applicationVersion
+        case screenShotImageUrl
+        case deviceModel
+        case deviceWidth
+        case deviceHeight
+        case deviceOrientation
+        case deviceType
+        case bundlePackageId
+        case operatingSystem
+        case applicationName
+        case applicationBuild
+        case sdkVersion
+        case sdkName
+        case osVersion
+        case layout
+    }
+}
+
+extension Capture {
+    // TODO: just for testing prior to API readiness!
+    func prettyPrint() {
+        guard
+            let data = try? JSONEncoder().encode(self),
+            let object = try? JSONSerialization.jsonObject(with: data, options: []),
+            let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+            let prettyPrintedString = String(data: data, encoding: .utf8) else { return }
+        print(prettyPrintedString)
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
@@ -11,7 +11,7 @@ import UIKit
 internal struct Capture: Identifiable {
 
     struct View: Encodable {
-        let id = UUID()
+        let id = UUID().appcuesFormatted
         // swiftlint:disable:next identifier_name
         let x: CGFloat
         // swiftlint:disable:next identifier_name
@@ -23,22 +23,23 @@ internal struct Capture: Identifiable {
         let children: [View]?
     }
 
-    let id = UUID()
-    let applicationId: String
+    let id = UUID().appcuesFormatted
+    let timestamp: Date
     let displayName: String
-    let applicationVersion = Bundle.main.version
-    let screenShotImageUrl: URL?
+    let screenshotImageUrl: URL?
+    let appId: String
+    let appName = Bundle.main.displayName
+    let appBuild = Bundle.main.build
+    let appVersion = Bundle.main.version
     let deviceModel = UIDevice.current.modelName
     let deviceWidth = UIScreen.main.bounds.size.width
     let deviceHeight = UIScreen.main.bounds.size.height
     let deviceOrientation = UIDevice.current.orientation.isLandscape ? "landscape" : "portrait"
     let deviceType = UIDevice.current.userInterfaceIdiom.analyticsName
     let bundlePackageId = Bundle.main.identifier
-    let operatingSystem = "ios"
-    let applicationName = Bundle.main.displayName
-    let applicationBuild = Bundle.main.build
     let sdkVersion = __appcues_version
     let sdkName = "appcues-ios"
+    let osName = "ios"
     let osVersion = UIDevice.current.systemVersion
     let layout: View
 
@@ -52,22 +53,23 @@ extension Capture: Encodable {
     // to exclude screenshot from encoding
     private enum CodingKeys: String, CodingKey {
         case id
-        case applicationId
+        case timestamp
+        case appId
+        case appVersion
+        case appName
+        case appBuild
         case displayName
-        case applicationVersion
-        case screenShotImageUrl
+        case screenshotImageUrl
         case deviceModel
         case deviceWidth
         case deviceHeight
         case deviceOrientation
         case deviceType
         case bundlePackageId
-        case operatingSystem
-        case applicationName
-        case applicationBuild
+        case osName
+        case osVersion
         case sdkVersion
         case sdkName
-        case osVersion
         case layout
     }
 }
@@ -76,7 +78,7 @@ extension Capture {
     // TODO: just for testing prior to API readiness!
     func prettyPrint() {
         guard
-            let data = try? JSONEncoder().encode(self),
+            let data = try? NetworkClient.encoder.encode(self),
             let object = try? JSONSerialization.jsonObject(with: data, options: []),
             let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
             let prettyPrintedString = String(data: data, encoding: .utf8) else { return }

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
@@ -46,7 +46,7 @@ internal struct Capture: Identifiable {
     // the plan is for this to be sent to a separate endpoint to upload the image, then
     // get back a URL to that image to use for `screenshotImageUrl` in the capture model
     // sent to Appcues
-    let screenshot: Data
+    let screenshot: UIImage
 }
 
 extension Capture: Encodable {

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
@@ -54,7 +54,7 @@ extension UIView {
         return name
     }
 
-    func screenshot() -> Data? {
+    func screenshot() -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(frame.size, false, 1)
         defer {
             UIGraphicsEndImageContext()
@@ -62,7 +62,7 @@ extension UIView {
 
         drawHierarchy(in: self.bounds, afterScreenUpdates: false)
 
-        return UIGraphicsGetImageFromCurrentImageContext()?.jpegData(compressionQuality: 0.5)
+        return UIGraphicsGetImageFromCurrentImageContext()
     }
 
     func captureLayout() -> Capture.View? {
@@ -72,9 +72,11 @@ extension UIView {
     private func asCaptureView(in bounds: CGRect) -> Capture.View? {
         let absolutePosition = self.convert(self.bounds, to: nil)
 
+        // discard views that are not visible in the screenshot image
         guard absolutePosition.intersects(bounds) else { return nil }
 
         let children: [Capture.View] = self.subviews.compactMap {
+            // discard hidden views and subviews within
             guard !$0.isHidden else { return nil }
             return $0.asCaptureView(in: bounds)
         }

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
@@ -41,7 +41,7 @@ extension UIView {
             id: nil)
     }
 
-    var screenCaptureDisplayName: String {
+    func screenCaptureDisplayName(at timestamp: Date) -> String {
         var name = ""
         if let window = self as? UIWindow,
            let root = window.rootViewController {
@@ -50,7 +50,7 @@ extension UIView {
             name = String(describing: self.classForCoder)
         }
 
-        name += " (\(screenNameDateFormatter.string(from: Date())))"
+        name += " (\(screenNameDateFormatter.string(from: timestamp)))"
         return name
     }
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
@@ -1,0 +1,91 @@
+//
+//  UIView+Capture.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 1/11/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+private var screenNameDateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd_HH:mm:ss"
+    return formatter
+}()
+
+private extension UIViewController {
+    var viewControllerForName: UIViewController {
+        if let navigationController = self as? UINavigationController,
+           let visibleViewController = navigationController.visibleViewController {
+            return visibleViewController.viewControllerForName
+        } else if let tabBarController = self as? UITabBarController,
+                  let selected = tabBarController.selectedViewController {
+            return selected.viewControllerForName
+        } else if let presented = self.presentedViewController {
+            return presented.viewControllerForName
+        } else {
+            guard children.count == 1 else { return self }
+            return children[0].viewControllerForName
+        }
+    }
+}
+
+extension UIView {
+
+    var appcuesSelector: ElementSelector? {
+        return ElementSelector(
+            accessibilityIdentifier: accessibilityIdentifier,
+            description: accessibilityLabel,
+            tag: tag != 0 ? "\(self.tag)" : nil,
+            id: nil)
+    }
+
+    var screenCaptureDisplayName: String {
+        var name = ""
+        if let window = self as? UIWindow,
+           let root = window.rootViewController {
+            name = root.viewControllerForName.displayName
+        } else {
+            name = String(describing: self.classForCoder)
+        }
+
+        name += " (\(screenNameDateFormatter.string(from: Date())))"
+        return name
+    }
+
+    func screenshot() -> Data? {
+        UIGraphicsBeginImageContextWithOptions(frame.size, false, 1)
+        defer {
+            UIGraphicsEndImageContext()
+        }
+
+        drawHierarchy(in: self.bounds, afterScreenUpdates: false)
+
+        return UIGraphicsGetImageFromCurrentImageContext()?.jpegData(compressionQuality: 0.5)
+    }
+
+    func captureLayout() -> Capture.View? {
+        return self.asCaptureView(in: self.bounds)
+    }
+
+    private func asCaptureView(in bounds: CGRect) -> Capture.View? {
+        let absolutePosition = self.convert(self.bounds, to: nil)
+
+        guard absolutePosition.intersects(bounds) else { return nil }
+
+        let children: [Capture.View] = self.subviews.compactMap {
+            guard !$0.isHidden else { return nil }
+            return $0.asCaptureView(in: bounds)
+        }
+
+        return Capture.View(
+            x: absolutePosition.origin.x,
+            y: absolutePosition.origin.y,
+            width: absolutePosition.width,
+            height: absolutePosition.height,
+            type: "\(type(of: self))",
+            selector: appcuesSelector,
+            children: children.isEmpty ? nil : children)
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -145,10 +145,12 @@ extension UIDebugger: DebugViewDelegate {
         if let window = UIApplication.shared.windows.first(where: { !($0 is DebugUIWindow) }),
            let screenshot = window.screenshot(),
            let layout = window.captureLayout() {
+            let timestamp = Date()
             let capture = Capture(
-                applicationId: config.applicationID,
-                displayName: window.screenCaptureDisplayName,
-                screenShotImageUrl: URL(string: "http://www.appcues.com/screenshot/\(UUID())"),
+                timestamp: timestamp,
+                displayName: window.screenCaptureDisplayName(at: timestamp),
+                screenshotImageUrl: URL(string: "http://www.appcues.com/screenshot/\(UUID())"),
+                appId: config.applicationID,
                 layout: layout,
                 screenshot: screenshot)
 

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -134,8 +134,28 @@ extension UIDebugger: DebugViewDelegate {
             hide()
         case .open:
             viewModel.ping()
-        case .show, .close, .reposition, .screenCapture:
+        case .screenCapture:
+            captureScreen()
+        case .show, .close, .reposition:
             break
+        }
+    }
+
+    private func captureScreen() {
+        if let window = UIApplication.shared.windows.first(where: { !($0 is DebugUIWindow) }),
+           let screenshot = window.screenshot(),
+           let layout = window.captureLayout() {
+            let capture = Capture(
+                applicationId: config.applicationID,
+                displayName: window.screenCaptureDisplayName,
+                screenShotImageUrl: URL(string: "http://www.appcues.com/screenshot/\(UUID())"),
+                layout: layout,
+                screenshot: screenshot)
+
+            // next steps are to upload image, get image URL, and then upload screen capture to API for real
+
+            // test output for now
+            capture.prettyPrint()
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ElementSelector.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ElementSelector.swift
@@ -1,0 +1,31 @@
+//
+//  ElementSelector.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 1/11/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal struct ElementSelector: Codable {
+    let accessibilityIdentifier: String?
+    let description: String?
+    let tag: String?
+    let id: String?
+
+    init?(accessibilityIdentifier: String?, description: String?, tag: String?, id: String?) {
+        // must have at least one identifiable property to be a valid selector
+        if accessibilityIdentifier == nil &&
+            description == nil &&
+            tag == nil &&
+            id == nil {
+            return nil
+        }
+
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.description = description
+        self.tag = tag
+        self.id = id
+    }
+}


### PR DESCRIPTION
This is the next step of the screen capture work - generating a capture model - the eventual JSON structure that we'll send to the API. A lot of this inspired/adapted from what @mmaatttt did in initial POC work in https://github.com/appcues/appcues-ios-sdk/commit/fa456edbab24c83fd0398931f342f346605ea7df.

The structure here is following on to initial model design work scoped out in [this doc], and currently being worked by the backend team here https://github.com/appcues/customer-api/pull/1041.

There is no UI or confirmation dialog here - that will follow on next. This allows you to open the snapshot button via deep link from previous PR, and then generate this model from the current UIWindow and print to the console (temporarily).

Example output and some comments for discussion are [here](https://github.com/appcues/appcues-mobile-experience-spec/pull/129/files#diff-46885be354956f8c9f5f25c4017e0677c07a74fb51a82c47818c94e5442331ef)