### PR TITLE
Apply traits after any pre-step container navigation executes

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/ExperiencePackage.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/ExperiencePackage.swift
@@ -11,7 +11,7 @@ import UIKit
 internal class ExperiencePackage {
     // References to the trait instances are held here to ensure they persist the lifetime of the experience being rendered.
     private let traitInstances: [ExperienceTrait]
-    let stepDecoratingTraitUpdater: (Int, Int) throws -> Void
+    let stepDecoratingTraitUpdater: (Int, Int?) throws -> Void
     let steps: [Experience.Step.Child]
     let containerController: ExperienceContainerViewController
     let wrapperController: UIViewController
@@ -21,7 +21,7 @@ internal class ExperiencePackage {
 
     internal init(
         traitInstances: [ExperienceTrait],
-        stepDecoratingTraitUpdater: @escaping (Int, Int) throws -> Void,
+        stepDecoratingTraitUpdater: @escaping (Int, Int?) throws -> Void,
         steps: [Experience.Step.Child],
         containerController: ExperienceContainerViewController,
         wrapperController: UIViewController,

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -80,23 +80,16 @@ internal class TraitComposer: TraitComposing {
         let backdropView = UIView()
         decomposedTraits.wrapperCreating?.addBackdrop(backdropView: backdropView, to: wrappedContainerViewController)
 
-        // Apply initial decorators for the target step
-        try stepModelsWithTraits[targetPageIndex].decomposedTraits.containerDecorating.forEach {
-            try $0.decorate(containerController: containerController)
-        }
-        try stepModelsWithTraits[targetPageIndex].decomposedTraits.backdropDecorating.forEach {
-            try $0.decorate(backdropView: backdropView)
-        }
-        metadataDelegate.publish()
-
-        let stepDecoratingTraitUpdater: (Int, Int) throws -> Void = { newIndex, previousIndex in
+        let stepDecoratingTraitUpdater: (Int, Int?) throws -> Void = { newIndex, previousIndex in
             // Remove old decorations
-            try stepModelsWithTraits[previousIndex].decomposedTraits.containerDecorating.forEach {
-                try $0.undecorate(containerController: containerController)
-            }
+            if let previousIndex = previousIndex {
+                try stepModelsWithTraits[previousIndex].decomposedTraits.containerDecorating.forEach {
+                    try $0.undecorate(containerController: containerController)
+                }
 
-            try stepModelsWithTraits[previousIndex].decomposedTraits.backdropDecorating.forEach {
-                try $0.undecorate(backdropView: backdropView)
+                try stepModelsWithTraits[previousIndex].decomposedTraits.backdropDecorating.forEach {
+                    try $0.undecorate(backdropView: backdropView)
+                }
             }
 
             // Add new decorations

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -56,9 +56,12 @@ class TraitComposerTests: XCTestCase {
             ],
             redirectURL: nil,
             nextContentID: nil)
+        let stepIndex = Experience.StepIndex(group: 0, item: 0)
+        let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: stepIndex)
 
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        // simulate the presentation, this updater called from ExperienceStateMachine.SideEffect.executePresentContainer
+        try package.stepDecoratingTraitUpdater(stepIndex.item, nil)
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -84,8 +87,12 @@ class TraitComposerTests: XCTestCase {
             wrapperCreatingExpectation: wrapperCreatingExpectation,
             backdropDecoratingExpectation: backdropDecoratingExpectation)
 
+        let stepIndex = Experience.StepIndex(group: 0, item: 0)
+        let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: stepIndex)
+
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        // simulate the presentation, this updater called from ExperienceStateMachine.SideEffect.executePresentContainer
+        try package.stepDecoratingTraitUpdater(stepIndex.item, nil)
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -106,8 +113,12 @@ class TraitComposerTests: XCTestCase {
             wrapperCreatingExpectation: expectation(description: "Create wrapper called"),
             backdropDecoratingExpectation: expectation(description: "Backdrop decorate called"))
 
+        let stepIndex = Experience.StepIndex(group: 1, item: 0)
+        let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: stepIndex)
+
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 1, item: 0))
+        // simulate the presentation, this updater called from ExperienceStateMachine.SideEffect.executePresentContainer
+        try package.stepDecoratingTraitUpdater(stepIndex.item, nil)
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -204,8 +215,13 @@ class TraitComposerTests: XCTestCase {
             redirectURL: nil,
             nextContentID: nil)
 
+        let stepIndex = Experience.StepIndex(group: 0, item: 0)
+        let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: stepIndex)
+
         // Act
-        _ = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: Experience.StepIndex(group: 0, item: 0))
+        // simulate the presentation, this updater called from ExperienceStateMachine.SideEffect.executePresentContainer
+        try package.stepDecoratingTraitUpdater(stepIndex.item, nil)
+
 
         // Assert
         waitForExpectations(timeout: 1)


### PR DESCRIPTION
This is an update to support the use case of: pre-step navigation, then show a step with a targeted-element that depends on the navigation to the new screen being completed.

Previously, the call to the `TraitComposer.package` function would result in the backdrop decorating traits applying their initial decorations - which could result in target-element lookups occurring. This was happening prior to the execution of the navigation actions, before the presentation of the new container.

Now, the application of initial step decoration is delayed until later in the process, after navigation actions have had a chance to execute - in hte `executePresentContainer` function of `ExperienceStateMachine.SideEffect`

note: this is targeting `traits-2.0` as it primarily relates to target-element behavior. Technically, we could port back a similar (but different) update to the 1.x branch which _may_ be applicable to navigation step usage prior to this update, but it is more likely this will come up as an issue in 2.0 targeted element flows. The trait application flow is significantly different in the 1.x branch.