### PR TITLE
Fix double publishing of the target rectangle frame

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetRectangleTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetRectangleTrait.swift
@@ -37,11 +37,17 @@ internal class AppcuesTargetRectangleTrait: BackdropDecoratingTrait {
     }
 
     func decorate(backdropView: UIView) throws {
-        metadataDelegate?.set([ "targetRectangle": calculateRect(bounds: backdropView.bounds) ])
+        // The first decorate call on the first step in a group will have a nil window because the views aren't added yet,
+        // so skip setting a targetRectangle until we have proper bounds. The change handler below will take care of that.
+        if backdropView.window != nil {
+            metadataDelegate?.set([ "targetRectangle": calculateRect(bounds: backdropView.bounds) ])
+        }
 
         // Monitor the backdrop bounds to recalculate relative positioning on changes.
         backdropView.insertSubview(frameObserverView, at: 0)
         frameObserverView.pin(to: backdropView)
+        // Ensure the view bounds are updated *before* we add the frame observer block.
+        frameObserverView.layoutIfNeeded()
 
         frameObserverView.onChange = { [weak self] bounds in
             self?.metadataDelegate?.set([ "targetRectangle": self?.calculateRect(bounds: bounds) ])


### PR DESCRIPTION
The target rectangle trait was doing an extra metadata publish on step change from within the frame observer.

Publishing twice on a step change breaks the `@appcues/backdrop-keyhole` animation because the first publish has the correct values to animate but that animation gets replaced by the second publish which has the same values.

Calling `layoutIfNeeded()` *before* adding the observer takes care of the double. Then there's an edge case for the first step in a group where the backdrop view still has zero bounds because it's not in the view hierarchy yet, so checking for the `window` being set means we can skip publishing a value the first time and get a proper animation triggered by the frame observer.

The `@appcues/target-element` trait will likely require similar changes, but I'll tackle that separately for the demo.