### PR TITLE
Add support for verticalAlignment styling on dialog modal

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/DialogContainerView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/DialogContainerView.swift
@@ -42,7 +42,6 @@ internal class DialogContainerView: UIView {
             // ensure the dialog can't exceed the container height (it should scroll instead).
             dialogView.topAnchor.constraint(greaterThanOrEqualTo: safeAreaLayoutGuide.topAnchor),
             dialogView.bottomAnchor.constraint(lessThanOrEqualTo: safeAreaLayoutGuide.bottomAnchor),
-            dialogView.centerYAnchor.constraint(equalTo: centerYAnchor),
             // this is required so the dialogView has an initial non-zero height, after which it can start sizing to the content.
             dialogView.layoutMarginsGuide.bottomAnchor.constraint(greaterThanOrEqualTo: dialogView.layoutMarginsGuide.topAnchor, constant: 1),
             dialogView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/DialogContainerViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/DialogContainerViewController.swift
@@ -49,6 +49,15 @@ internal class DialogContainerViewController: UIViewController {
 
         containerView.shadowLayer = CAShapeLayer(shadowModel: style?.shadow)
 
+        switch style?.verticalAlignment {
+        case "top":
+            containerView.dialogView.topAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.topAnchor).isActive = true
+        case "bottom":
+            containerView.dialogView.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        default:
+            containerView.dialogView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor).isActive = true
+        }
+
         return self
     }
 }


### PR DESCRIPTION
targeting `main` for a potential 1.x release

Support `style.verticalAlignment` for top | center | bottom

| top | center | bottom |
| --- | --- | --- |
| ![Screenshot 2023-01-19 at 3 40 37 PM](https://user-images.githubusercontent.com/19266448/213556900-96d18057-e286-4b75-87dc-2632cc44088c.png) | ![Screenshot 2023-01-19 at 3 41 06 PM](https://user-images.githubusercontent.com/19266448/213556953-5fd0158e-9db5-46b6-9bf9-0a6af837c5f6.png)  | ![Screenshot 2023-01-19 at 3 40 52 PM](https://user-images.githubusercontent.com/19266448/213556970-94f46fe1-13d1-4168-8ff3-13e6eb3d6ee0.png)
 | 