### PR TITLE
Add accessibility identifiers to Cocoapods example app

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -3,13 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		0384A2A89074FC193A107EE5 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663BEDD1883CC408AA4A302 /* SignInViewController.swift */; };
 		04F09F9C75FB66578541D199 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */; };
 		160BF92965F22C6957DEB27C /* Mulish-Italic-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */; };
+		1A3AD9592979EA050058533F /* HomeTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3AD9582979EA050058533F /* HomeTabBarController.swift */; };
 		3EADA9762D050C3E2ED69514 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */; };
 		40A181AE1ED5DE1982FA05CC /* Mulish-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */; };
 		64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB61619365785F4544ED13D /* GroupViewController.swift */; };
@@ -28,6 +29,7 @@
 /* Begin PBXFileReference section */
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
+		1A3AD9582979EA050058533F /* HomeTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabBarController.swift; sourceTree = "<group>"; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		2E1A69E4D4B48E802A9AFB6B /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				384497BA35A275E793B475C1 /* ProfileViewController.swift */,
 				25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */,
 				8663BEDD1883CC408AA4A302 /* SignInViewController.swift */,
+				1A3AD9582979EA050058533F /* HomeTabBarController.swift */,
 			);
 			path = CocoapodsExample;
 			sourceTree = "<group>";
@@ -105,7 +108,6 @@
 				BF4337FB1DE156596E9104A6 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
 				2E1A69E4D4B48E802A9AFB6B /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -157,8 +159,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1200;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 95033167E7E129F199208F61 /* Build configuration list for PBXProject "AppcuesCocoapodsExample" */;
 			compatibilityVersion = "Xcode 11.0";
@@ -267,6 +267,7 @@
 				64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */,
 				CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */,
 				A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */,
+				1A3AD9592979EA050058533F /* HomeTabBarController.swift in Sources */,
 				0384A2A89074FC193A107EE5 /* SignInViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dsu-JA-RYQ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dsu-JA-RYQ">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -15,7 +15,7 @@
             <objects>
                 <navigationController id="dsu-JA-RYQ" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="rKI-dv-nfO">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -35,35 +35,38 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="DFP-td-vP8">
-                                <rect key="frame" x="40" y="128" width="334" height="172"/>
+                                <rect key="frame" x="40" y="132" width="334" height="172"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Given Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PT3-vN-rTD">
-                                        <rect key="frame" x="0.0" y="0.0" width="334" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="334" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Given Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Tl-gR-eNQ">
-                                        <rect key="frame" x="0.0" y="28.5" width="334" height="34"/>
+                                    <textField opaque="NO" tag="2001" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Given Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Tl-gR-eNQ">
+                                        <rect key="frame" x="0.0" y="25" width="334" height="34"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="txtGivenName" label="Given Name"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Family Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yCh-uM-tj0">
-                                        <rect key="frame" x="0.0" y="70.5" width="334" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="67" width="334" height="20.5"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Family Name" textAlignment="natural" minimumFontSize="17" id="FMi-kV-XtR">
-                                        <rect key="frame" x="0.0" y="99" width="334" height="34"/>
+                                    <textField opaque="NO" tag="2002" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Family Name" textAlignment="natural" minimumFontSize="17" id="FMi-kV-XtR">
+                                        <rect key="frame" x="0.0" y="95.5" width="334" height="34"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="txtFamilyName" label="Family Name"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="FzB-Lh-Eb0">
-                                        <rect key="frame" x="0.0" y="141" width="334" height="31"/>
+                                    <button opaque="NO" tag="2003" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="FzB-Lh-Eb0">
+                                        <rect key="frame" x="0.0" y="137.5" width="334" height="34.5"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="btnSaveProfile" label="Save"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="filled" title="Save"/>
                                         <connections>
@@ -98,10 +101,10 @@
             </objects>
             <point key="canvasLocation" x="-314" y="1732"/>
         </scene>
-        <!--Tab Bar Controller-->
+        <!--Home Tab Bar Controller-->
         <scene sceneID="Fpf-vg-lJV">
             <objects>
-                <tabBarController id="EKa-1M-EaW" sceneMemberID="viewController">
+                <tabBarController id="EKa-1M-EaW" customClass="HomeTabBarController" customModule="AppcuesCocoapodsExample" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" id="zkk-uv-H8D"/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="o0Q-du-T0J">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="49"/>
@@ -127,21 +130,21 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Zi-osT">
-                                <rect key="frame" x="40" y="128" width="334" height="100"/>
+                                <rect key="frame" x="40" y="132" width="334" height="100"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eOt-Jw-1zd">
-                                        <rect key="frame" x="0.0" y="0.0" width="334" height="19"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="334" height="15.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="User ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MFN-Xh-XUq">
-                                        <rect key="frame" x="0.0" y="27" width="334" height="34"/>
+                                        <rect key="frame" x="0.0" y="23.5" width="334" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="xwL-xQ-fl6">
-                                        <rect key="frame" x="0.0" y="69" width="334" height="31"/>
+                                        <rect key="frame" x="0.0" y="65.5" width="334" height="34.5"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="filled" title="Sign In"/>
@@ -153,7 +156,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gL3-Si-fOx">
-                                <rect key="frame" x="140" y="831" width="134.5" height="31"/>
+                                <rect key="frame" x="130" y="827.5" width="154.5" height="34.5"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Anonymous User"/>
                                 <connections>
@@ -191,9 +194,13 @@
         <scene sceneID="dOd-X2-cY1">
             <objects>
                 <navigationController id="FK3-TP-f03" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Profile" image="person" catalog="system" id="6xZ-kX-GMW"/>
+                    <tabBarItem key="tabBarItem" title="Profile" image="person" catalog="system" id="6xZ-kX-GMW">
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="tabProfile"/>
+                        </userDefinedRuntimeAttributes>
+                    </tabBarItem>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="8c2-j3-qZL">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -208,10 +215,14 @@
         <scene sceneID="asy-jO-YXo">
             <objects>
                 <navigationController id="XJ3-u7-yjq" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Group" image="person.3" catalog="system" id="sLb-d9-Lvb"/>
+                    <tabBarItem key="tabBarItem" title="Group" image="person.3" catalog="system" id="sLb-d9-Lvb">
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="tabGroup"/>
+                        </userDefinedRuntimeAttributes>
+                    </tabBarItem>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="4iI-BG-Ndh">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -231,7 +242,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="js5-7t-elQ">
-                                <rect key="frame" x="40" y="128" width="334" height="101.5"/>
+                                <rect key="frame" x="40" y="132" width="334" height="105"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aYF-oG-O6J">
                                         <rect key="frame" x="0.0" y="0.0" width="334" height="20.5"/>
@@ -239,13 +250,15 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uPt-1p-rg9">
+                                    <textField opaque="NO" tag="3001" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uPt-1p-rg9">
                                         <rect key="frame" x="0.0" y="28.5" width="334" height="34"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="txtGroup" label="Group"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UsU-Rf-qFv">
-                                        <rect key="frame" x="0.0" y="70.5" width="334" height="31"/>
+                                    <button opaque="NO" tag="3002" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UsU-Rf-qFv">
+                                        <rect key="frame" x="0.0" y="70.5" width="334" height="34.5"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="btnSaveGroup" label="Save"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="filled" title="Save"/>
                                         <connections>
@@ -281,18 +294,20 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ftz-h7-czn">
-                                <rect key="frame" x="20" y="128" width="374" height="70"/>
+                                <rect key="frame" x="20" y="132" width="374" height="77"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xsR-1u-kQl">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="31"/>
+                                    <button opaque="NO" tag="1002" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xsR-1u-kQl">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="34.5"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="btnEvent1" label="Event 1"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="tinted" title="Trigger Event 1"/>
                                         <connections>
                                             <action selector="buttonOneTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="oko-8F-6E8"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JIX-16-Osw">
-                                        <rect key="frame" x="0.0" y="39" width="374" height="31"/>
+                                    <button opaque="NO" tag="1003" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JIX-16-Osw">
+                                        <rect key="frame" x="0.0" y="42.5" width="374" height="34.5"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="btnEvent2" label="Event 2"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="tinted" title="Trigger Event 2"/>
                                         <connections>
@@ -311,7 +326,7 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Trigger Events" id="1Wg-Nt-6AG">
-                        <barButtonItem key="rightBarButtonItem" title="Debug" id="2EG-CO-a7g">
+                        <barButtonItem key="rightBarButtonItem" tag="1001" title="Debug" id="2EG-CO-a7g">
                             <connections>
                                 <action selector="debugTapped:" destination="IV4-7k-Qev" id="dwJ-yS-z6H"/>
                             </connections>
@@ -326,9 +341,13 @@
         <scene sceneID="wzk-0K-XBg">
             <objects>
                 <navigationController id="5i6-8x-7nf" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Events" image="recordingtape" catalog="system" id="uki-uJ-rK0"/>
+                    <tabBarItem key="tabBarItem" title="Events" image="recordingtape" catalog="system" id="uki-uJ-rK0">
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="tabEvents"/>
+                        </userDefinedRuntimeAttributes>
+                    </tabBarItem>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="SEe-Vi-Of1">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -344,9 +363,9 @@
         <segue reference="qoH-MI-PZN"/>
     </inferredMetricsTieBreakers>
     <resources>
-        <image name="person" catalog="system" width="128" height="117"/>
+        <image name="person" catalog="system" width="128" height="121"/>
         <image name="person.3" catalog="system" width="128" height="62"/>
-        <image name="recordingtape" catalog="system" width="128" height="59"/>
+        <image name="recordingtape" catalog="system" width="128" height="60"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/HomeTabBarController.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/HomeTabBarController.swift
@@ -1,0 +1,26 @@
+//
+//  HomeTabBarController.swift
+//  AppcuesCocoapodsExample
+//
+//  Created by James Ellis on 1/19/23.
+//
+
+import UIKit
+
+class HomeTabBarController: UITabBarController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // workaround due to tabBarItem not supporting accessibility in typical fashion
+        let tabBarControls = tabBar.subviews.compactMap { $0 as? UIControl }
+        let tabBarItems = tabBar.items ?? []
+        // this takes the accessibility info from each tabBarItem and applies it to the
+        // underlying tab controls that get rendered so our selectors can find them
+        zip(tabBarControls, tabBarItems).forEach { control, item in
+            control.accessibilityIdentifier = item.accessibilityIdentifier
+            control.accessibilityLabel = item.accessibilityLabel
+            control.tag = item.tag
+        }
+    }
+}

--- a/Examples/DeveloperCocoapodsExample/Podfile.lock
+++ b/Examples/DeveloperCocoapodsExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Appcues (1.1.1)
+  - Appcues (1.1.2)
 
 DEPENDENCIES:
   - Appcues (from `../../Appcues.podspec`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../../Appcues.podspec"
 
 SPEC CHECKSUMS:
-  Appcues: 758c5d86c18e49d09f501e771ca0cfd67651a5ce
+  Appcues: 6a4a6f7b5ebc2d0920b1a42421b732a185fc696b
 
 PODFILE CHECKSUM: 7a3abcd818687cb341a5696d302103f523e3edc0
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.11.2


### PR DESCRIPTION
This matches the identifiers that were previously updated in the SPM example in #317, so we can test target element behaviors with this app.

events tab
* tabEvents
* btnEvent1
* btnEvent2

profile tab
* tabProfile
* txtGivenName
* txtFamilyName
* btnSaveProfile

group tab
* tabGroup
* txtGroup
* btnSaveGroup