### PR TITLE
Fix keyboard avoidance with the send capture dialog

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -89,10 +89,7 @@ internal class DebugViewController: UIViewController {
             },
             screenName: screen.displayName)
 
-        let confirmationViewController = UIHostingController(rootView: confirmationView)
-        confirmationViewController.view.backgroundColor = .clear
-        confirmationViewController.modalTransitionStyle = .crossDissolve
-        confirmationViewController.modalPresentationStyle = .overFullScreen
+        let confirmationViewController = DebugModalViewController(rootView: confirmationView)
         present(confirmationViewController, animated: true)
     }
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
@@ -105,7 +105,7 @@ extension DebugModalViewController {
         let backdropView: UIView = {
             let view = UIView(frame: .zero)
             view.translatesAutoresizingMaskIntoConstraints = false
-            view.backgroundColor = UIColor(white: 0.0, alpha: 0.33)
+            view.backgroundColor = UIColor.label.withAlphaComponent(0.33)
             return view
         }()
 
@@ -116,6 +116,8 @@ extension DebugModalViewController {
             view.contentInsetAdjustmentBehavior = .always
             // For text input blocks, we want scrolling the modal content to be able to dismiss the keyboard.
             view.keyboardDismissMode = .interactive
+            view.layer.cornerRadius = 6.0
+            view.backgroundColor = UIColor.systemBackground
             return view
         }()
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
@@ -1,0 +1,157 @@
+//
+//  DebugModalViewController.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 1/30/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+// A UIViewController that can be used to host any SwiftUI modal content to be presented,
+// and handle keyboard avoidance, if necessary.
+//
+// This is similar to the structure of the ExperienceWrapperViewController - providing
+// the backdrop - and the ExperienceStepViewController centered within - providing the scroll
+// container where the hosted SwiftUI content resides. However, this is a more specific and
+// reduced implementation that is decoupled from Experience step content and data.
+@available(iOS 13.0, *)
+internal class DebugModalViewController<Content>: UIViewController where Content: View {
+
+    lazy var containerView = DebugModalWrapperView()
+
+    private lazy var preferredHeightConstraint: NSLayoutConstraint = {
+        var constraint = containerView.scrollView.heightAnchor.constraint(equalToConstant: 0)
+        constraint.priority = .defaultLow
+        constraint.isActive = true
+        return constraint
+    }()
+
+    private let contentViewController: UIViewController
+
+    init(rootView: Content) {
+        self.contentViewController = AppcuesHostingController(rootView: rootView)
+        self.contentViewController.view.backgroundColor = .clear
+
+        super.init(nibName: nil, bundle: nil)
+
+        modalTransitionStyle = .crossDissolve
+        modalPresentationStyle = .overFullScreen
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = containerView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        embedChildViewController(contentViewController, inSuperview: containerView.contentView, respectLayoutMargins: true)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil)
+    }
+
+    override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+        super.preferredContentSizeDidChange(forChildContentContainer: container)
+
+        // If the current child controller changes it's preferred size, propagate that this controller's view.
+        preferredHeightConstraint.constant = container.preferredContentSize.height
+    }
+
+    @objc
+    private func adjustForKeyboard(notification: Notification) {
+        guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+
+        if notification.name == UIResponder.keyboardWillHideNotification {
+            containerView.scrollView.contentInset.bottom = 0
+        } else {
+            let keyboardFrameInScreen = keyboardValue.cgRectValue
+            let keyboardFrameInView = containerView.scrollView.convert(keyboardFrameInScreen, from: view.window)
+            let intersection = containerView.scrollView.bounds.intersection(keyboardFrameInView)
+
+            containerView.scrollView.contentInset.bottom = intersection.height
+        }
+
+        containerView.scrollView.scrollIndicatorInsets = containerView.scrollView.contentInset
+
+        // Scroll the first responder into view.
+        // This happens automatically in some cases (eg UITextField), but is a bit janky and this is smoother.
+        // Also UITextView doesn't automatically scroll to visible as expected and so requires this implementation.
+        if let targetView = view.firstResponder {
+            let frameInScrollView = containerView.scrollView.convert(targetView.frame, from: targetView)
+            containerView.scrollView.scrollRectToVisible(frameInScrollView, animated: false)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension DebugModalViewController {
+    internal class DebugModalWrapperView: UIView {
+        let backdropView: UIView = {
+            let view = UIView(frame: .zero)
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.backgroundColor = UIColor(white: 0.0, alpha: 0.33)
+            return view
+        }()
+
+        lazy var scrollView: UIScrollView = {
+            let view = UIScrollView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            // Force a consistent safe area behavior regardless of whether the content scrolls
+            view.contentInsetAdjustmentBehavior = .always
+            // For text input blocks, we want scrolling the modal content to be able to dismiss the keyboard.
+            view.keyboardDismissMode = .interactive
+            return view
+        }()
+
+        lazy var contentView: UIView = {
+            let view = UIView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.directionalLayoutMargins = .zero
+            return view
+        }()
+
+        required init() {
+            super.init(frame: .zero)
+
+            backgroundColor = .clear
+
+            scrollView.addSubview(contentView)
+
+            addSubview(backdropView)
+            addSubview(scrollView)
+
+            contentView.pin(to: scrollView)
+            backdropView.pin(to: self)
+
+            NSLayoutConstraint.activate([
+                scrollView.centerYAnchor.constraint(equalTo: centerYAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
+                scrollView.topAnchor.constraint(greaterThanOrEqualTo: safeAreaLayoutGuide.topAnchor),
+                scrollView.bottomAnchor.constraint(lessThanOrEqualTo: safeAreaLayoutGuide.bottomAnchor),
+                contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+            ])
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
@@ -17,7 +17,7 @@ import SwiftUI
 // container where the hosted SwiftUI content resides. However, this is a more specific and
 // reduced implementation that is decoupled from Experience step content and data.
 @available(iOS 13.0, *)
-internal class DebugModalViewController<Content>: UIViewController where Content: View {
+internal class DebugModalViewController<Content: View>: UIViewController {
 
     lazy var containerView = DebugModalWrapperView()
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
@@ -24,25 +24,16 @@ internal enum SendCaptureUI {
         @State var screenName = ""
 
         var body: some View {
-            VStack {
-                Spacer()
-
-                VStack(spacing: 16) {
-                    header
-                    screenshotImage
-                    nameInput
-                    bottomButtons
-                }
-                .padding(25)
-                .frame(maxWidth: .infinity)
-                .background(Color.white)
-                .cornerRadius(6.0)
-
-                Spacer()
+            VStack(spacing: 16) {
+                header
+                screenshotImage
+                nameInput
+                bottomButtons
             }
             .padding(25)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.black.opacity(0.33).edgesIgnoringSafeArea(.all))
+            .frame(maxWidth: .infinity)
+            .background(Color.white)
+            .cornerRadius(6.0)
         }
 
         @ViewBuilder var header: some View {

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
@@ -32,8 +32,6 @@ internal enum SendCaptureUI {
             }
             .padding(25)
             .frame(maxWidth: .infinity)
-            .background(Color.white)
-            .cornerRadius(6.0)
         }
 
         @ViewBuilder var header: some View {

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
@@ -71,10 +71,13 @@ internal enum SendCaptureUI {
                 Text("Name")
                     .font(.system(size: 12))
                     .foregroundColor(.appcuesBlurple)
-                TextField("Name", text: $screenName)
-                    .font(.system(size: 16))
-                    .textFieldStyle(.roundedBorder)
+                MultilineTextView(text: $screenName,
+                                  model: TextInputStyle(numberOfLines: 1, font: UIFont.systemFont(ofSize: 16)))
                     .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color.appcuesTextInputBorder, lineWidth: 1))
             }
         }
 


### PR DESCRIPTION
Three commits here to address the pieces

1. Extract out a protocol for the MultiLineTextView component to use for its model properties so that it could be shared with this use case, and we could get the "done" toolbar that is not available in SwiftUI in iOS 13
2. Update the SendCaptureUI dialog contents to use this text view implementation instead of the SwiftUI version
3. (the largest part) - rework the hosting ViewController structure to support loading our dialog contents, in SwiftUI, inside of a UIViewController that properly handles the keyboard avoidance and scrolling focused text view into visible region

The implementation of DebugModalViewController adapts ideas from the ExperienceWrapperViewController and ExperienceStepViewController, but condenses them down into a single ViewController structure, since the use case here is much more narrow. I think I've got this sorted out, but it was a little tricky.  Basic structure is this:

* DebugModalViewController has a root view of DebugModalWrapperView
* DebugModalWrapperView has two subviews - the backdropView which goes edge to edge, and the scrollView which is centered in the screen
* The scrollView has a contentView - which is where the embedded SwiftUI content ends up getting hosted
* The scrollView height is controlled by watching the preferredContentSize of that child SwiftUI hosted content (inside an AppcuesHostingViewController) 
* The DebugModalViewController can then listen for the necessary keyboard notifications and update contentInset on the scrollView as needed, in `adjustForKeyboard`

https://user-images.githubusercontent.com/19266448/215563283-74aab102-33af-4187-b1b4-b4ff74f28e9c.mov
