### PR TITLE
Only apply cornerRadius to FAB when visible

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FloatingView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FloatingView.swift
@@ -55,11 +55,16 @@ internal class FloatingView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        // Round the self corners for a nice automatic accessibility path,
-        // but don't clip since that would obscure the unread indicator.
-        layer.cornerRadius = frame.width / 2
-        // Clipping the imageView is ok though.
-        imageView.layer.cornerRadius = frame.width / 2
+        // only apply rounding when visible, as size is transformed in
+        // animateVisibility which can lead to incorrect cornerRadius calculation
+        // here
+        if self.alpha == 1 {
+            // Round the self corners for a nice automatic accessibility path,
+            // but don't clip since that would obscure the unread indicator.
+            layer.cornerRadius = frame.width / 2
+            // Clipping the imageView is ok though.
+            imageView.layer.cornerRadius = frame.width / 2
+        }
     }
 
     @objc


### PR DESCRIPTION
This is to address an issue Ben saw in https://www.loom.com/share/2cbb97aee89144d599088a617021223e

where the FAB can end up square like:
![Screenshot 2023-02-02 at 3 26 23 PM](https://user-images.githubusercontent.com/19266448/216442125-e1ae55a1-4915-43b7-aee6-470983a1a98a.png)

Open to alternative ideas to best handle, but here is what is causing it:
* The FAB is hidden while the confirmation dialog is shown
* This calls FloatingView.animateVisibility - which hides the view by animating alpha to zero, but also does a CGAffineTransform shrink of the view down to a tiny size
* When the app is backgrounded, `layoutSubviews` is called for some reason on FloatingView. This causes a recalculation of the cornerRadius to occur. At this point `frame.width` is something very tiny so the cornerRadius is set to effectively zero - resulting in the square.

This change will skip that cornerRadius calculation if the view is not visible (alpha != 1) - so that we only try to calculate the cornerRadius when we know we have the full desired frame size.