### PR TITLE
Update animation duration to parse from milliseconds

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
@@ -10,7 +10,7 @@ import UIKit
 
 internal class AppcuesStepTransitionAnimationTrait: ContainerDecoratingTrait {
     struct Config: Decodable {
-        let duration: Double?
+        let duration: Int?
         let easing: Easing?
     }
 
@@ -23,7 +23,7 @@ internal class AppcuesStepTransitionAnimationTrait: ContainerDecoratingTrait {
 
     required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
         let config = configuration.decode(Config.self)
-        self.duration = config?.duration ?? 0.3
+        self.duration = Double(config?.duration ?? 300) / 1_000
         self.easing = config?.easing ?? .linear
     }
 


### PR DESCRIPTION
Note that `AppcuesStepTransitionAnimationTrait.duration` on L21 is a `TimeInterval` which is defined as seconds, so the unit should be clear.