### PR TITLE
Update sticky content to work using safe area

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -24,6 +24,15 @@ internal class ExperienceStepViewController: UIViewController {
 
     private let contentViewController: UIViewController
 
+    var stickySpacing: UIEdgeInsets = .zero {
+        didSet {
+            stepView.scrollView.contentInset = stickySpacing
+            stepView.scrollView.scrollIndicatorInsets = stickySpacing
+            // Ensure the main content starts below the top sticky content
+            stepView.scrollView.contentOffset.y = -(stickySpacing.top + stepView.safeAreaInsets.top)
+        }
+    }
+
     init(viewModel: ExperienceStepViewModel, stepState: ExperienceData.StepState, notificationCenter: NotificationCenter? = nil) {
         self.viewModel = viewModel
         self.stepState = stepState
@@ -77,8 +86,8 @@ internal class ExperienceStepViewController: UIViewController {
 
         let contentSize = stepView.scrollView.contentSize
         preferredContentSize = CGSize(
-            width: contentSize.width + additionalSafeAreaInsets.left + additionalSafeAreaInsets.right,
-            height: contentSize.height + additionalSafeAreaInsets.top + additionalSafeAreaInsets.bottom
+            width: contentSize.width,
+            height: contentSize.height + stickySpacing.top + stickySpacing.bottom
         )
     }
 
@@ -133,9 +142,9 @@ internal class ExperienceStepViewController: UIViewController {
 
         switch edge {
         case .top:
-            constraints.append(stickyContentVC.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor))
+            constraints.append(stickyContentVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor))
         case .bottom:
-            constraints.append(stickyContentVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor))
+            constraints.append(stickyContentVC.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor))
         }
 
         NSLayoutConstraint.activate(constraints)
@@ -143,12 +152,12 @@ internal class ExperienceStepViewController: UIViewController {
         stickyContentVC.didMove(toParent: self)
 
         // Pass sticky content size changes to the parent controller to update the insets.
-        stickyContentVC.onSizeChange = { [weak self] size, safeArea in
+        stickyContentVC.onSizeChange = { [weak self] size, _ in
             switch edge {
             case .top:
-                self?.additionalSafeAreaInsets.top = size.height - safeArea.top
+                self?.stickySpacing.top = size.height
             case .bottom:
-                self?.additionalSafeAreaInsets.bottom = size.height - safeArea.bottom
+                self?.stickySpacing.bottom = size.height
             }
         }
     }


### PR DESCRIPTION
The previous approach was to inset the safe area of ExperienceStepViewController by the size of the sticky content and then set the sticky content outside the safe area. 

This was causing extra layout passes because SwiftUI knew the content was in the safe area and basically didn't appreciate that fact. It was slow in some cases and actually froze the app in one particularly extreme example that Ben found.

We also had an issue where the sticky content was taller than than available container height (especially notable in half sheets) and so the safe areas exceeded the container height and left no space for the content. This is user error in the experience design to a certain extent, but the way it was displayed on iOS looked even more broken. Now the sticky content will still entirely overlap, but in a way that makes sense.

Modifying just the scrollView insets allows the sticky content to be safely within the safe area. The only tricky part is needing to set the scrollview `contentOffset` as well to make sure the top of the content doesn't start under a sticky top element.

This branch was published as TestFlight build #55.