### PR TITLE
Tooltip UI enhancements

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -60,6 +60,8 @@ extension AppcuesCarouselTrait {
             carouselView.collectionView.register(StepPageCell.self, forCellWithReuseIdentifier: StepPageCell.reuseID)
             carouselView.collectionView.dataSource = self
             carouselView.collectionView.delegate = self
+
+            stepControllers.forEach { ($0 as? ExperienceStepViewController)?.stepView.resetHorizontalSafeAreas = true }
         }
 
         override func viewWillAppear(_ animated: Bool) {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/TooltipWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/TooltipWrapperView.swift
@@ -310,18 +310,28 @@ internal class TooltipWrapperView: ExperienceWrapperView {
         )
 
         let pointerEdge: Pointer.Edge
+        let pointerSideLength: CGFloat
         switch tooltipPosition {
         case .top:
             pointerEdge = .bottom
+            pointerSideLength = mainRect.width
         case .bottom:
             pointerEdge = .top
+            pointerSideLength = mainRect.width
         case .leading:
             pointerEdge = .trailing
+            pointerSideLength = mainRect.height
         case .trailing:
             pointerEdge = .leading
+            pointerSideLength = mainRect.height
         }
 
-        let pointer = Pointer(edge: pointerEdge, size: pointerSize, offset: offsetFromCenter)
+        let constrainedPointerSize = CGSize(
+            width: min(pointerSize.width, pointerSideLength - cornerRadius * 2),
+            height: pointerSize.height
+        )
+
+        let pointer = Pointer(edge: pointerEdge, size: constrainedPointerSize, offset: offsetFromCenter)
         let tooltipPath = UIBezierPath(tooltipAround: mainRect, cornerRadius: cornerRadius, pointer: pointer)
 
         return tooltipPath.cgPath

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -183,10 +183,15 @@ extension ExperienceStepViewController {
             return view
         }()
 
-        // When nested inside the carousel traits collection view, the left and right safe area insets get doubled applied.
-        // This zeros out those values to achieve the desired layout.
+        /// When nested inside the carousel traits collection view, the left and right safe area insets get doubled applied in some cases.
+        /// This zeros out those values to achieve the desired layout.
+        var resetHorizontalSafeAreas = false
         override var safeAreaInsets: UIEdgeInsets {
-            UIEdgeInsets(top: super.safeAreaInsets.top, left: 0, bottom: super.safeAreaInsets.bottom, right: 0)
+            if resetHorizontalSafeAreas {
+                return UIEdgeInsets(top: super.safeAreaInsets.top, left: 0, bottom: super.safeAreaInsets.bottom, right: 0)
+            } else {
+                return super.safeAreaInsets
+            }
         }
 
         init() {


### PR DESCRIPTION
Two little fixes in two commits.

First, we want to cap the pointer width to not be wider than the tooltip. Not a likely case, but it looked really bad when it happened.

Second, for leading/trailing tooltips, the content was going into the safe area in the pointer. This is because of a workaround for landscape mode fullscreen carousel modals. I looked into fixing the carousel case a different way, but came up blank, so I've changed the workaround to only be applied by the carousel trait, rather than affecting everything and now tooltips display properly too.

|Good|Bad|
|-|-|
|![good pointer](https://user-images.githubusercontent.com/845681/218848286-9aa701da-e234-4b2f-aeed-acd95fe6e5d9.png)|![bad pointer](https://user-images.githubusercontent.com/845681/218848323-94c40610-53d1-4c15-a658-a8b492d9b1f9.png)|
|![good safe](https://user-images.githubusercontent.com/845681/218848305-b01b24c8-ae60-42d5-bda0-bbfe869304c5.png)|![bad safe](https://user-images.githubusercontent.com/845681/218848331-9b2eaca0-402a-4b8c-8209-f2375d5972fc.png)|