### PR TITLE
Update experience decoding error test

### DIFF
--- a/Sources/AppcuesKit/Data/Networking/DecodingError+Custom.swift
+++ b/Sources/AppcuesKit/Data/Networking/DecodingError+Custom.swift
@@ -15,15 +15,33 @@ extension DecodingError {
         case let DecodingError.dataCorrupted(context):
             message = "\(context)"
         case let DecodingError.keyNotFound(key, context):
-            message = "key '\(key)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
-        case let DecodingError.valueNotFound(value, context):
-            message = "value '\(value)' not found: \(context.debugDescription) codingPath: \(context.codingPath)"
-        case let DecodingError.typeMismatch(type, context):
-            message = "type '\(type)' mismatch: \(context.debugDescription) codingPath: \(context.codingPath)"
+            message = "Expected key '\(key.pretty)' not found at codingPath: \(context.codingPath.pretty)"
+        case let DecodingError.valueNotFound(_, context):
+            message = "\(context.debugDescription) codingPath: \(context.codingPath.pretty)"
+        case let DecodingError.typeMismatch(_, context):
+            message = "\(context.debugDescription) codingPath: \(context.codingPath.pretty)"
         @unknown default:
             message = "error: \(self)"
         }
 
         return "Error parsing Experience JSON data: \(message)"
+    }
+}
+
+extension CodingKey {
+    var pretty: String {
+        if let intValue = intValue {
+            return "\(intValue)"
+        }
+
+        return stringValue
+    }
+}
+
+extension Array where Element == CodingKey {
+    var pretty: String {
+        String(self
+            .map { $0.pretty }
+            .joined(separator: "."))
     }
 }

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
@@ -138,7 +138,9 @@ internal class DebugViewModel: ObservableObject {
             // Add a dismiss button to remove the row. Non-error rows are automatically removed when the experience completes.
             action = Action(symbolName: "xmark") { [weak self] in
                 guard let self = self else { return }
-                self.experienceStatuses = self.experienceStatuses.filter { $0.id != properties.experienceID }
+                DispatchQueue.main.async {
+                    self.experienceStatuses = self.experienceStatuses.filter { $0.id != properties.experienceID }
+                }
             }
         case .stepSeen:
             status = .verified

--- a/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
@@ -225,8 +225,8 @@ class QualifyResponseDecodeTests: XCTestCase {
         XCTAssertEqual("c9c11671-f418-451e-9b4a-33d54ed5299f", item7.id.appcuesFormatted)
 
 
-        XCTAssertTrue(item0.error!.starts(with: "Error parsing Experience JSON data: key 'CodingKeys(stringValue: \"type\", intValue: nil)' not found"))
-        XCTAssertTrue(item5.error!.starts(with: "Error parsing Experience JSON data: value 'String' not found: Expected String value but found null instead"))
-        XCTAssertTrue(item7.error!.starts(with: "Error parsing Experience JSON data: type 'String' mismatch: Expected to decode String but found a number instead"))
+        XCTAssertEqual(item0.error, "Error parsing Experience JSON data: Expected key \'type\' not found at codingPath: 0.steps.0.children.0.content")
+        XCTAssertEqual(item5.error, "Error parsing Experience JSON data: Expected String value but found null instead. codingPath: 5.steps.0.children.0.type")
+        XCTAssertEqual(item7.error, "Error parsing Experience JSON data: Expected to decode String but found a number instead. codingPath: 7.steps.0.type")
     }
 }


### PR DESCRIPTION
Random little thing, but I was annoyed trying to figure out where an error in my JSON was, so I improved the messages. They're shorter and clearer now:

```
// Old
key 'CodingKeys(stringValue: "type", intValue: nil)' not found: No value associated with key CodingKeys(stringValue: "type", intValue: nil) ("type"). codingPath: [_JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "steps", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0)]
// New
Expected key 'type' not found at codingPath: 0.steps.0

// Old
value 'String' not found: Expected String value but found null instead. codingPath: [_JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "steps", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "type", intValue: nil)]
// New
Expected String value but found null instead. codingPath: 0.steps.0.type

// Old
type 'String' mismatch: Expected to decode String but found a number instead. codingPath: [_JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "steps", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "type", intValue: nil)]
// New
Expected to decode String but found a number instead. codingPath: 0.steps.0.type
```

Looks much better in the debugger now:

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-15 at 14 30 06](https://user-images.githubusercontent.com/845681/219134994-096c65c0-532c-4a79-bf44-f24ec594273d.png)

