### PR TITLE
Feature/skippable trait enhancements

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
@@ -11,7 +11,7 @@ import UIKit
 @available(iOS 13.0, *)
 internal class AppcuesBackdropKeyholeTrait: BackdropDecoratingTrait {
     struct Config: Decodable {
-        let shape: String
+        let shape: String?
         let cornerRadius: Double?
         let blurRadius: Double?
         let spreadRadius: Double?
@@ -25,14 +25,11 @@ internal class AppcuesBackdropKeyholeTrait: BackdropDecoratingTrait {
     private let spreadRadius: CGFloat?
 
     required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
-        guard let config = configuration.decode(Config.self),
-              let keyholeShape = KeyholeShape(config.shape, cornerRadius: config.cornerRadius, blurRadius: config.blurRadius) else {
-            return nil
-        }
+        let config = configuration.decode(Config.self)
 
-        self.shape = keyholeShape
+        self.shape = KeyholeShape(config?.shape, cornerRadius: config?.cornerRadius, blurRadius: config?.blurRadius)
 
-        if let spreadRadius = config.spreadRadius {
+        if let spreadRadius = config?.spreadRadius {
             self.spreadRadius = spreadRadius
         } else {
             self.spreadRadius = nil
@@ -208,15 +205,13 @@ extension AppcuesBackdropKeyholeTrait {
         case rectangle(cornerRadius: CGFloat)
         case circle(blurRadius: CGFloat)
 
-        init?(_ shape: String?, cornerRadius: Double? = nil, blurRadius: Double? = nil) {
+        init(_ shape: String?, cornerRadius: Double? = nil, blurRadius: Double? = nil) {
             switch shape {
-            case "rectangle":
-                // fallback to a tiny value instead of 0 so the path can animate nicely to other values
-                self = .rectangle(cornerRadius: cornerRadius ?? .leastNonzeroMagnitude)
             case "circle":
                 self = .circle(blurRadius: blurRadius ?? 0)
             default:
-                return nil
+                // fallback to a tiny value instead of 0 so the path can animate nicely to other values
+                self = .rectangle(cornerRadius: cornerRadius ?? .leastNonzeroMagnitude)
             }
         }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -11,7 +11,7 @@ import UIKit
 @available(iOS 13.0, *)
 internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
     struct Config: Decodable {
-        let backgroundColor: ExperienceComponent.Style.DynamicColor?
+        let backgroundColor: ExperienceComponent.Style.DynamicColor
     }
 
     static var type: String = "@appcues/backdrop"

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
@@ -27,10 +27,10 @@ internal class AppcuesTooltipTrait: StepDecoratingTrait, WrapperCreatingTrait, P
     let pointerSize: CGSize
 
     required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
-        guard let config = configuration.decode(Config.self) else { return nil }
-        self.hidePointer = config.hidePointer ?? false
-        self.pointerSize = CGSize(width: config.pointerBase ?? 16, height: config.pointerLength ?? 8)
-        self.tooltipStyle = config.style
+        let config = configuration.decode(Config.self)
+        self.hidePointer = config?.hidePointer ?? false
+        self.pointerSize = CGSize(width: config?.pointerBase ?? 16, height: config?.pointerLength ?? 8)
+        self.tooltipStyle = config?.style
     }
 
     func decorate(stepController: UIViewController) throws {


### PR DESCRIPTION
Adds new config options to `@appcues/skippable`. The minimal close button draws a thinner x using a `differenceBlendMode`. The button target is still the same size for usability.

I also updated a few trait inits to match the schemas: if no config values are required in the spec, then the trait should init properly without requiring a config dictionary. (Noticed this because I was doing skippable wrong)