### PR TITLE
Do not mark experience completed if dismissed on the final step

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -150,11 +150,6 @@ internal class ExperienceRenderer: ExperienceRendering {
     }
 
     func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?) {
-        // Force `markComplete` to be true if dismissing from the last step in the experience.
-        let currentStepIndex = getCurrentStepIndex()
-        let forceMarkComplete = currentStepIndex != nil && currentStepIndex == getCurrentExperienceData()?.stepIndices.last
-        let markComplete = markComplete || forceMarkComplete
-
         guard Thread.isMainThread else {
             DispatchQueue.main.async {
                 self.dismissCurrentExperience(markComplete: markComplete, completion: completion)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -121,10 +121,10 @@ extension ExperienceStateMachine: ExperienceContainerLifecycleHandler {
         switch state {
         case .endingExperience:
             experienceDidDisappear()
-        case let .renderingStep(experience, stepIndex, package, _) where package.wrapperController.isBeingDismissed:
+        case let .renderingStep(_, _, package, _) where package.wrapperController.isBeingDismissed:
             experienceDidDisappear()
             // Update state in response to UI changes that have happened already (a call to UIViewController.dismiss).
-            try? transition(.endExperience(markComplete: stepIndex == experience.stepIndices.last))
+            try? transition(.endExperience(markComplete: false))
         default:
             break
         }

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -14,15 +14,10 @@ class ExperienceRendererTests: XCTestCase {
 
     var appcues: MockAppcues!
     var experienceRenderer: ExperienceRenderer!
-    private var updates: [TrackingUpdate] = []
 
     override func setUpWithError() throws {
         appcues = MockAppcues()
         experienceRenderer = ExperienceRenderer(container: appcues.container)
-    }
-
-    override func tearDownWithError() throws {
-        updates = []
     }
 
     func testShowPublished() throws {
@@ -260,13 +255,14 @@ class ExperienceRendererTests: XCTestCase {
         // Arrange
         let completionExpectation = expectation(description: "Completion called")
 
+        var updates: [TrackingUpdate] = []
         let preconditionPresentExpectation = expectation(description: "Experience presented")
         let dismissExpectation = expectation(description: "Experience dismissed")
         let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
         experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
-        appcues.analyticsPublisher.onPublish = { update in self.updates.append(update) }
+        appcues.analyticsPublisher.onPublish = { update in updates.append(update) }
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -16,14 +16,9 @@ class ExperienceStateMachineTests: XCTestCase {
     typealias Action = ExperienceStateMachine.Action
 
     var appcues: MockAppcues!
-    private var updates: [TrackingUpdate] = []
 
     override func setUpWithError() throws {
         appcues = MockAppcues()
-    }
-
-    override func tearDownWithError() throws {
-        updates = []
     }
 
     func testInitialState() throws {
@@ -185,14 +180,15 @@ class ExperienceStateMachineTests: XCTestCase {
         // the @appcues/skippable trait would do this
 
         // Arrange
+        var updates: [TrackingUpdate] = []
         let dismissExpectation = expectation(description: "Experience dismissed")
-        let experience = ExperienceData.singleStepMock
+        let experience = ExperienceData.mock
         let package: ExperiencePackage = experience.package(dismissExpectation: dismissExpectation)
 
-        let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 0, item: 0), package, isFirst: true)
+        let initialState: State = .renderingStep(experience, Experience.StepIndex(group: 1, item: 0), package, isFirst: true)
         let stateMachine = givenState(is: initialState)
         package.containerController.lifecycleHandler = stateMachine
-        appcues.analyticsPublisher.onPublish = { update in self.updates.append(update) }
+        appcues.analyticsPublisher.onPublish = { update in updates.append(update) }
 
         let observer = ExperienceStateMachine.AnalyticsObserver(container: appcues.container)
         stateMachine.addObserver(observer)


### PR DESCRIPTION
Requested change for parity with web, and to make our Studio analytics dashboards more comprehendible for customers.