### PR TITLE
Add fastlane option to nuke and regenerate certs and profiles with match

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,6 +63,29 @@ platform :ios do
       verbose: true)
   end
 
+  desc "Nuke code signing"
+  lane :nuke_match do
+    app_store_connect_api_key
+
+    match_nuke(
+      storage_mode: "s3",
+      s3_region: ENV["AWS_REGION"],
+      s3_bucket: ENV["AWS_S3_BUCKET"],
+      s3_access_key: ENV["AWS_ACCESS_KEY_ID"],
+      s3_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      type: "appstore",
+      app_identifier: "com.appcues.sdk-example-cocoapods",
+      team_id: "KHSQ25769M",
+      verbose: true)
+  end
+
+  desc "Reset/renew code signing"
+  lane :reset_match do
+    app_store_connect_api_key
+    nuke_match
+    prep_match
+  end
+
   desc "Push example app to Testflight beta"
   lane :beta_example do | options |
     Dir.chdir("../Examples/DeveloperCocoapodsExample") do

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -55,6 +55,22 @@ Sanity check to make sure the spm example app compiles
 
 Setup code signing
 
+### ios nuke_match
+
+```sh
+[bundle exec] fastlane ios nuke_match
+```
+
+Nuke code signing
+
+### ios reset_match
+
+```sh
+[bundle exec] fastlane ios reset_match
+```
+
+Reset/renew code signing
+
 ### ios beta_example
 
 ```sh


### PR DESCRIPTION
When our distribution certificate expires, this is the option needed to `nuke` (remove from dev portal and S3) and then regenerate, using existing `prep_match`.

```
fastlane nuke_match
```

Should really only be run once, as it will wipe all the profiles out, including the Cocoapods example here and all other iOS example apps we have in our App Store connect profile. Then, visit each product and run 

```
fastlane prep_match
```

To regenerate the profile for that product.

The option for `fastlane reset_match` is just a convenience to do a nuke + prep.