### PR TITLE
Add anonymous user ID prefix

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -140,7 +140,7 @@ public class Appcues: NSObject {
     /// qualified content.
     @objc
     public func anonymous(properties: [String: Any]? = nil) {
-        identify(isAnonymous: true, userID: config.anonymousIDFactory(), properties: properties)
+        identify(isAnonymous: true, userID: "anon:\(config.anonymousIDFactory())", properties: properties)
     }
 
     /// Clears out the current user in this session.  Can be used when the user logs out of your application.

--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -71,7 +71,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             "_lastScreenTitle": previousScreen,
             "_updatedAt": Date(),
             "_lastContentShownAt": storage.lastContentShownAt,
-            "_sessionId": appcues?.sessionID?.uuidString
+            "_sessionId": appcues?.sessionID?.appcuesFormatted
         ]
 
         if !Locale.preferredLanguages.isEmpty {

--- a/Sources/AppcuesKit/Data/Extensions/UIDevice+Custom.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UIDevice+Custom.swift
@@ -11,6 +11,6 @@ import UIKit
 
 extension UIDevice {
     static var identifier: String {
-        (current.identifierForVendor ?? UUID()).uuidString
+        (current.identifierForVendor ?? UUID()).appcuesFormatted
     }
 }

--- a/Sources/AppcuesKit/Data/Models/Activity.swift
+++ b/Sources/AppcuesKit/Data/Models/Activity.swift
@@ -53,7 +53,7 @@ extension Activity: Encodable {
         try container.encode(accountID, forKey: .accountID)
         try container.encode(userID, forKey: .userID)
         try container.encode(groupID, forKey: .groupID)
-        try container.encode(requestID, forKey: .requestID)
+        try container.encode(requestID.appcuesFormatted, forKey: .requestID)
         if let events = events {
             try container.encode(events, forKey: .events)
         }

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -53,6 +53,14 @@ class AppcuesTests: XCTestCase {
         XCTAssertEqual(4, subscriber.trackedUpdates)
     }
 
+    func testAnonymousUserIdPrefix() throws {
+        // Act
+        appcues.anonymous()
+
+        // Assert
+        XCTAssertEqual("anon:", appcues.storage.userID.prefix(5))
+    }
+
     func testIdentifyWithEmptyUserIsNotTracked() throws {
         // Arrange
         var trackedUpdates = 0


### PR DESCRIPTION
targets `main` for a potential 1.3.1 release

Matching web SDK behavior by adding an `anon:` prefix on any anonymous user ID generated and used in the `anonymous()` function call. Backend services can use this convention to reliably differentiate anonymous user traffic.

Also updated the default value `identifierForVendor` to use `.appcuesFormatted` (lowercase). This value is also the `_localId` auto prop. Also, a couple of other UUID spots: `_sessionId` auto prop, and `request_id` top level value, updated to lowercase to match other usages in Appcues backend and other clients.