### PR TITLE
Remove the properties parameter from anonymous function

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -139,8 +139,15 @@ public class Appcues: NSObject {
     /// the `identify` call.  This will cause the SDK to begin tracking activity and checking for
     /// qualified content.
     @objc
-    public func anonymous(properties: [String: Any]? = nil) {
-        identify(isAnonymous: true, userID: config.anonymousIDFactory(), properties: properties)
+    public func anonymous() {
+        identify(isAnonymous: true, userID: config.anonymousIDFactory(), properties: nil)
+    }
+
+    /// This function has been removed. Calling the anonymous function with a properties parameter
+    /// is no longer supported. A call to `anonymous()` with no parameters should be used instead.
+    @available(*, unavailable, message: "properties are no longer supported for anonymous users.")
+    public func anonymous(properties: [String: Any]?) {
+        // removed
     }
 
     /// Clears out the current user in this session.  Can be used when the user logs out of your application.

--- a/Sources/AppcuesKit/AppcuesKit.docc/Debugging.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/Debugging.md
@@ -62,6 +62,6 @@ If an experience fails to show, the debugger will note it with "Content Omitted"
 
 The Recent Events section of the debugger shows the list of all events that have passed through the Appcues SDK, with the most recent events at the top of the list. The list of events can be filtered by type by selecting the Filter icon in the header row and selecting an event type.
 
-Session and Experience events are automatically tracked by the SDK. Screen (``Appcues/screen(title:properties:)`` or ``Appcues/trackScreens()``), Custom (``Appcues/track(name:properties:)``), User Profile (``Appcues/identify(userID:properties:)`` or ``Appcues/anonymous(properties:)``), and Group (``Appcues/group(groupID:properties:)``) events are tracked by your app calling the Appcues SDK.
+Session and Experience events are automatically tracked by the SDK. Screen (``Appcues/screen(title:properties:)`` or ``Appcues/trackScreens()``), Custom (``Appcues/track(name:properties:)``), User Profile (``Appcues/identify(userID:properties:)`` or ``Appcues/anonymous()``), and Group (``Appcues/group(groupID:properties:)``) events are tracked by your app calling the Appcues SDK.
 
 Tap an event row to see the details of that event including all the properties associated with it.

--- a/Sources/AppcuesKit/AppcuesKit.docc/Extensions/Appcues.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/Extensions/Appcues.md
@@ -11,7 +11,7 @@
 
 - <doc:Identifying>
 - ``Appcues/identify(userID:properties:)``
-- ``Appcues/anonymous(properties:)``
+- ``Appcues/anonymous()``
 - ``Appcues/group(groupID:properties:)``
 - ``Appcues/reset()``
 

--- a/Sources/AppcuesKit/AppcuesKit.docc/Identifying.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/Identifying.md
@@ -10,8 +10,8 @@ In order to target content to the right users at the right time, you need to ide
 
 The inverse of identifying is resetting. For example, if a user logs out of your app. Calling ``Appcues/reset()`` will disable tracking of screens and events until a user is identified again.
 
-## Indentifying Anonymous Users
+## Identifying Anonymous Users
 
-``Appcues/anonymous(properties:)``
+``Appcues/anonymous()``
 
 The format of anonymous ID's can customized with ``Appcues/Config/anonymousIDFactory(_:)``.


### PR DESCRIPTION
This is a `traits-2.0` branch change (breaking) - we'll no longer support properties passed in on anonymous() user calls. This is to match the web SDK and comply with data security expectations.