### PR TITLE
Add safe area insets to screen capture metadata

### DIFF
--- a/Sources/AppcuesKit/Data/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Data/Networking/Endpoint.swift
@@ -78,7 +78,7 @@ internal enum CustomerAPIEndpoint: Endpoint {
         switch self {
         case let .preSignedImageUpload(_, filename):
             components.path = "/v1/accounts/\(config.accountID)/mobile/\(config.applicationID)/pre-upload-screenshot"
-            components.query = "?name=\(filename)"
+            components.query = "name=\(filename)"
         case .screenCapture:
             components.path = "/v1/accounts/\(config.accountID)/mobile/\(config.applicationID)/screens"
         }

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
@@ -35,6 +35,21 @@ internal struct Capture: Identifiable {
         let sdkName = "appcues-ios"
         let osName = "ios"
         let osVersion = UIDevice.current.systemVersion
+        let insets: Insets
+    }
+
+    struct Insets: Encodable {
+        let left: CGFloat
+        let right: CGFloat
+        let top: CGFloat
+        let bottom: CGFloat
+
+        init(_ insets: UIEdgeInsets) {
+            self.left = insets.left
+            self.right = insets.right
+            self.top = insets.top
+            self.bottom = insets.bottom
+        }
     }
 
     let id = UUID().appcuesFormatted
@@ -42,7 +57,7 @@ internal struct Capture: Identifiable {
     var displayName: String
     var screenshotImageUrl: URL?
     let layout: View
-    let metadata = Metadata()
+    let metadata: Metadata
     let timestamp: Date
 
     // The image data here is sent to a separate endpoint to upload the image, then

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -164,6 +164,7 @@ extension UIDebugger: DebugViewDelegate {
             displayName: window.screenCaptureDisplayName(at: timestamp),
             screenshotImageUrl: URL(string: "http://www.appcues.com/screenshot/\(UUID())"),
             layout: layout,
+            metadata: Capture.Metadata(insets: Capture.Insets(window.safeAreaInsets)),
             timestamp: timestamp,
             screenshot: screenshot)
 


### PR DESCRIPTION
Also fix a double `?` on query string of pre-signed image upload request.