### PR TITLE
Add success and failure toast implementations for screen capture using simplified UIView

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugView.swift
@@ -154,8 +154,8 @@ internal class DebugView: UIView {
             dismissView.trailingAnchor.constraint(equalTo: trailingAnchor),
             dismissView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            toastView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 25),
-            toastView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25),
+            toastView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor, constant: 25),
+            toastView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor, constant: -25),
             toastView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -25),
             toastView.heightAnchor.constraint(equalToConstant: 64)
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/CaptureToastView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/CaptureToastView.swift
@@ -1,0 +1,103 @@
+//
+//  CaptureToastView.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 3/8/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal class CaptureToastView: UIView {
+
+    var onRetry: (() -> Void)?
+
+    private var stackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.alignment = .center
+        view.spacing = 8.0
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private var messageLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        return label
+    }()
+
+    private var retryButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("Try again", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14)
+        button.layer.borderWidth = 1.0
+        button.layer.borderColor = UIColor.white.cgColor
+        button.layer.cornerRadius = 6.0
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        layer.cornerRadius = 6.0
+
+        stackView.addArrangedSubview(messageLabel)
+        stackView.addArrangedSubview(retryButton)
+
+        addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+
+            retryButton.heightAnchor.constraint(equalToConstant: 40),
+            retryButton.widthAnchor.constraint(equalToConstant: 90)
+        ])
+
+        retryButton.addTarget(self, action: #selector(retryButtonTapped), for: .touchUpInside)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureSuccess(_ capture: Capture) {
+        backgroundColor = .appcuesToastSuccess
+        retryButton.isHidden = true
+        var message = NSMutableAttributedString(string: "\"\(capture.displayName)\"", attributes: [
+            .font: UIFont.systemFont(ofSize: 14, weight: .bold),
+            .foregroundColor: UIColor.white
+        ])
+        message.append(NSAttributedString(string: " is now available for preview and targeting.", attributes: [
+            .font: UIFont.systemFont(ofSize: 14, weight: .regular),
+            .foregroundColor: UIColor.white
+        ]))
+        messageLabel.attributedText = message
+        onRetry = nil
+    }
+
+    func configureFailure(onRetry: @escaping () -> Void) {
+        backgroundColor = .appcuesToastFailure
+        retryButton.isHidden = false
+        messageLabel.attributedText = NSAttributedString(string: "Upload failed", attributes: [
+            .font: UIFont.systemFont(ofSize: 14, weight: .bold),
+            .foregroundColor: UIColor.white
+        ])
+        self.onRetry = onRetry
+    }
+
+    @objc
+    func retryButtonTapped() {
+        onRetry?()
+    }
+}
+
+private extension UIColor {
+    static let appcuesToastSuccess = UIColor(red: 0.0, green: 0.447, blue: 0.839, alpha: 1.0)
+    static let appcuesToastFailure = UIColor(red: 0.867, green: 0.133, blue: 0.439, alpha: 1.0)
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/CaptureToastView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/CaptureToastView.swift
@@ -17,6 +17,8 @@ internal class CaptureToastView: UIView {
         view.axis = .horizontal
         view.alignment = .center
         view.spacing = 8.0
+        view.layoutMargins = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+        view.isLayoutMarginsRelativeArrangement = true
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -49,10 +51,10 @@ internal class CaptureToastView: UIView {
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             retryButton.heightAnchor.constraint(equalToConstant: 40),
             retryButton.widthAnchor.constraint(equalToConstant: 90)
@@ -69,7 +71,7 @@ internal class CaptureToastView: UIView {
     func configureSuccess(_ capture: Capture) {
         backgroundColor = .appcuesToastSuccess
         retryButton.isHidden = true
-        var message = NSMutableAttributedString(string: "\"\(capture.displayName)\"", attributes: [
+        let message = NSMutableAttributedString(string: "\"\(capture.displayName)\"", attributes: [
             .font: UIFont.systemFont(ofSize: 14, weight: .bold),
             .foregroundColor: UIColor.white
         ])

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
@@ -98,32 +98,6 @@ internal enum SendCaptureUI {
             }
         }
     }
-
-    struct CaptureSuccessToastView: View {
-
-        let screenName: String
-
-        var body: some View {
-            VStack {
-                toastMessage
-                    .lineSpacing(7)
-                    .multilineTextAlignment(.leading)
-                    .foregroundColor(.white)
-                    .padding(16)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.blue)
-                    .cornerRadius(6)
-            }
-            .padding(25)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-
-        @ViewBuilder var toastMessage: Text {
-            Text("\"\(screenName)\"").font(.system(size: 14, weight: .bold ))
-            +
-            Text(" is now available for preview and targeting.").font(.system(size: 14))
-        }
-    }
 }
 
 @available(iOS 13.0, *)

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -177,15 +177,24 @@ extension UIDebugger: DebugViewDelegate {
                 capture.displayName = name
 
                 // save the screen into the account/app
-                self.saveScreenCapture(networking: self.networking, screen: capture, authorization: authorization) { result in
-                    if case .success = result {
-                        DispatchQueue.main.async {
-                            // show toast
-                            debugViewController.showCaptureSuccess(screen: capture)
-                        }
-                    }
+                self.saveScreen(debugViewController: debugViewController, capture: capture, authorization: authorization)
+            }
+        }
+    }
 
-                    // need error handling here on save failures
+    private func saveScreen(debugViewController: DebugViewController, capture: Capture, authorization: Authorization) {
+        self.saveScreenCapture(networking: self.networking, screen: capture, authorization: authorization) { result in
+            switch result {
+            case .success:
+                DispatchQueue.main.async {
+                    debugViewController.showCaptureSuccess(screen: capture)
+                }
+            case .failure:
+                DispatchQueue.main.async {
+                    debugViewController.showCaptureFailure {
+                        // onRetry - recursively call save to try again
+                        self.saveScreen(debugViewController: debugViewController, capture: capture, authorization: authorization)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is a second swing at what was done in #352 , using a simplified approach that implements the toasts in a UIView, rather than having to [deal with all the complexities](https://github.com/appcues/appcues-ios-sdk/pull/352#discussion_r1126649047) of hosting a SwiftUI toast view inside of a UIKit container.

The end result should look and behave identically to the previous PR.
* Toast shows 3 sec on success, 6 sec on failure
* Tapping retry button triggers another save attempt with the same capture and token (useful in rare client network glitch case)
* Tapping anywhere else outside of the toast, or any part of the toast other than the button will initiate a dismiss

Success

https://user-images.githubusercontent.com/19266448/223795054-e1f82f63-6455-4332-a1b5-ad4e3b247351.mov

Failure

https://user-images.githubusercontent.com/19266448/223795086-f91ea818-cb2f-47ab-af5b-caa44ae07add.mov