### PR TITLE
Update AppcuesNavigationDelegate to handle universal link cases

### DIFF
--- a/Sources/AppcuesKit/Presentation/Public/AppcuesNavigationDelegate.swift
+++ b/Sources/AppcuesKit/Presentation/Public/AppcuesNavigationDelegate.swift
@@ -15,5 +15,5 @@ public protocol AppcuesNavigationDelegate: AnyObject {
     /// - Parameters:
     ///   - url: The URL of the destination to navigate.
     ///   - completion: Closure to invoke when navigation is completed, passing `true` if successfully navigated, `false` if not.
-    func navigate(to url: URL, completion: @escaping (Bool) -> Void)
+    func navigate(to url: URL, openExternally: Bool, completion: @escaping (Bool) -> Void)
 }


### PR DESCRIPTION
Breaking change to `AppcuesNavigationDelegate`.