### PR TITLE
Update Circle CI to use Xcode 14.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ orbs:
 executors:
   xcode_14:
     macos:
-      xcode: 14.0.0
+      xcode: 14.2.0
     working_directory: /Users/distiller/project
     shell: /bin/bash --login -o pipefail
     environment:


### PR DESCRIPTION
Trying out a deploy from `main` here https://app.circleci.com/pipelines/github/appcues/appcues-ios-sdk/1707/workflows/cbd14ec4-dfc8-4cf0-ad3f-a9a1a0afda4d/jobs/1558