### PR TITLE
Ensure an error color overrides rich text coloring

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -27,7 +27,7 @@ internal struct AppcuesText: View {
 
 @available(iOS 13.0, *)
 extension Text {
-    init(textModel: ExperienceComponent.TextModel) {
+    init(textModel: ExperienceComponent.TextModel, skipColor: Bool = false) {
         self.init("")
 
         // Note: a ViewBuilder approach here doesn't work because the requirement that we operate strictly on `Text`
@@ -41,7 +41,7 @@ extension Text {
                 text = text.font(font)
             }
 
-            if let foregroundColor = Color(dynamicColor: span.style?.foregroundColor) {
+            if !skipColor, let foregroundColor = Color(dynamicColor: span.style?.foregroundColor) {
                 text = text.foregroundColor(foregroundColor)
             }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -18,7 +18,7 @@ internal struct TintedTextView: View {
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 
-        Text(textModel: model)
+        Text(textModel: model, skipColor: tintColor != nil)
             .applyTextStyle(style, model: model)
             .setupActions(on: viewModel, for: model)
             .ifLet(tintColor) { view, val in


### PR DESCRIPTION
For reference, `TintedTextView` is used exclusively by `AppcuesOptionSelect` and `AppcuesTextInput` to show the label. We skip applying the rich text color which allows the errorTintColor to be applied to the whole rich text object.

|Error Tint|Regular Rich Text|
|-|-|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-28 at 11 25 13](https://user-images.githubusercontent.com/845681/228288014-81670d33-8c5c-4129-a283-d9a991a47631.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-28 at 11 25 11](https://user-images.githubusercontent.com/845681/228288004-5557d225-520e-49e5-9b9a-53fd8d442118.png)|
