### PR TITLE
Ensure experiences aren’t presented over the debugger

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
@@ -38,7 +38,13 @@ extension UIApplication: TopControllerGetting {
     }
 
     func topViewController() -> UIViewController? {
-        guard let rootViewController = activeKeyWindow?.rootViewController else { return nil }
+        var window: UIWindow? = activeKeyWindow
+
+        if window == nil || window!.isAppcuesWindow {
+            window = UIApplication.shared.windows.first { !$0.isAppcuesWindow }
+        }
+
+        guard let rootViewController = window?.rootViewController else { return nil }
         return topViewController(controller: rootViewController)
     }
 


### PR DESCRIPTION
A bit related to #375 and using `isAppcuesWindow`... It's always been the case that a modal can appear on top of the debugger (usually when you have Charles constantly returning a qualified experience) which is because the debugger window claims the `activeKeyWindow` mantle. The same thing can happen for tooltips, which is even stranger, so I figured we should clean this up.

I still want to use `activeKeyWindow` to theoretically support multi-window iPad apps properly, so I'm keeping that but checking if it's `isAppcuesWindow` and then falling back to a simpler window detection.

This method is used by the modal trait, the tooltip trait, and a handful of other places that I've verified should **prefer** (or be **indifferent** to) this new behaviour:

- State machine looking for `AppcuesExperienceDelegate` (preferred)
- Automatic screen tracking (preferred, since at a glance it looks like automatic screen tracking would currently find the debugger VC since it doesn't set `untrackedScreenKey`)
- Link action presenting the safari controller (indifferent)
- Deep link handler checking if the scene is active (indifferent)