### PR TITLE
Update code coverage to exclude presentation files

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,15 @@ platform :ios do
       scheme: "Appcues",
       proj: "Appcues.xcodeproj",
       cobertura_xml: true,
-      ignore: ["Tests/*"],
+      ignore: [
+        # Presentation layer is tested with snapshot and UI tests
+        "Sources/AppcuesKit/Presentation/Debugger/*",
+        "Sources/AppcuesKit/Presentation/Extensions/*",
+        "Sources/AppcuesKit/Presentation/Generated/*",
+        "Sources/AppcuesKit/Presentation/UI/*",
+        "Sources/AppcuesKit/Vendor/*",
+        "Tests/*"
+      ],
       output_directory: "fastlane/test_output"
     )
   end


### PR DESCRIPTION
Ignoring these directories will improve the usefulness of the codecov reports on PRs. It'll also remove the annoying inline warnings about missing coverage for things that won't ever be tested with unit tests in this repository.