### PR TITLE
Fix tooltip corner radius when there’s a border

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/TooltipWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/TooltipWrapperView.swift
@@ -55,7 +55,11 @@ internal class TooltipWrapperView: ExperienceWrapperView {
 
     private let maskLayer = CAShapeLayer()
     private let innerMaskLayer = CAShapeLayer()
-    private let borderLayer = CAShapeLayer()
+    private let borderLayer: CAShapeLayer = {
+        let layer = CAShapeLayer()
+        layer.lineWidth = 0
+        return layer
+    }()
 
     required init() {
         super.init()
@@ -87,8 +91,15 @@ internal class TooltipWrapperView: ExperienceWrapperView {
 
         // Set tooltip shape for content inside the border
         if let innerView = contentWrapperView.subviews.first {
+            let innerBounds = CGRect(
+                x: 0,
+                y: 0,
+                // the visible lineWidth is /2, but then we need to *2 for each side
+                width: contentWrapperView.bounds.width - borderLayer.lineWidth,
+                height: contentWrapperView.bounds.height - borderLayer.lineWidth
+            )
             innerMaskLayer.path = tooltipPath(
-                in: contentWrapperView.bounds,
+                in: innerBounds,
                 boxCornerRadius: boxCornerRadius - borderLayer.lineWidth / 2
             )
             innerView.layer.mask = innerMaskLayer


### PR DESCRIPTION
In #365 I did [🐛 Fix tooltip content clipping during initial layout](https://github.com/appcues/appcues-ios-sdk/pull/365/commits/dd0c1f9560080c8612e6c2d178570bbf87eb70b7), but that didn't work properly with border widths because the frame width/height for the inner mask was including the border width. Changed that and also made sure the initial width is 0 instead of 1.

|Fixed|Broken|
|-|-|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-04-06 at 11 28 46](https://user-images.githubusercontent.com/845681/230427178-4f67ddb4-34ff-45c4-8cd3-988180ecc561.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-04-06 at 11 28 14](https://user-images.githubusercontent.com/845681/230427220-67dd0e4e-9a79-45bb-a498-c6128df14326.png)|
