### PR TITLE
Move ExperienceTraitLevel to ExperiencePluginConfiguration

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -65,9 +65,9 @@ internal class ActionRegistry {
 
     /// Enqueue an array of experience action data models to be executed. This version is for non-interactive action execution,
     /// such as actions that execute as part of the navigation to a step.
-    func enqueue(actionModels: [Experience.Action], completion: @escaping () -> Void) {
+    func enqueue(actionModels: [Experience.Action], level: ExperiencePluginConfiguration.Level, completion: @escaping () -> Void) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: ExperiencePluginConfiguration($0.configDecoder))
+            actions[$0.type]?.init(configuration: ExperiencePluginConfiguration($0.configDecoder, level: level))
         }
         execute(transformQueue(actionInstances), completion: completion)
     }
@@ -79,9 +79,14 @@ internal class ActionRegistry {
 
     /// Enqueue an array of experience action data models to be executed. This version is used for interactive actions that are taken
     /// during an experience, such as button taps.
-    func enqueue(actionModels: [Experience.Action], interactionType: String, viewDescription: String?) {
+    func enqueue(
+        actionModels: [Experience.Action],
+        level: ExperiencePluginConfiguration.Level,
+        interactionType: String,
+        viewDescription: String?
+    ) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: ExperiencePluginConfiguration($0.configDecoder))
+            actions[$0.type]?.init(configuration: ExperiencePluginConfiguration($0.configDecoder, level: level))
         }
 
         // As a heuristic, take the last action that's `MetadataSettingAction`, since that's most likely

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -223,7 +223,7 @@ extension ExperienceStateMachine {
             case .continuation(let action):
                 try machine.transition(action)
             case let .presentContainer(experience, stepIndex, package, actions):
-                machine.actionRegistry.enqueue(actionModels: actions) {
+                machine.actionRegistry.enqueue(actionModels: actions, level: .group) {
                     executePresentContainer(
                         machine: machine,
                         experience: experience,

--- a/Sources/AppcuesKit/Presentation/Public/ExperiencePluginConfiguration.swift
+++ b/Sources/AppcuesKit/Presentation/Public/ExperiencePluginConfiguration.swift
@@ -12,10 +12,25 @@ import Foundation
 @objc
 public class ExperiencePluginConfiguration: NSObject {
 
+    /// Context in which a plugin can be applied.
+    @objc
+    public enum Level: Int {
+        /// A plugin defined on an entire experience.
+        case experience
+        /// A plugin defined on a group of steps in an experience.
+        case group
+        /// A plugin defined on single step in an experience.
+        case step
+    }
+
     private var decoder: PluginDecoder
 
-    init(_ decoder: PluginDecoder) {
+    /// The context where the plugin was defined.
+    public let level: Level
+
+    init(_ decoder: PluginDecoder, level: Level) {
         self.decoder = decoder
+        self.level = level
     }
 
     /// Returns a value of the type you specify, decoded from a JSON object.

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
@@ -24,7 +24,7 @@ internal class AppcuesBackdropKeyholeTrait: BackdropDecoratingTrait {
     private let shape: KeyholeShape
     private let spreadRadius: CGFloat?
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         let config = configuration.decode(Config.self)
 
         self.shape = KeyholeShape(config?.shape, cornerRadius: config?.cornerRadius, blurRadius: config?.blurRadius)

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -20,7 +20,7 @@ internal class AppcuesBackdropTrait: BackdropDecoratingTrait {
 
     private let backgroundColor: UIColor
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         guard let config = configuration.decode(Config.self),
               let backgroundColor = UIColor(dynamicColor: config.backgroundColor) else {
             return nil

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -18,15 +18,15 @@ internal class AppcuesBackgroundContentTrait: StepDecoratingTrait, ContainerDeco
 
     weak var metadataDelegate: TraitMetadataDelegate?
 
-    private let level: ExperienceTraitLevel
+    private let level: ExperiencePluginConfiguration.Level
     private let content: ExperienceComponent
 
     private weak var backgroundViewController: UIViewController?
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         guard let config = configuration.decode(Config.self) else { return nil }
 
-        self.level = level
+        self.level = configuration.level
         self.content = config.content
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -14,7 +14,7 @@ internal class AppcuesCarouselTrait: ContainerCreatingTrait {
 
     weak var metadataDelegate: TraitMetadataDelegate?
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
     }
 
     func createContainer(

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -22,7 +22,7 @@ internal class AppcuesModalTrait: StepDecoratingTrait, WrapperCreatingTrait, Pre
     private let presentationStyle: PresentationStyle
     private let modalStyle: ExperienceComponent.Style?
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         guard let config = configuration.decode(Config.self) else { return nil }
         self.presentationStyle = config.presentationStyle
         self.modalStyle = config.style

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
@@ -22,7 +22,7 @@ internal class AppcuesPagingDotsTrait: ContainerDecoratingTrait {
     private weak var containerController: ExperienceContainerViewController?
     private weak var view: UIView?
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         let config = configuration.decode(Config.self)
         self.style = config?.style
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -29,7 +29,7 @@ internal class AppcuesSkippableTrait: ContainerDecoratingTrait, BackdropDecorati
     private weak var view: UIViewController.CloseButton?
     private var gestureRecognizer: UITapGestureRecognizer?
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         let config = configuration.decode(Config.self)
         self.buttonAppearance = config?.buttonAppearance ?? .default
         self.ignoreBackdropTap = config?.ignoreBackdropTap ?? false

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
@@ -21,7 +21,7 @@ internal class AppcuesStepTransitionAnimationTrait: ContainerDecoratingTrait {
     private let duration: TimeInterval
     private let easing: Easing
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         let config = configuration.decode(Config.self)
         self.duration = Double(config?.duration ?? 300) / 1_000
         self.easing = config?.easing ?? .linear

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
@@ -24,7 +24,7 @@ internal class AppcuesTargetElementTrait: BackdropDecoratingTrait {
 
     private lazy var frameObserverView = FrameObserverView()
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         guard let config = configuration.decode(Config.self) else { return nil }
         self.config = config
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetRectangleTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetRectangleTrait.swift
@@ -33,7 +33,7 @@ internal class AppcuesTargetRectangleTrait: BackdropDecoratingTrait {
 
     private lazy var frameObserverView = FrameObserverView()
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         guard let config = configuration.decode(Config.self) else { return nil }
         self.config = config
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
@@ -28,7 +28,7 @@ internal class AppcuesTooltipTrait: StepDecoratingTrait, WrapperCreatingTrait, P
     let pointerSize: CGSize
     let pointerCornerRadius: CGFloat
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         let config = configuration.decode(Config.self)
         self.hidePointer = config?.hidePointer ?? false
         self.pointerSize = CGSize(width: config?.pointerBase ?? 16, height: config?.pointerLength ?? 8)

--- a/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/ExperienceTrait.swift
@@ -10,17 +10,6 @@ import UIKit
 
 // swiftlint:disable file_types_order
 
-/// Context in which a trait can be applied.
-@objc
-public enum ExperienceTraitLevel: Int {
-    /// A trait to be applied to the entire experience.
-    case experience
-    /// A trait to be applied to a group of steps in an experience.
-    case group
-    /// A trait to be applied to a single step in an experience.
-    case step
-}
-
 /// A type that describes a trait of an `Experience`.
 @objc
 public protocol ExperienceTrait {
@@ -36,7 +25,7 @@ public protocol ExperienceTrait {
     /// Initializer from an `Experience.Trait` data model.
     ///
     /// This initializer should verify the config has any required properties and return `nil` if not.
-    init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel)
+    init?(configuration: ExperiencePluginConfiguration)
 }
 
 /// A trait that modifies the `UIViewController` that encapsulates the contents of a specific step in the experience.

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -195,7 +195,7 @@ extension TraitComposer {
         weak var metadataDelegate: TraitMetadataDelegate?
 
         init() {}
-        required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {}
+        required init?(configuration: ExperiencePluginConfiguration) {}
 
         func createContainer(
             for stepControllers: [UIViewController],

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -40,9 +40,9 @@ internal class TraitRegistry {
         traits[trait.type] = trait
     }
 
-    func instances(for models: [Experience.Trait], level: ExperienceTraitLevel) -> [ExperienceTrait] {
+    func instances(for models: [Experience.Trait], level: ExperiencePluginConfiguration.Level) -> [ExperienceTrait] {
         models.compactMap { traitModel in
-            traits[traitModel.type]?.init(configuration: ExperiencePluginConfiguration(traitModel.configDecoder), level: level)
+            traits[traitModel.type]?.init(configuration: ExperiencePluginConfiguration(traitModel.configDecoder, level: level))
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -50,6 +50,7 @@ internal class ExperienceStepViewModel: ObservableObject {
     func enqueueActions(_ actions: [Experience.Action], type: String, viewDescription: String?) {
         actionRegistry?.enqueue(
             actionModels: actions,
+            level: .step,
             interactionType: type,
             viewDescription: viewDescription
         )

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -35,6 +35,7 @@ class ActionRegistryTests: XCTestCase {
         // Assert
         actionRegistry.enqueue(
             actionModels: [actionModel],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
         waitForExpectations(timeout: 1)
@@ -56,6 +57,7 @@ class ActionRegistryTests: XCTestCase {
         // Assert
         actionRegistry.enqueue(
             actionModels: [actionModel],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
         waitForExpectations(timeout: 1)
@@ -81,6 +83,7 @@ class ActionRegistryTests: XCTestCase {
         // Assert
         actionRegistry.enqueue(
             actionModels: [actionModel],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
         waitForExpectations(timeout: 1)
@@ -100,6 +103,7 @@ class ActionRegistryTests: XCTestCase {
         // Act
         actionRegistry.enqueue(
             actionModels: [actionModel, actionModel, actionModel, actionModel, actionModel],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -127,12 +131,14 @@ class ActionRegistryTests: XCTestCase {
         // Act
         actionRegistry.enqueue(
             actionModels: [delayedActionModel],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
         // Enqueue more while the delayed one is processing
         actionRegistry.enqueue(
             actionModels: [actionModel, actionModel, actionModel, actionModel],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "Another Button")
 
@@ -159,6 +165,7 @@ class ActionRegistryTests: XCTestCase {
         // Act
         actionRegistry.enqueue(
             actionModels: [actionModel, actionModel, actionModel2, actionModel, actionModel],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 

--- a/Tests/AppcuesKitTests/Actions/StepInteractionActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/StepInteractionActionTests.swift
@@ -37,6 +37,7 @@ class StepInteractionActionTests: XCTestCase {
                     type: "@appcues/track",
                     config: AppcuesTrackAction.Config(eventName: "Some event"))
             ],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -70,6 +71,7 @@ class StepInteractionActionTests: XCTestCase {
                     type: "@appcues/track",
                     config: AppcuesTrackAction.Config(eventName: "Some event"))
             ],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -103,6 +105,7 @@ class StepInteractionActionTests: XCTestCase {
                     type: "@appcues/link",
                     config: AppcuesLinkAction.Config(url: URL(string: "https://appcues.com")!, openExternally: nil))
             ],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -136,6 +139,7 @@ class StepInteractionActionTests: XCTestCase {
                     type: "@appcues/launch-experience",
                     config: AppcuesLaunchExperienceAction.Config(experienceID: "c1d5336f-6416-4805-9e82-4073c9b8cdb8"))
             ],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -165,6 +169,7 @@ class StepInteractionActionTests: XCTestCase {
                     type: "@appcues/close",
                     config: AppcuesCloseAction.Config(markComplete: true))
             ],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -194,6 +199,7 @@ class StepInteractionActionTests: XCTestCase {
                     type: "@appcues/continue",
                     config: AppcuesContinueAction.Config(index: nil, offset: nil, stepID: UUID(uuidString: "c1ba5af5-df15-4e38-834b-c7c33ee91e44")))
             ],
+            level: .step,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 

--- a/Tests/AppcuesKitTests/ExperiencePluginConfiguration+Testable.swift
+++ b/Tests/AppcuesKitTests/ExperiencePluginConfiguration+Testable.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AppcuesKit
 
 extension ExperiencePluginConfiguration {
-    convenience init(_ config: Any?) {
-        self.init(FakePluginDecoder(config))
+    convenience init(_ config: Any?, level: Level = .step) {
+        self.init(FakePluginDecoder(config), level: level)
     }
 }
 

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -132,9 +132,9 @@ class SampleTrait: ExperienceTrait, StepDecoratingTrait, ContainerCreatingTrait,
 
     weak var metadataDelegate: TraitMetadataDelegate?
 
-    required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+    required init?(configuration: ExperiencePluginConfiguration) {
         // Do not add `@unknown default` here, since we want to know about new cases
-        switch level {
+        switch configuration.level {
         case .experience:
             break
         case .group:

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -280,7 +280,7 @@ class TraitComposerTests: XCTestCase {
     }
 
     func testDefaultContainerCreatingTrait() throws {
-        let traitInstance = try XCTUnwrap(TraitComposer.DefaultContainerCreatingTrait(configuration: ExperiencePluginConfiguration(nil), level: .group))
+        let traitInstance = try XCTUnwrap(TraitComposer.DefaultContainerCreatingTrait(configuration: ExperiencePluginConfiguration(nil, level: .group)))
         let pageMonitor = PageMonitor(numberOfPages: 0, currentPage: 0)
         let container = try traitInstance.createContainer(for: [], with: pageMonitor)
         XCTAssertTrue(container is DefaultContainerViewController)
@@ -319,8 +319,8 @@ class TraitComposerTests: XCTestCase {
     func testDecompose() throws {
         // Arrange
         let traits: [ExperienceTrait] = [
-            try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil), level: .experience)),
-            try XCTUnwrap(TestPresentingTrait(configuration: ExperiencePluginConfiguration(nil), level: .experience))
+            try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil, level: .experience))),
+            try XCTUnwrap(TestPresentingTrait(configuration: ExperiencePluginConfiguration(nil, level: .experience)))
         ]
 
         // Act
@@ -339,10 +339,10 @@ class TraitComposerTests: XCTestCase {
     func testAppendDecomposedTraits() throws {
         // Arrange
         let experienceTraits: [ExperienceTrait] = [
-            try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil), level: .experience)),
-            try XCTUnwrap(TestPresentingTrait(configuration: ExperiencePluginConfiguration(nil), level: .experience))
+            try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil, level: .experience))),
+            try XCTUnwrap(TestPresentingTrait(configuration: ExperiencePluginConfiguration(nil, level: .experience)))
         ]
-        let groupTrait = try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil), level: .experience))
+        let groupTrait = try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil, level: .experience)))
         let decomposedTraits = TraitComposer.DecomposedTraits(traits: experienceTraits)
 
         // Act
@@ -361,11 +361,11 @@ class TraitComposerTests: XCTestCase {
     func testPropagateDecomposedTraits() throws {
         // Arrange
         let experienceTraits: [ExperienceTrait] = [
-            try XCTUnwrap(Test2Trait(configuration: ExperiencePluginConfiguration(nil), level: .experience)),
-            try XCTUnwrap(Test3Trait(configuration: ExperiencePluginConfiguration(nil), level: .group))
+            try XCTUnwrap(Test2Trait(configuration: ExperiencePluginConfiguration(nil, level: .experience))),
+            try XCTUnwrap(Test3Trait(configuration: ExperiencePluginConfiguration(nil, level: .group)))
         ]
         let decomposedTraits = TraitComposer.DecomposedTraits(traits: experienceTraits)
-        let stepTrait = try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil), level: .experience))
+        let stepTrait = try XCTUnwrap(TestTrait(configuration: ExperiencePluginConfiguration(nil, level: .experience)))
         let decomposedStepTraits = TraitComposer.DecomposedTraits(traits: [stepTrait])
 
         // Act
@@ -512,7 +512,7 @@ extension TraitComposerTests {
 
         var backdropDecoratingExpectation: XCTestExpectation?
 
-        required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+        required init?(configuration: ExperiencePluginConfiguration) {
             let config = configuration.decode(Config.self)
             self.groupID = config?.groupID
 
@@ -589,7 +589,7 @@ extension TraitComposerTests {
         var presentExpectation: XCTestExpectation?
         var removeExpectation: XCTestExpectation?
 
-        required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {
+        required init?(configuration: ExperiencePluginConfiguration) {
             let config = configuration.decode(Config.self)
             self.groupID = config?.groupID
 

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -66,6 +66,6 @@ private extension TraitRegistryTests {
 
         weak var metadataDelegate: AppcuesKit.TraitMetadataDelegate?
 
-        required init?(configuration: ExperiencePluginConfiguration, level: ExperienceTraitLevel) {}
+        required init?(configuration: ExperiencePluginConfiguration) {}
     }
 }


### PR DESCRIPTION
Way back in https://github.com/appcues/appcues-ios-sdk/pull/231 we added `ExperienceTraitLevel` which gets passed in the `ExperienceTrait.init`. This is fine as is, but it’s really not something that gets used much (it was designed only for one specific trait), so I was thinking we could move it into `ExperiencePluginConfig` as a property. This in theory has a few benefits, none of which are huge, but add up to a nice improvement:

1. `ExperienceAction` inits could now use this (not that we have a real good use case for it, but it would allow a trait to know if it’s being used at the group level)
2. The trait init is simpler and we have a pattern to include other new things in the plugin config object instead of the trait init which creates more flexibility for us to add things (including `internal`-only things) without breaking changes to the init interface.
3. `ExperienceTraitLevel` can be renamed to `ExperiencePluginConfig.Level` which removes it from the list of public things we’re exposing at the root level of the API, which isn’t that meaningful, but I like keeping that list simple where possible.

This is a breaking change 💥 so looking to do it now before we lock in 2.0