### PR TITLE
Update CI test config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ parameters:
 # -------------------------
 orbs:
   slack: circleci/slack@4.4.4
-  codecov: codecov/codecov@3.1.1
+  codecov: codecov/codecov@3.2.4
 
 # -------------------------
 #        EXECUTORS
@@ -84,7 +84,7 @@ jobs:
           name: Run fastlane tests
           command: bundle exec fastlane validate_code
       - store_test_results:
-          path: fastlane/test_output
+          path: fastlane/test_output/report.junit
       - codecov/upload:
           file: "fastlane/test_output/cobertura.xml"
       - slack/notify:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,6 +23,8 @@ platform :ios do
       scheme: "Appcues",
       proj: "Appcues.xcodeproj",
       cobertura_xml: true,
+      use_bundle_exec: true,
+      circleci: ENV["CIRCLECI"],
       ignore: [
         # Presentation layer is tested with snapshot and UI tests
         "Sources/AppcuesKit/Presentation/Debugger/*",


### PR DESCRIPTION
The `Uploading test results` (to CircleCI) step was always failing ([example](https://app.circleci.com/pipelines/github/appcues/appcues-ios-sdk/1768/workflows/bd66840e-877b-436a-ab61-0b92d98fc876/jobs/1620/parallel-runs/0/steps/0-110)) because it was trying to upload the cobertura file. Specifying the file that we do what fixes that.

Separately, the Codecov upload fails sometimes with various errors (but the Circle step always passes regardless) so I bumped the codecov orb version and updated a couple slather config items to see if that makes it more reliable. I don't have great sense of why it's flaky, and it's not worth a ton of time to investigate.