### PR TITLE
Add missing entries in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.1)
     minitest (5.18.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -217,6 +218,9 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nokogiri (1.14.3)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
     optparse (0.1.1)
@@ -282,6 +286,7 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22


### PR DESCRIPTION
I think I goofed on this in #389 just merged, when the platform `x86_64-darwin-22` was added. Running `bundle install` actually generates a few other updates in the file and I think we need to keep this updated for build cache to work correctly.