### PR TITLE
Add target interaction trait to control interactions with target rectangle

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -67,7 +67,7 @@ internal class ActionRegistry {
     /// such as actions that execute as part of the navigation to a step.
     func enqueue(actionModels: [Experience.Action], level: AppcuesExperiencePluginConfiguration.Level, completion: @escaping () -> Void) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level))
+            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level, appcues: appcues))
         }
         execute(transformQueue(actionInstances), completion: completion)
     }
@@ -86,10 +86,10 @@ internal class ActionRegistry {
         viewDescription: String?
     ) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level))
+            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level, appcues: appcues))
         }
 
-        // As a heuristic, take the last action that's `MetadataSettingAction`, since that's most likely
+        // As a heuristic, take the last action that's `InteractionLoggingAction`, since that's most likely
         // to be the action that we'd want to see in the event export.
         let primaryAction = actionInstances.reversed().compactMapFirst { $0 as? InteractionLoggingAction }
         let interactionAction = AppcuesStepInteractionAction(

--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
@@ -28,9 +28,13 @@ public class AppcuesExperiencePluginConfiguration: NSObject {
     /// The context where the plugin was defined.
     public let level: Level
 
-    init(_ decoder: PluginDecoder, level: Level) {
+    /// The instance of the Appcues SDK where the plugin is being applied.
+    public weak var appcues: Appcues?
+
+    init(_ decoder: PluginDecoder, level: Level, appcues: Appcues?) {
         self.decoder = decoder
         self.level = level
+        self.appcues = appcues
     }
 
     /// Returns a value of the type you specify, decoded from a JSON object.

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetBehaviorTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetBehaviorTrait.swift
@@ -1,0 +1,108 @@
+//
+//  AppcuesTargetBehaviorTrait.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 4/25/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+internal class AppcuesTargetBehaviorTrait: AppcuesBackdropDecoratingTrait {
+    struct Config: Decodable {
+        let actions: [Experience.Action]?
+    }
+
+    enum ActionType: String {
+        case tap
+        case longPress
+    }
+
+    static let type: String = "@appcues/target-behavior"
+
+    weak var metadataDelegate: AppcuesTraitMetadataDelegate?
+
+    private let tapActions: [Experience.Action]
+    private let longPressActions: [Experience.Action]
+
+    private weak var appcues: Appcues?
+
+    private lazy var targetView: UIView = {
+        let view = UIView()
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapTarget)))
+        view.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTarget)))
+        return view
+    }()
+
+    required init?(configuration: AppcuesExperiencePluginConfiguration) {
+        self.appcues = configuration.appcues
+
+        let config = configuration.decode(Config.self)
+        let actions = config?.actions ?? []
+
+        tapActions = actions.filter { ActionType(rawValue: $0.trigger) == .tap }
+        longPressActions = actions.filter { ActionType(rawValue: $0.trigger) == .longPress }
+    }
+
+    func decorate(backdropView: UIView) throws {
+        guard let metadataDelegate = metadataDelegate else {
+            // nothing to do without a targetRectangle from the metadata dictionary
+            targetView.removeFromSuperview()
+            return
+        }
+
+        metadataDelegate.registerHandler(for: Self.type, animating: false) { [weak self] in
+            self?.handle(backdropView: backdropView, metadata: $0)
+        }
+    }
+
+    func undecorate(backdropView: UIView) throws {
+        targetView.removeFromSuperview()
+
+        metadataDelegate?.removeHandler(for: Self.type)
+    }
+
+    private func handle(backdropView: UIView, metadata: AppcuesTraitMetadata) {
+        guard let newTarget: CGRect = metadata["targetRectangle"] else {
+            targetView.frame = .zero
+            targetView.removeFromSuperview()
+            return
+        }
+
+        if targetView.superview != backdropView {
+            targetView.removeFromSuperview()
+            backdropView.addSubview(targetView)
+        }
+
+        targetView.frame = newTarget
+    }
+
+    @objc
+    private func didTapTarget() {
+        guard !tapActions.isEmpty, let actionRegistry = appcues?.container.resolve(ActionRegistry.self) else {
+            return
+        }
+
+        actionRegistry.enqueue(
+            actionModels: tapActions,
+            level: .step,
+            interactionType: "Target Tapped",   // ??
+            viewDescription: "Target Rectangle" // ??
+        )
+    }
+
+    @objc
+    private func didLongPressTarget() {
+        guard !longPressActions.isEmpty, let actionRegistry = appcues?.container.resolve(ActionRegistry.self) else {
+            return
+        }
+
+        actionRegistry.enqueue(
+            actionModels: longPressActions,
+            level: .step,
+            interactionType: "Target Long Pressed", // ??
+            viewDescription: "Target Rectangle"     // ??
+        )
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -1,5 +1,5 @@
 //
-//  AppcuesTargetBehaviorTrait.swift
+//  AppcuesTargetInteractionTrait.swift
 //  AppcuesKit
 //
 //  Created by James Ellis on 4/25/23.
@@ -9,7 +9,7 @@
 import UIKit
 
 @available(iOS 13.0, *)
-internal class AppcuesTargetBehaviorTrait: AppcuesBackdropDecoratingTrait {
+internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
     struct Config: Decodable {
         let actions: [Experience.Action]?
     }
@@ -19,7 +19,7 @@ internal class AppcuesTargetBehaviorTrait: AppcuesBackdropDecoratingTrait {
         case longPress
     }
 
-    static let type: String = "@appcues/target-behavior"
+    static let type: String = "@appcues/target-interaction"
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
@@ -87,8 +87,8 @@ internal class AppcuesTargetBehaviorTrait: AppcuesBackdropDecoratingTrait {
         actionRegistry.enqueue(
             actionModels: tapActions,
             level: .step,
-            interactionType: "Target Tapped",   // ??
-            viewDescription: "Target Rectangle" // ??
+            interactionType: "Target Tapped",
+            viewDescription: "Target Rectangle"
         )
     }
 
@@ -101,8 +101,8 @@ internal class AppcuesTargetBehaviorTrait: AppcuesBackdropDecoratingTrait {
         actionRegistry.enqueue(
             actionModels: longPressActions,
             level: .step,
-            interactionType: "Target Long Pressed", // ??
-            viewDescription: "Target Rectangle"     // ??
+            interactionType: "Target Long Pressed",
+            viewDescription: "Target Rectangle"
         )
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -28,7 +28,7 @@ internal class TraitRegistry {
         register(trait: AppcuesTargetRectangleTrait.self)
         register(trait: AppcuesTargetElementTrait.self)
         register(trait: AppcuesBackdropKeyholeTrait.self)
-        register(trait: AppcuesTargetBehaviorTrait.self)
+        register(trait: AppcuesTargetInteractionTrait.self)
     }
 
     func register(trait: AppcuesExperienceTrait.Type) {

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -11,8 +11,11 @@ import UIKit
 @available(iOS 13.0, *)
 internal class TraitRegistry {
     private var traits: [String: AppcuesExperienceTrait.Type] = [:]
+    private weak var appcues: Appcues?
 
     init(container: DIContainer) {
+        self.appcues = container.owner
+
         // Register default traits
         register(trait: AppcuesStepTransitionAnimationTrait.self)
         register(trait: AppcuesModalTrait.self)
@@ -25,6 +28,7 @@ internal class TraitRegistry {
         register(trait: AppcuesTargetRectangleTrait.self)
         register(trait: AppcuesTargetElementTrait.self)
         register(trait: AppcuesBackdropKeyholeTrait.self)
+        register(trait: AppcuesTargetBehaviorTrait.self)
     }
 
     func register(trait: AppcuesExperienceTrait.Type) {
@@ -42,7 +46,9 @@ internal class TraitRegistry {
 
     func instances(for models: [Experience.Trait], level: AppcuesExperiencePluginConfiguration.Level) -> [AppcuesExperienceTrait] {
         models.compactMap { traitModel in
-            traits[traitModel.type]?.init(configuration: AppcuesExperiencePluginConfiguration(traitModel.configDecoder, level: level))
+            traits[traitModel.type]?.init(
+                configuration: AppcuesExperiencePluginConfiguration(traitModel.configDecoder, level: level, appcues: appcues)
+            )
         }
     }
 }

--- a/Tests/AppcuesKitTests/ExperiencePluginConfiguration+Testable.swift
+++ b/Tests/AppcuesKitTests/ExperiencePluginConfiguration+Testable.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AppcuesKit
 
 extension AppcuesExperiencePluginConfiguration {
-    convenience init(_ config: Any?, level: Level = .step) {
-        self.init(FakePluginDecoder(config), level: level)
+    convenience init(_ config: Any?, level: Level = .step, appcues: Appcues? = nil) {
+        self.init(FakePluginDecoder(config), level: level, appcues: appcues)
     }
 }
 


### PR DESCRIPTION
This adds an implementation of `@appcues/target-interaction` (naming tbd, [spec PR](https://github.com/appcues/appcues-mobile-experience-spec/pull/175)). This trait can be used to create a transparent UIView that lays over the target rectangle, from metadata, and captures taps and long presses. The trait can supply actions to take on those interactions, using standard experience action format. If no actions are provided, the trait simply captures those interactions and prevents them from flowing through to the backdrop - meaning it would not dismiss the flow, for example, if the skippable trait was otherwise dismissing on other backdrop taps.

One notable update is that `AppcuesExperiencePluginConfiguration` now includes the `Appcues` instance. This was made available here so that traits can have access to use this instance if needed. This new trait will use the instance to get the `ActionRegistry` and execute actions, when necessary.