### PR TITLE
Use identity verification instead of sender validation for feature name in docs

### DIFF
--- a/Sources/AppcuesKit/AppcuesKit.docc/Identifying.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/Identifying.md
@@ -10,8 +10,8 @@ In order to target content to the right users at the right time, you need to ide
 
 The inverse of identifying is resetting. For example, if a user logs out of your app. Calling ``Appcues/reset()`` will disable tracking of screens and events until a user is identified again.
 
-### Sender Validation
-If your Appcues account is configured for sender validation, pass the user signature in the properties included on the ``Appcues/identify(userID:properties:)`` call. Use the key "appcues:user_id_signature" and the string value of the signature.
+### Identity Verification
+If your Appcues account is configured for identity verification, pass the user signature in the properties included on the ``Appcues/identify(userID:properties:)`` call. Use the key "appcues:user_id_signature" and the string value of the signature.
 
 ```swift
 appcues.identify(userID: userID, properties: ["appcues:user_id_signature": signature])


### PR DESCRIPTION
Requested naming update to align with the feature name throughout Appcues documentation.