### PR TITLE
Add pipeline orchestration to run snapshot tests in spec repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,24 +187,26 @@ jobs:
         - persist_to_workspace:
             root: .
             paths: 
-              - pipeline.txt  
+              - pipeline.txt
   check-status-of-spec-test-pipeline:
     docker: 
       - image: cimg/base:current
     resource_class: small 
     steps:
+      # checkout so the source files are here for the codecov upload
+      - checkout
       - attach_workspace:
           at: workspace
       - run:
           name: Check triggered workflow status
           command: |
             triggered_pipeline_id=$(cat workspace/pipeline.txt)
-            created_workflow_status=$(curl --request GET \
+            curl --request GET \
                 --url "https://circleci.com/api/v2/pipeline/${triggered_pipeline_id}/workflow" \
                 --header "Circle-Token: $CIRCLE_API_TOKEN" \
                 --header "content-type: application/json" \
-              | jq -r '.items[0].status'
-            )
+                --output pipeline.json
+            created_workflow_status=$(jq -r '.items[0].status' pipeline.json)
             echo $created_workflow_status
             if [[ "$created_workflow_status" != "success" ]]; then
               echo "Workflow not successful - ${created_workflow_status}"
@@ -212,7 +214,25 @@ jobs:
             fi
             
             echo "Created workflow successful"
-      # TODO: get codecov report and upload
+      - run:
+          name: Get codecov report
+          command: |
+            triggered_workflow_id=$(jq -r '.items[0].id' pipeline.json)
+            created_job_number=$(curl --request GET \
+                --url "https://circleci.com/api/v2/workflow/${triggered_workflow_id}/job" \
+                --header "Circle-Token: $CIRCLE_API_TOKEN" \
+                --header "content-type: application/json" \
+              | jq -r '.items[0].job_number'
+            )
+            cobertura_artifact_url=$(curl --request GET \
+                --url "https://circleci.com/api/v2/project/github/appcues/appcues-mobile-experience-spec/${created_job_number}/artifacts" \
+                --header "Circle-Token: $CIRCLE_API_TOKEN" \
+                --header "content-type: application/json" \
+              | jq -r '.items[] | select( .path == "fastlane/test_output/cobertura.xml" ).url'
+            )
+            curl -L "$cobertura_artifact_url?circle-token=$CIRCLE_API_TOKEN" --output cobertura.xml
+      - codecov/upload:
+          file: "cobertura.xml"
 
 # -------------------------
 #        WORKFLOWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,53 @@ jobs:
               ]
             }
           channel: team-mobile-bots
+  trigger-spec-test-pipeline:
+      docker: 
+        - image: cimg/base:current
+      resource_class: small
+      steps:
+        - run:
+            name: Trigger spec pipeline
+            # branch value below should be `main` once `appcues-mobile-experience-spec/feature/ci-orchestration` is merged to `main`
+            command: |
+              CREATED_PIPELINE_ID=$(curl --request POST \
+                --url https://circleci.com/api/v2/project/github/appcues/appcues-mobile-experience-spec/pipeline \
+                --header "Circle-Token: $CIRCLE_API_TOKEN" \
+                --header "content-type: application/json" \
+                --data "{ \"branch\": \"feature/ci-orchestration\", \"parameters\": { \"platform\": \"ios\", \"sdk-branch\": \"$CIRCLE_BRANCH\", \"triggering-pipeline-id\": \"<< pipeline.id >>\" }}" \
+              | jq -r '.id'
+              )
+              echo "Triggered spec pipeline $CREATED_PIPELINE_ID"
+              echo $CREATED_PIPELINE_ID > pipeline.txt
+        - persist_to_workspace:
+            root: .
+            paths: 
+              - pipeline.txt  
+  check-status-of-spec-test-pipeline:
+    docker: 
+      - image: cimg/base:current
+    resource_class: small 
+    steps:
+      - attach_workspace:
+          at: workspace
+      - run:
+          name: Check triggered workflow status
+          command: |
+            triggered_pipeline_id=$(cat workspace/pipeline.txt)
+            created_workflow_status=$(curl --request GET \
+                --url "https://circleci.com/api/v2/pipeline/${triggered_pipeline_id}/workflow" \
+                --header "Circle-Token: $CIRCLE_API_TOKEN" \
+                --header "content-type: application/json" \
+              | jq -r '.items[0].status'
+            )
+            echo $created_workflow_status
+            if [[ "$created_workflow_status" != "success" ]]; then
+              echo "Workflow not successful - ${created_workflow_status}"
+              (exit -1) 
+            fi
+            
+            echo "Created workflow successful"
+      # TODO: get codecov report and upload
 
 # -------------------------
 #        WORKFLOWS
@@ -178,7 +225,20 @@ workflows:
         - not: *is_main
         - not: << pipeline.parameters.deploy-beta >>
     jobs:
-      - validate_code:
+      # Temporarily commented out to save resources while we test the rest
+      # - validate_code:
+      #     context:
+      #       - Appcues
+      - trigger-spec-test-pipeline:
+          context:
+            - Appcues
+      - wait-for-spec-test-pipeline:
+          type: approval
+          requires: 
+            - trigger-spec-test-pipeline
+      - check-status-of-spec-test-pipeline:
+          requires:
+            - wait-for-spec-test-pipeline
           context:
             - Appcues
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,22 +77,6 @@ commands:
 #          JOBS
 # -------------------------
 jobs:
-  validate_code:
-    executor: xcode_14
-    steps:
-      - install_with_cache
-      - run:
-          name: Run fastlane tests
-          command: bundle exec fastlane validate_code
-      - store_test_results:
-          path: fastlane/test_output/report.junit
-      - codecov/upload:
-          file: "fastlane/test_output/cobertura.xml"
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-          channel: team-mobile-bots
-
   deploy_example:
     executor: xcode_14
     steps:
@@ -249,22 +233,20 @@ jobs:
             curl -L "$cobertura_artifact_url?circle-token=$CIRCLE_API_TOKEN" --output cobertura.xml
       - codecov/upload:
           file: "cobertura.xml"
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          channel: team-mobile-bots
 
 # -------------------------
 #        WORKFLOWS
 # -------------------------
 workflows:
   version: 2
-  pr_validation:
+  branch_validation:
     when:
-      and:
-        - not: *is_main
-        - not: << pipeline.parameters.deploy-beta >>
+        not: << pipeline.parameters.deploy-beta >>
     jobs:
-      # Temporarily commented out to save resources while we test the rest
-      # - validate_code:
-      #     context:
-      #       - Appcues
       - trigger-spec-test-pipeline:
           context:
             - Appcues
@@ -282,15 +264,5 @@ workflows:
     when: << pipeline.parameters.deploy-beta >>
     jobs:
       - deploy_example:
-          context:
-            - Appcues
-
-  main_verification:
-    when:
-      and:
-        - *is_main
-        - not: << pipeline.parameters.deploy-beta >>
-    jobs:
-      - validate_code:
           context:
             - Appcues

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,16 +173,32 @@ jobs:
       steps:
         - run:
             name: Trigger spec pipeline
-            # branch value below should be `main` once `appcues-mobile-experience-spec/feature/ci-orchestration` is merged to `main`
+            # If there's a spec repo branch with the same name as the one currently executing,
+            # trigger against that as a means to allow coordinated test updates.
+            # If we get `{ "message" : "Branch not found" }`, fall back to running on `main`.
             command: |
-              CREATED_PIPELINE_ID=$(curl --request POST \
-                --url https://circleci.com/api/v2/project/github/appcues/appcues-mobile-experience-spec/pipeline \
-                --header "Circle-Token: $CIRCLE_API_TOKEN" \
-                --header "content-type: application/json" \
-                --data "{ \"branch\": \"feature/ci-orchestration\", \"parameters\": { \"platform\": \"ios\", \"sdk-branch\": \"$CIRCLE_BRANCH\", \"triggering-pipeline-id\": \"<< pipeline.id >>\" }}" \
-              | jq -r '.id'
-              )
-              echo "Triggered spec pipeline $CREATED_PIPELINE_ID"
+              REMOTE_BRANCH=$CIRCLE_BRANCH
+
+              create_remote_pipeline () {
+                echo "Try remote job for $REMOTE_BRANCH"
+                CREATED_PIPELINE_ID=$(curl --request POST \
+                  --url https://circleci.com/api/v2/project/github/appcues/appcues-mobile-experience-spec/pipeline \
+                  --header "Circle-Token: $CIRCLE_API_TOKEN" \
+                  --header "content-type: application/json" \
+                  --data "{ \"branch\": \"$REMOTE_BRANCH\", \"parameters\": { \"platform\": \"ios\", \"sdk-branch\": \"$CIRCLE_BRANCH\", \"triggering-pipeline-id\": \"<< pipeline.id >>\" }}" \
+                | jq -r '.id'
+                )
+              }
+
+              create_remote_pipeline
+              
+              if [ "$CREATED_PIPELINE_ID" = 'null' ]
+              then
+                REMOTE_BRANCH='main'
+                create_remote_pipeline
+              fi
+
+              echo "Triggered spec pipeline $CREATED_PIPELINE_ID on branch $REMOTE_BRANCH"
               echo $CREATED_PIPELINE_ID > pipeline.txt
         - persist_to_workspace:
             root: .


### PR DESCRIPTION
This is the other half of https://github.com/appcues/appcues-mobile-experience-spec/pull/185 based on https://circleci.com/blog/pipeline-orchestration-circleback/

There's 3 new jobs here:

1. `trigger-spec-test-pipeline` where we want to run the unit tests alongside the snapshot tests, so we trigger the `appcues-mobile-experience-spec` pipeline (trying first for a branch name matching the one triggering and then falling back to `main`) with the name of the branch we want to test against.
2. `wait-for-spec-test-pipeline` an approval job that suspends this pipeline until an approval action is triggered (in this case by the `appcues-mobile-experience-spec` pipeline.
3. `check-status-of-spec-test-pipeline` where we use the saved ID of the triggered job to get its status, and if successful get the code coverage report to upload to CodeCov.

I've removed the existing `validate_code` job since the unit tests are run on the remote job, and then since `pr_validation` and `main_verification` were doing the same thing, I replaced them with a new name `branch_validation`.
