### PR TITLE
Fix format of survey form response field ID

### DIFF
--- a/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// Allows overriding of UUID creation for determenistic testing.
+// Allows overriding of UUID creation for deterministic testing.
 extension UUID {
     static var generator: () -> UUID = UUID.init
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -292,7 +292,7 @@ extension ExperienceData.StepState: Encodable {
 
         try formItems.forEach { id, formItem in
             var itemContainer = container.nestedContainer(keyedBy: ItemKeys.self)
-            try itemContainer.encode(id, forKey: .fieldId)
+            try itemContainer.encode(id.appcuesFormatted, forKey: .fieldId)
             try itemContainer.encode(formItem.type, forKey: .fieldType)
             try itemContainer.encode(formItem.required, forKey: .fieldRequired)
             try itemContainer.encode(formItem.getValue(), forKey: .value)

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
@@ -130,7 +130,7 @@ class AnalyticsBroadcasterTests: XCTestCase {
             "interactionData": [
                 "formResponse": [
                     [
-                        "fieldId": "85259845-9661-463D-A90A-F500AD7F7DCF",
+                        "fieldId": "85259845-9661-463d-a90a-f500ad7f7dcf",
                         "fieldType": "textInput",
                         "fieldRequired": true,
                         "value": "default value",


### PR DESCRIPTION
Found in https://appcues.slack.com/archives/C03JYPH1NJZ/p1684250936524709

I tried to survey the rest of the codebase to make sure we don't have this issue anywhere else, but it's a bit tricky to be sure. We've got it correct already in places like https://github.com/appcues/appcues-ios-sdk/blob/fab91923f6ad9624164c7d9abdd5bf6d65ac620c/Sources/AppcuesKit/Data/Models/Activity.swift#L58