### PR TITLE
Trait unit tests

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
@@ -77,8 +77,12 @@ internal class UIKitElementSelector: AppcuesElementSelector {
 // and identifies applicable views with a UIKitElementSelector.
 @available(iOS 13.0, *)
 internal class UIKitElementTargeting: AppcuesElementTargeting {
+    // Inject a window for testing purposes
+    var window: UIWindow?
+
     func captureLayout() -> AppcuesViewElement? {
-        return UIApplication.shared.windows.first { !$0.isAppcuesWindow }?.asViewElement()
+        let captureWindow = (window ?? UIApplication.shared.windows.first { !$0.isAppcuesWindow })
+        return captureWindow?.asViewElement()
     }
 
     func inflateSelector(from properties: [String: String]) -> AppcuesElementSelector? {

--- a/Tests/AppcuesKitTests/Traits/AppcuesStepTransitionAnimationTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesStepTransitionAnimationTraitTests.swift
@@ -1,0 +1,133 @@
+//
+//  AppcuesStepTransitionAnimationTraitTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-05-16.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class AppcuesStepTransitionAnimationTraitTests: XCTestCase {
+
+    var appcues: MockAppcues!
+
+    let metadataDelegate = AppcuesTraitMetadataDelegate()
+    var metadataUpdates: [AppcuesTraitMetadata] = []
+
+    var containerController: AppcuesExperienceContainerViewController!
+
+
+    override func setUpWithError() throws {
+        appcues = MockAppcues()
+        metadataUpdates = []
+        metadataDelegate.registerHandler(for: "test", animating: false) { metadata in self.metadataUpdates.append(metadata) }
+
+        containerController = DefaultContainerViewController(stepControllers: [], pageMonitor: AppcuesExperiencePageMonitor(numberOfPages: 0, currentPage: 0))
+    }
+
+    func testInit() throws {
+        // Act
+        let trait = AppcuesStepTransitionAnimationTrait(appcues: appcues)
+
+        // Assert
+        XCTAssertEqual(AppcuesStepTransitionAnimationTrait.type, "@appcues/step-transition-animation")
+        XCTAssertNotNil(trait)
+    }
+
+    func testValueMapping() throws {
+        // Assert
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.linear.curve,
+            UIView.AnimationOptions.curveLinear
+        )
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.easeIn.curve,
+            UIView.AnimationOptions.curveEaseIn
+        )
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.easeOut.curve,
+            UIView.AnimationOptions.curveEaseOut
+        )
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.easeInOut.curve,
+            UIView.AnimationOptions.curveEaseInOut
+        )
+
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.linear.timingFunction,
+            CAMediaTimingFunctionName.linear
+        )
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.easeIn.timingFunction,
+            CAMediaTimingFunctionName.easeIn
+        )
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.easeOut.timingFunction,
+            CAMediaTimingFunctionName.easeOut
+        )
+        XCTAssertEqual(
+            AppcuesStepTransitionAnimationTrait.Easing.easeInOut.timingFunction,
+            CAMediaTimingFunctionName.easeInEaseOut
+        )
+
+        XCTAssertNil(AppcuesStepTransitionAnimationTrait.Easing(metadataValue: nil))
+        XCTAssertEqual(AppcuesStepTransitionAnimationTrait.Easing(metadataValue: "linear"), .linear)
+        XCTAssertEqual(AppcuesStepTransitionAnimationTrait.Easing(metadataValue: "easeIn"), .easeIn)
+        XCTAssertEqual(AppcuesStepTransitionAnimationTrait.Easing(metadataValue: "easeOut"), .easeOut)
+        XCTAssertEqual(AppcuesStepTransitionAnimationTrait.Easing(metadataValue: "easeInOut"), .easeInOut)
+    }
+
+    func testDecorate() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesStepTransitionAnimationTrait(appcues: appcues))
+        trait.metadataDelegate = metadataDelegate
+
+        // Act
+        try trait.decorate(containerController: containerController)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 1)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        XCTAssertEqual(latestMetadata["animationDuration"], 0.3)
+        XCTAssertEqual(latestMetadata["animationEasing"], "linear")
+    }
+
+    func testUndecorate() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesStepTransitionAnimationTrait(appcues: appcues))
+        trait.metadataDelegate = metadataDelegate
+
+        try trait.decorate(containerController: containerController)
+        metadataDelegate.publish()
+
+        // Act
+        try trait.undecorate(containerController: containerController)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 2)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        let animationDuration: TimeInterval? = latestMetadata["animationDuration"]
+        XCTAssertNil(animationDuration)
+        let easing: String? = latestMetadata["animationEasing"]
+        XCTAssertNil(easing)
+    }
+
+}
+
+@available(iOS 13.0, *)
+extension AppcuesStepTransitionAnimationTrait {
+    convenience init?(appcues: Appcues?) {
+        self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))
+    }
+
+    convenience init?(appcues: Appcues?, duration: Int, easing: Easing) {
+        self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesStepTransitionAnimationTrait.Config(duration: duration, easing: easing), appcues: appcues))
+    }
+}

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
@@ -1,0 +1,240 @@
+//
+//  AppcuesTargetElementTraitTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-05-16.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class AppcuesTargetElementTraitTests: XCTestCase {
+
+    var appcues: MockAppcues!
+
+    let metadataDelegate = AppcuesTraitMetadataDelegate()
+    var metadataUpdates: [AppcuesTraitMetadata] = []
+
+    var window: UIWindow!
+    var rootViewController: UIViewController!
+    var backdropView: UIView!
+
+    override func setUpWithError() throws {
+        appcues = MockAppcues()
+        metadataUpdates = []
+        metadataDelegate.registerHandler(for: "test", animating: false) { metadata in self.metadataUpdates.append(metadata) }
+
+        backdropView = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 1000))
+
+        rootViewController = UIViewController()
+        _ = rootViewController.view
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 500, height: 1000))
+        window.rootViewController = rootViewController
+        window.makeKeyAndVisible()
+        window.addSubview(backdropView)
+    }
+
+    override func tearDownWithError() throws {
+        try XCTUnwrap(Appcues.elementTargeting as? UIKitElementTargeting).window = nil
+    }
+
+    func testInit() throws {
+        // Act
+        let nilConfigTrait = AppcuesTargetElementTrait(configuration: AppcuesExperiencePluginConfiguration(nil))
+        let trait = AppcuesTargetElementTrait(appcues: appcues, selector: [:])
+
+        // Assert
+        XCTAssertEqual(AppcuesTargetElementTrait.type, "@appcues/target-element-beta")
+        XCTAssertNil(nilConfigTrait)
+        XCTAssertNotNil(trait)
+    }
+
+    func testDecorateThrowsInvalidSelector() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: [:]))
+
+        // Act/Assert
+        XCTAssertThrowsError(try trait.decorate(backdropView: backdropView)) {
+            XCTAssertEqual(($0 as? AppcuesTraitError)?.description, "Invalid selector [:]")
+        }
+    }
+
+    func testDecorateThrowsNoLayout() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: ["accessibilityIdentifier":"myID"]))
+
+        // Act/Assert
+        XCTAssertThrowsError(try trait.decorate(backdropView: backdropView)) {
+            XCTAssertEqual(($0 as? AppcuesTraitError)?.description, "Could not read application layout information")
+        }
+    }
+
+    func testDecorateThrowsNoMatch() throws {
+        // Arrange
+        try XCTUnwrap(Appcues.elementTargeting as? UIKitElementTargeting).window = window
+
+        // A hidden view should be ignored
+        let view1 = UIView(frame: CGRect(x: 20, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID")
+        view1.isHidden = true
+        rootViewController.view.addSubview(view1)
+
+        // A view outside the window from should be ignored
+        let view2 = UIView(frame: CGRect(x: 1040, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID")
+        rootViewController.view.addSubview(view2)
+
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: ["accessibilityIdentifier":"myID"]))
+
+        // Act/Assert
+        XCTAssertThrowsError(try trait.decorate(backdropView: backdropView)) {
+            XCTAssertEqual(($0 as? AppcuesTraitError)?.description, #"No view matching selector ["accessibilityIdentifier": "myID"]"#)
+        }
+    }
+
+    func testDecorateThrowsMultipleMatch() throws {
+        // Arrange
+        try XCTUnwrap(Appcues.elementTargeting as? UIKitElementTargeting).window = window
+
+        let view1 = UIView(frame: CGRect(x: 20, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID")
+        rootViewController.view.addSubview(view1)
+        let view2 = UIView(frame: CGRect(x: 140, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID")
+        rootViewController.view.addSubview(view2)
+
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: ["accessibilityIdentifier":"myID"]))
+
+        // Act/Assert
+        XCTAssertThrowsError(try trait.decorate(backdropView: backdropView)) {
+            XCTAssertEqual(($0 as? AppcuesTraitError)?.description, #"multiple non-distinct views (2) matched selector ["accessibilityIdentifier": "myID"]"#)
+        }
+    }
+
+    func testDecorate() throws {
+        // Arrange
+        try XCTUnwrap(Appcues.elementTargeting as? UIKitElementTargeting).window = window
+
+        let view1 = UIView(frame: CGRect(x: 20, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID")
+        rootViewController.view.addSubview(view1)
+
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: ["accessibilityIdentifier":"myID"]))
+        trait.metadataDelegate = metadataDelegate
+
+        // Act
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 1)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        XCTAssertEqual(latestMetadata["targetRectangle"], CGRect(x: 20, y: 20, width: 100, height: 100))
+    }
+
+    func testDecorateMultipleMatches() throws {
+        // Arrange
+        try XCTUnwrap(Appcues.elementTargeting as? UIKitElementTargeting).window = window
+
+        let view1 = UIView(frame: CGRect(x: 20, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID", accessibilityLabel: "My View")
+        rootViewController.view.addSubview(view1)
+        let view2 = UIView(frame: CGRect(x: 140, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID", tag: 54)
+        rootViewController.view.addSubview(view2)
+
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: ["accessibilityIdentifier":"myID", "accessibilityLabel": "My View", "tag": "54"]))
+        trait.metadataDelegate = metadataDelegate
+
+        // Act
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 1)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        XCTAssertEqual(latestMetadata["targetRectangle"], CGRect(x: 140, y: 20, width: 100, height: 100))
+    }
+
+    func testFrameRecalculation() throws {
+        // Arrange
+        try XCTUnwrap(Appcues.elementTargeting as? UIKitElementTargeting).window = window
+
+        let view1 = UIView(frame: CGRect(x: 20, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID")
+        rootViewController.view.addSubview(view1)
+
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: ["accessibilityIdentifier":"myID"]))
+        trait.metadataDelegate = metadataDelegate
+
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Act
+        view1.frame = CGRect(x: 500, y: 20, width: 100, height: 100)
+        window.frame = CGRect(x: 0, y: 0, width: 1000, height: 500)
+        backdropView.frame = CGRect(x: 0, y: 0, width: 1000, height: 500)
+        backdropView.setNeedsLayout()
+        backdropView.layoutIfNeeded()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 2)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        XCTAssertEqual(latestMetadata["targetRectangle"], CGRect(x: 500, y: 20, width: 100, height: 100))
+    }
+
+    func testUndecorate() throws {
+        // Arrange
+        try XCTUnwrap(Appcues.elementTargeting as? UIKitElementTargeting).window = window
+
+        let view1 = UIView(frame: CGRect(x: 20, y: 20, width: 100, height: 100), accessibilityIdentifier: "myID")
+        rootViewController.view.addSubview(view1)
+
+        let trait = try XCTUnwrap(AppcuesTargetElementTrait(appcues: appcues, selector: ["accessibilityIdentifier":"myID"]))
+        trait.metadataDelegate = metadataDelegate
+
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+
+        // Act
+        try trait.undecorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 2)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        let targetRectangle: CGRect? = latestMetadata["targetRectangle"]
+        XCTAssertNil(targetRectangle)
+        let contentPreferredPosition: ContentPosition? = latestMetadata["contentPreferredPosition"]
+        XCTAssertNil(contentPreferredPosition)
+        let contentDistanceFromTarget: CGFloat? = latestMetadata["contentDistanceFromTarget"]
+        XCTAssertNil(contentDistanceFromTarget)
+    }
+
+}
+
+extension UIView {
+    convenience init(frame: CGRect, accessibilityIdentifier: String? = nil, accessibilityLabel: String? = nil, tag: Int? = nil) {
+        self.init(frame: frame)
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityLabel = accessibilityLabel
+        if let tag = tag {
+            self.tag = tag
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesTargetElementTrait {
+    convenience init?(
+        appcues: Appcues?,
+        selector: [String: String],
+        contentPreferredPosition: ContentPosition? = nil,
+        contentDistanceFromTarget: Double? = nil
+    ) {
+        self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesTargetElementTrait.Config(
+            contentPreferredPosition: contentPreferredPosition,
+            contentDistanceFromTarget: contentDistanceFromTarget,
+            selector: selector
+        ), appcues: appcues))
+    }
+}

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetRectangleTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetRectangleTraitTests.swift
@@ -1,0 +1,149 @@
+//
+//  AppcuesTargetRectangleTraitTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-05-16.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class AppcuesTargetRectangleTraitTests: XCTestCase {
+
+    var appcues: MockAppcues!
+
+    let metadataDelegate = AppcuesTraitMetadataDelegate()
+    var metadataUpdates: [AppcuesTraitMetadata] = []
+
+    var backdropView: UIView!
+
+    override func setUpWithError() throws {
+        appcues = MockAppcues()
+        metadataUpdates = []
+        metadataDelegate.registerHandler(for: "test", animating: false) { metadata in self.metadataUpdates.append(metadata) }
+
+        backdropView = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 1000))
+        let window = UIWindow(frame: .zero)
+        window.addSubview(backdropView)
+    }
+
+    func testInit() throws {
+        // Act
+        let nilConfigTrait = AppcuesTargetRectangleTrait(configuration: AppcuesExperiencePluginConfiguration(nil))
+        let trait = AppcuesTargetRectangleTrait(appcues: appcues)
+
+        // Assert
+        XCTAssertEqual(AppcuesTargetRectangleTrait.type, "@appcues/target-rectangle")
+        XCTAssertNil(nilConfigTrait)
+        XCTAssertNotNil(trait)
+    }
+
+    func testDecorate() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesTargetRectangleTrait(appcues: appcues))
+        trait.metadataDelegate = metadataDelegate
+
+        // Act
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 1)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        XCTAssertEqual(latestMetadata["targetRectangle"], CGRect(x: 0, y: 0, width: 0, height: 0))
+    }
+
+    func testFrameCalculation() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesTargetRectangleTrait(appcues: appcues, x: -10, y: 20, width: 100, height: 60, relativeX: 0.5, relativeY: 0.5))
+        trait.metadataDelegate = metadataDelegate
+
+        // Act
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 1)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        XCTAssertEqual(latestMetadata["targetRectangle"], CGRect(x: 240, y: 520, width: 100, height: 60))
+    }
+
+    func testFrameRecalculation() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesTargetRectangleTrait(appcues: appcues, x: -10, y: 20, width: 100, height: 60, relativeX: 0.5, relativeY: 0.5))
+        trait.metadataDelegate = metadataDelegate
+
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Act
+        backdropView.frame = CGRect(x: 0, y: 0, width: 1000, height: 500)
+        backdropView.setNeedsLayout()
+        backdropView.layoutIfNeeded()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 2)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        XCTAssertEqual(latestMetadata["targetRectangle"], CGRect(x: 490, y: 270, width: 100, height: 60))
+    }
+
+    func testUndecorate() throws {
+        // Arrange
+        let trait = try XCTUnwrap(AppcuesTargetRectangleTrait(appcues: appcues))
+        trait.metadataDelegate = metadataDelegate
+
+        try trait.decorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Act
+        try trait.undecorate(backdropView: backdropView)
+        metadataDelegate.publish()
+
+        // Assert
+        XCTAssertEqual(metadataUpdates.count, 2)
+        let latestMetadata = try XCTUnwrap(metadataUpdates.last)
+
+        let targetRectangle: CGRect? = latestMetadata["targetRectangle"]
+        XCTAssertNil(targetRectangle)
+        let contentPreferredPosition: ContentPosition? = latestMetadata["contentPreferredPosition"]
+        XCTAssertNil(contentPreferredPosition)
+        let contentDistanceFromTarget: CGFloat? = latestMetadata["contentDistanceFromTarget"]
+        XCTAssertNil(contentDistanceFromTarget)
+    }
+
+}
+
+@available(iOS 13.0, *)
+extension AppcuesTargetRectangleTrait {
+    convenience init?(
+        appcues: Appcues?,
+        contentPreferredPosition: ContentPosition? = nil,
+        contentDistanceFromTarget: Double? = nil,
+        x: Double? = nil,
+        y: Double? = nil,
+        width: Double? = nil,
+        height: Double? = nil,
+        relativeX: Double? = nil,
+        relativeY: Double? = nil,
+        relativeWidth: Double? = nil,
+        relativeHeight: Double? = nil
+    ) {
+        self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesTargetRectangleTrait.Config(
+            contentPreferredPosition: contentPreferredPosition,
+            contentDistanceFromTarget: contentDistanceFromTarget,
+            x: x,
+            y: y,
+            width: width,
+            height: height,
+            relativeX: relativeX,
+            relativeY: relativeY,
+            relativeWidth: relativeWidth,
+            relativeHeight: relativeHeight
+        ), appcues: appcues))
+    }
+}


### PR DESCRIPTION
Adding some unit tests for traits that for functionality that can be easily tested without snapshot tests. `UIKitElementTargeting` is indirectly tested via the trait. It might not be a bad idea to add more tests for specific edge cases in `UIKitElementTargeting` later on, but this covers the basics.