### PR TITLE
Update inits for testability

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -277,17 +277,18 @@ extension Experience.Step: Decodable {
             type: String,
             traits: [Experience.Trait],
             actions: [String: [Experience.Action]],
-            content: ExperienceComponent,
-            stickyTopContent: ExperienceComponent? = nil,
-            stickyBottomContent: ExperienceComponent? = nil
+            content: ExperienceComponent
         ) {
             self.id = id
             self.type = type
             self.traits = traits
             self.actions = actions
-            self.content = content
-            self.stickyTopContent = stickyTopContent
-            self.stickyBottomContent = stickyBottomContent
+
+            let (bodyComponent, stickyTopComponent, stickyBottomComponent) = content.divided()
+
+            self.content = bodyComponent
+            self.stickyTopContent = stickyTopComponent
+            self.stickyBottomContent = stickyBottomComponent
         }
     }
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/EnvironmentValues+ImageCache.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EnvironmentValues+ImageCache.swift
@@ -10,7 +10,8 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 internal struct ImageCacheKey: EnvironmentKey {
-    static let defaultValue = SessionImageCache()
+    // This is mutable so a custom cache can be injected for testing.
+    static var defaultValue = SessionImageCache()
 }
 
 @available(iOS 13.0, *)


### PR DESCRIPTION
A couple little changes that:

1. Allow for trait snapshot tests of sticky content. The trait snapshot system uses the `Experience.init()` which wasn't handling sticky content (not a bug since that init never gets used that way outside of tests). Sticky content isn't specifically a trait (anymore), but it can be tested nicely that way with injecting the list of primitives.
2. Making `ImageCacheKey.defaultValue` mutable allows us to set the default value in tests to a subclass of `SessionImageCache` that dynamically maps requests to the asset catalog instead of the [current verbose way](https://github.com/appcues/appcues-mobile-experience-spec/blob/51f2958d061ee0caed827c144a7276630f721a0f/verification-suites/ios/SnapshotTests/XCTestCase%2BComponentSnapshot.swift#L160-L176) we prime the cache.