### PR TITLE
Fix deep link launching debugger when app is backgrounded

### DIFF
--- a/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
@@ -84,7 +84,7 @@ internal class DeepLinkHandler: DeepLinkHandling {
     }
 
     private func dispatch(action: Action) {
-        if topControllerGetting.topViewController() != nil {
+        if topControllerGetting.hasActiveWindowScenes {
             // UIScene is already active and we can handle the action immediately.
             handle(action: action)
         } else if actionsToHandle.isEmpty {

--- a/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 internal protocol TopControllerGetting {
+    var hasActiveWindowScenes: Bool { get }
+
     func topViewController() -> UIViewController?
 }
 internal protocol URLOpening {
@@ -23,6 +25,15 @@ extension UIApplication: TopControllerGetting {
         self.connectedScenes
             .filter { $0.activationState == .foregroundActive }
             .compactMap { $0 as? UIWindowScene }
+    }
+
+    // We expose this property because a unit test cannot init a UIWindowScene for mocking different states.
+    var hasActiveWindowScenes: Bool {
+        if #available(iOS 13.0, *) {
+            return !activeWindowScenes.isEmpty
+        } else {
+            return false
+        }
     }
 
     // Note: multitasking with two instances of the same app side by side will have both designated as `.foregroundActive`,

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -237,6 +237,8 @@ private class MockNavigationDelegate: AppcuesNavigationDelegate {
 @available(iOS 13.0, *)
 extension AppcuesLinkActionTests {
     class MockURLOpener: TopControllerGetting, URLOpening {
+        var hasActiveWindowScenes: Bool = true
+
         var onOpen: ((URL) -> Void)?
         var onUniversalOpen: ((URL) -> Bool)?
         var onPresent: ((UIViewController) -> Void)?

--- a/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
+++ b/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
@@ -178,6 +178,8 @@ class DeepLinkHandlerTests: XCTestCase {
 @available(iOS 13.0, *)
 extension DeepLinkHandlerTests {
     class MockTopControllerGetting: TopControllerGetting {
+        var hasActiveWindowScenes: Bool = true
+
         func topViewController() -> UIViewController? {
             UIViewController()
         }


### PR DESCRIPTION
I'm in the process of creating UI tests for launching the debugger (and screen capture) using deep links and realized it's not working properly for one of the scenarios. If the client app isn't in the foreground, there's a mismatch checking the state and so the debugger launching fails.

There's also the case where the app is foregrounded which isn't really possible on a device launching from a QR code in the camera app, but is often the case when launching the deep link on a simulator, which I think is why we haven't noticed it not working. Additionally, the experience preview deep link always works because the way it presents the experience is different than the logic used in the debugger.

UI tests to follow in the spec repo.