### PR TITLE
Add View modifier to support SwiftUI element targeting

### DIFF
--- a/Sources/AppcuesKit/Data/Extensions/UIViewController+Tracking.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UIViewController+Tracking.swift
@@ -34,6 +34,9 @@ extension UIViewController {
         if name != "ViewController" {
             name = name.replacingOccurrences(of: "ViewController", with: "")
         }
+        if name.starts(with: "UIHostingController<") {
+            name = "UIHostingController"
+        }
         return name
     }
 

--- a/Sources/AppcuesKit/Data/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Data/Networking/Endpoint.swift
@@ -89,7 +89,7 @@ internal enum CustomerAPIEndpoint: Endpoint {
 
 /// Endpoint where the full URL is provided, such as the pre-signed image upload endpoint
 internal struct URLEndpoint: Endpoint {
-    let url: URL?
+    let url: URL
 
     func url(config: Appcues.Config, storage: DataStoring) -> URL? {
         return url

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/AppcuesTargetView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/AppcuesTargetView.swift
@@ -1,0 +1,38 @@
+//
+//  AppcuesTargetView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-05-29.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal struct ACTagView: UIViewRepresentable {
+    let identifier: String?
+
+    func makeUIView(context: Context) -> UIView {
+        return AppcuesTargetView(identifier: identifier)
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) { }
+}
+
+internal class AppcuesTargetView: UIView {
+
+    let appcuesID: String?
+
+    init(identifier: String?) {
+        appcuesID = identifier
+
+        super.init(frame: .zero)
+
+        isUserInteractionEnabled = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/ScreenshotUpload.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/ScreenshotUpload.swift
@@ -13,11 +13,11 @@ internal struct ScreenshotUpload: Decodable {
 
     struct Upload: Decodable {
         // the path to PUT image data to for upload, has credentials already included
-        let presignedUrl: String
+        let presignedUrl: URL
     }
 
     let upload: Upload
 
     // the resulting path to the uploaded screenshot to be linked to the screen capture metadata
-    let url: String
+    let url: URL
 }

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIDebugger+Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIDebugger+Capture.swift
@@ -11,7 +11,6 @@ import Foundation
 internal enum ScreenCaptureError: Error {
     case customerAPINotFound
     case noImageData
-    case noImageURL
     case failedCaptureEncoding
 }
 
@@ -94,20 +93,13 @@ extension UIDebugger {
             return
         }
 
-        // make sure we have a valid URL to reference this screen
-        // otherwise don't bother with upload
-        guard let screenshotImageUrl = URL(string: upload.url) else {
-            completion(.failure(ScreenCaptureError.noImageURL))
-            return
-        }
-
         // update the screenshotImageUrl on the screen we are capturing
         // this will be returned in completion handler if the upload succeeds
         var screen = screen
-        screen.screenshotImageUrl = screenshotImageUrl
+        screen.screenshotImageUrl = upload.url
 
         networking.put(
-            to: URLEndpoint(url: URL(string: upload.upload.presignedUrl)),
+            to: URLEndpoint(url: upload.upload.presignedUrl),
             authorization: nil, // pre-signed url, no auth needed on upload
             body: imageData,
             contentType: "image/png"

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
@@ -12,6 +12,7 @@ import UIKit
 // accessibilityLabel, and tag data from the underlying UIView to identify elements.
 internal class UIKitElementSelector: AppcuesElementSelector {
     private enum CodingKeys: String, CodingKey {
+        case appcuesID
         case accessibilityIdentifier
         case accessibilityLabel
         case tag
@@ -19,13 +20,15 @@ internal class UIKitElementSelector: AppcuesElementSelector {
 
     let accessibilityIdentifier: String?
     let tag: String?
+    let appcuesID: String?
 
-    init?(accessibilityIdentifier: String?, accessibilityLabel: String?, tag: String?) {
+    init?(appcuesID: String?, accessibilityIdentifier: String?, accessibilityLabel: String?, tag: String?) {
         // must have at least one identifiable property to be a valid selector
-        if accessibilityIdentifier == nil && accessibilityLabel == nil && tag == nil {
+        if appcuesID == nil && accessibilityIdentifier == nil && accessibilityLabel == nil && tag == nil {
             return nil
         }
 
+        self.appcuesID = appcuesID
         self.accessibilityIdentifier = accessibilityIdentifier
         self.tag = tag
 
@@ -44,6 +47,10 @@ internal class UIKitElementSelector: AppcuesElementSelector {
         // weight the selector property matches by how distinct they are considered
         var weight = 0
 
+        if appcuesID != nil && appcuesID == other.appcuesID {
+            weight += 10_000
+        }
+
         if accessibilityIdentifier != nil && accessibilityIdentifier == other.accessibilityIdentifier {
             weight += 10_000
         }
@@ -61,6 +68,9 @@ internal class UIKitElementSelector: AppcuesElementSelector {
 
     override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        if let appcuesID = appcuesID, !appcuesID.isEmpty {
+            try container.encode(appcuesID, forKey: .appcuesID)
+        }
         if let accessibilityIdentifier = accessibilityIdentifier, !accessibilityIdentifier.isEmpty {
             try container.encode(accessibilityIdentifier, forKey: .accessibilityIdentifier)
         }
@@ -87,6 +97,7 @@ internal class UIKitElementTargeting: AppcuesElementTargeting {
 
     func inflateSelector(from properties: [String: String]) -> AppcuesElementSelector? {
         return UIKitElementSelector(
+            appcuesID: properties["appcuesID"],
             accessibilityIdentifier: properties["accessibilityIdentifier"],
             accessibilityLabel: properties["accessibilityLabel"],
             tag: properties["tag"]
@@ -97,6 +108,7 @@ internal class UIKitElementTargeting: AppcuesElementTargeting {
 internal extension UIView {
     var appcuesSelector: UIKitElementSelector? {
         return UIKitElementSelector(
+            appcuesID: (self as? AppcuesTargetView)?.appcuesID,
             accessibilityIdentifier: accessibilityIdentifier,
             accessibilityLabel: accessibilityLabel,
             tag: tag != 0 ? "\(self.tag)" : nil

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
@@ -8,12 +8,6 @@
 
 import UIKit
 
-private var screenNameDateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd_HH:mm:ss"
-    return formatter
-}()
-
 private extension UIViewController {
     var viewControllerForName: UIViewController {
         if let navigationController = self as? UINavigationController,
@@ -32,16 +26,14 @@ private extension UIViewController {
 }
 
 internal extension UIView {
-    func screenCaptureDisplayName(at timestamp: Date) -> String {
-        var name = ""
-        if let window = self as? UIWindow,
-           let root = window.rootViewController {
+    func screenCaptureDisplayName() -> String {
+        let name: String
+        if let window = self as? UIWindow, let root = window.rootViewController {
             name = root.viewControllerForName.displayName
         } else {
             name = String(describing: self.classForCoder)
         }
 
-        name += " (\(screenNameDateFormatter.string(from: timestamp)))"
         return name
     }
 

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -163,7 +163,7 @@ extension UIDebugger: DebugViewDelegate {
         var capture = Capture(
             appId: config.applicationID,
             displayName: window.screenCaptureDisplayName(at: timestamp),
-            screenshotImageUrl: URL(string: "http://www.appcues.com/screenshot/\(UUID())"),
+            screenshotImageUrl: nil,
             layout: layout,
             metadata: Capture.Metadata(insets: Capture.Insets(window.safeAreaInsets)),
             timestamp: timestamp,

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -162,7 +162,7 @@ extension UIDebugger: DebugViewDelegate {
         let timestamp = Date()
         var capture = Capture(
             appId: config.applicationID,
-            displayName: window.screenCaptureDisplayName(at: timestamp),
+            displayName: window.screenCaptureDisplayName(),
             screenshotImageUrl: nil,
             layout: layout,
             metadata: Capture.Metadata(insets: Capture.Insets(window.safeAreaInsets)),

--- a/Sources/AppcuesKit/Presentation/Public/ElementTargeting/View+AppcuesView.swift
+++ b/Sources/AppcuesKit/Presentation/Public/ElementTargeting/View+AppcuesView.swift
@@ -1,0 +1,19 @@
+//
+//  View+AppcuesView.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-05-30.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+public extension View {
+    /// Associates the view with an identifier for Appcues element targeting.
+    /// - Parameter identifier: Unique name identifying the view.
+    /// - Returns: A view identifiable by Appcues element targeting.
+    func appcuesView(identifier: String?) -> some View {
+        self.background(ACTagView(identifier: identifier))
+    }
+}


### PR DESCRIPTION
The modifier adds a background `AppcuesTargetView` `UIView` which has the same frame as a the tagged view, allowing it to be targeted.

Also updating the default Name of captured screens to be nicer for SwiftUI views and removed the (now) redundant timestamp.