### PR TITLE
Ensure experiences are dismissed before screen capture

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -103,8 +103,13 @@ internal class DebugViewController: UIViewController {
         showToast(seconds: 3.0)
     }
 
-    func showCaptureFailure(onRetry: @escaping () -> Void) {
-        debugView.toastView.configureFailure { [weak self] in
+    func showCaptureFailure() {
+        debugView.toastView.configureCaptureFailure()
+        showToast(seconds: 3.0)
+    }
+
+    func showSaveFailure(onRetry: @escaping () -> Void) {
+        debugView.toastView.configureSaveFailure { [weak self] in
             // handling retry tap
             // hide the toast, then execute the provided retry callback
             self?.debugView.setToastView(visible: false, animated: false) {

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/CaptureToastView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/CaptureToastView.swift
@@ -83,7 +83,7 @@ internal class CaptureToastView: UIView {
         onRetry = nil
     }
 
-    func configureFailure(onRetry: @escaping () -> Void) {
+    func configureSaveFailure(onRetry: @escaping () -> Void) {
         backgroundColor = .appcuesToastFailure
         retryButton.isHidden = false
         messageLabel.attributedText = NSAttributedString(string: "Upload failed", attributes: [
@@ -91,6 +91,16 @@ internal class CaptureToastView: UIView {
             .foregroundColor: UIColor.white
         ])
         self.onRetry = onRetry
+    }
+
+    func configureCaptureFailure() {
+        backgroundColor = .appcuesToastFailure
+        retryButton.isHidden = true
+        messageLabel.attributedText = NSAttributedString(string: "Screen capture failed", attributes: [
+            .font: UIFont.systemFont(ofSize: 14, weight: .bold),
+            .foregroundColor: UIColor.white
+        ])
+        self.onRetry = nil
     }
 
     @objc

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -153,9 +153,7 @@ extension UIDebugger: DebugViewDelegate {
               let window = UIApplication.shared.windows.first(where: { !$0.isAppcuesWindow }),
               let screenshot = window.screenshot(),
               let layout = Appcues.elementTargeting.captureLayout() else {
-
-            // show error?
-
+            debugViewController?.showCaptureFailure()
             return
         }
 
@@ -193,7 +191,7 @@ extension UIDebugger: DebugViewDelegate {
                 }
             case .failure:
                 DispatchQueue.main.async {
-                    debugViewController.showCaptureFailure {
+                    debugViewController.showSaveFailure {
                         // onRetry - recursively call save to try again
                         self.saveScreen(debugViewController: debugViewController, capture: capture, authorization: authorization)
                     }

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -47,6 +47,7 @@ internal class UIDebugger: UIDebugging {
     private let notificationCenter: NotificationCenter
     private let analyticsPublisher: AnalyticsPublishing
     private let networking: Networking
+    private let experienceRenderer: ExperienceRendering
 
     private var debugViewController: DebugViewController? {
         return debugWindow?.rootViewController as? DebugViewController
@@ -58,6 +59,7 @@ internal class UIDebugger: UIDebugging {
         self.analyticsPublisher = container.resolve(AnalyticsPublishing.self)
         self.notificationCenter = container.resolve(NotificationCenter.self)
         self.networking = container.resolve(Networking.self)
+        self.experienceRenderer = container.resolve(ExperienceRendering.self)
 
         self.viewModel = DebugViewModel(
             networking: container.resolve(Networking.self),
@@ -149,6 +151,13 @@ extension UIDebugger: DebugViewDelegate {
     }
 
     private func captureScreen(authorization: Authorization) {
+        guard experienceRenderer.getCurrentExperienceData() == nil else {
+            experienceRenderer.dismissCurrentExperience(markComplete: false) { _ in
+                self.captureScreen(authorization: authorization)
+            }
+            return
+        }
+
         guard let debugViewController = debugViewController,
               let window = UIApplication.shared.windows.first(where: { !$0.isAppcuesWindow }),
               let screenshot = window.screenshot(),

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
@@ -16,7 +16,7 @@ internal class AppcuesTargetElementTrait: AppcuesBackdropDecoratingTrait {
         let selector: [String: String]
     }
 
-    static let type: String = "@appcues/target-element-beta"
+    static let type: String = "@appcues/target-element"
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
@@ -46,7 +46,7 @@ class AppcuesTargetElementTraitTests: XCTestCase {
         let trait = AppcuesTargetElementTrait(appcues: appcues, selector: [:])
 
         // Assert
-        XCTAssertEqual(AppcuesTargetElementTrait.type, "@appcues/target-element-beta")
+        XCTAssertEqual(AppcuesTargetElementTrait.type, "@appcues/target-element")
         XCTAssertNil(nilConfigTrait)
         XCTAssertNotNil(trait)
     }


### PR DESCRIPTION
The debugger now has a dependency on the `ExperienceRenderer` to be able to dismiss an experience if needed before performing a screen capture:

![iOS SDK Dependency Graph-2](https://github.com/appcues/appcues-ios-sdk/assets/845681/63308e6b-ec3f-4698-b283-6103e9235cfc)

Also took care of sc-53273 and rename the target-element trait, as well as added a toast message in place of a silent failure if the screen capture fails.