### PR TITLE
Update BlurHash init to optimize compile time

### DIFF
--- a/Sources/AppcuesKit/Vendor/UIImage+BlurHash.swift
+++ b/Sources/AppcuesKit/Vendor/UIImage+BlurHash.swift
@@ -41,7 +41,10 @@ extension UIImage {
                 let value = String(blurHash[2 ..< 6]).decode83()
                 return decodeDC(value)
             } else {
-                let value = String(blurHash[4 + i * 2 ..< 4 + i * 2 + 2]).decode83()
+                // compile time optimization
+                let startIndex = 4 + i * 2
+                let endIndex = 4 + i * 2 + 2
+                let value = String(blurHash[startIndex..<endIndex]).decode83()
                 return decodeAC(value, maximumValue: maximumValue * punch)
             }
         }


### PR DESCRIPTION
I was playing around with a couple [Swift compiler flags](https://www.jessesquires.com/blog/2017/09/18/measuring-compile-times-xcode9/)

```
-Xfrontend -warn-long-function-bodies=<limit-ms>
-Xfrontend -warn-long-expression-type-checking=<limit-ms>
```

This change reduces building the whole AppcuesKit framework from an average of 7.83s to 5.76s, a ~26% improvement. (Obviously exact values vary from machine to machine)