### PR TITLE
Add displayName to AppcuesViewElement

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
@@ -81,6 +81,20 @@ internal class UIKitElementSelector: AppcuesElementSelector {
             try container.encode(tag, forKey: .tag)
         }
     }
+
+    func displayName(with type: String) -> String? {
+        if let appcuesID = appcuesID {
+            return appcuesID
+        } else if let accessibilityIdentifier = accessibilityIdentifier {
+            return accessibilityIdentifier
+        } else if let tag = tag {
+            return "\(type) (tag \(tag))"
+        } else if let accessibilityLabel = accessibilityLabel {
+            return "\(type) (\(accessibilityLabel))"
+        }
+
+        return nil
+    }
 }
 
 // UIKit implementation of element targeting that captures the UIView hierarchy for the current UIWindow,
@@ -131,14 +145,18 @@ internal extension UIView {
             return $0.asViewElement(in: bounds)
         }
 
+        let selector = appcuesSelector
+        let type = "\(type(of: self))"
+
         return AppcuesViewElement(
             x: absolutePosition.origin.x,
             y: absolutePosition.origin.y,
             width: absolutePosition.width,
             height: absolutePosition.height,
-            type: "\(type(of: self))",
-            selector: appcuesSelector,
-            children: children.isEmpty ? nil : children
+            type: type,
+            selector: selector,
+            children: children.isEmpty ? nil : children,
+            displayName: selector?.displayName(with: type)
         )
     }
 }

--- a/Sources/AppcuesKit/Presentation/Public/ElementTargeting/AppcuesViewElement.swift
+++ b/Sources/AppcuesKit/Presentation/Public/ElementTargeting/AppcuesViewElement.swift
@@ -43,6 +43,9 @@ public class AppcuesViewElement: NSObject, Encodable {
     /// The sub-views contained within this view, if any.
     let children: [AppcuesViewElement]?
 
+    /// A user-readable textual representation of the view.
+    let displayName: String?
+
     /// Creates an instance of an AppcuesViewElement.
     /// - Parameters:
     ///   - x: The x-coordinate for view position, with origin in the upper-left corner, in screen coordinates.
@@ -61,7 +64,8 @@ public class AppcuesViewElement: NSObject, Encodable {
         height: CGFloat,
         type: String,
         selector: AppcuesElementSelector?,
-        children: [AppcuesViewElement]?
+        children: [AppcuesViewElement]?,
+        displayName: String? = nil
     ) {
         self.x = x
         self.y = y
@@ -70,6 +74,7 @@ public class AppcuesViewElement: NSObject, Encodable {
         self.type = type
         self.selector = selector
         self.children = children
+        self.displayName = displayName
     }
 }
 

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -83,14 +83,24 @@ class PublicAPITests: XCTestCase {
 
 class SampleElementTargeting: AppcuesElementTargeting {
     func captureLayout() -> AppcuesViewElement? {
-        AppcuesViewElement(
+        let elementWithDisplayName = AppcuesViewElement(
             x: 0,
             y: 0,
             width: 100,
             height: 100,
             type: "view",
             selector: AppcuesElementSelector(),
-            children: nil)
+            children: nil,
+            displayName: "display name")
+
+        return AppcuesViewElement(
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+            type: "view",
+            selector: AppcuesElementSelector(),
+            children: [elementWithDisplayName])
     }
 
     func inflateSelector(from properties: [String : String]) -> AppcuesElementSelector? {

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
@@ -210,6 +210,30 @@ class AppcuesTargetElementTraitTests: XCTestCase {
         XCTAssertNil(contentDistanceFromTarget)
     }
 
+    func testElementDisplayName() throws {
+        let view1 = UIView()
+        view1.accessibilityIdentifier = "myAccessibilityID"
+        let view1Element = try XCTUnwrap(view1.asViewElement())
+        XCTAssertEqual(view1Element.displayName, "myAccessibilityID")
+
+        let view2 = AppcuesTargetView(identifier: "someID")
+        let view2Element = try XCTUnwrap(view2.asViewElement())
+        XCTAssertEqual(view2Element.displayName, "someID")
+
+        let view3 = UIView()
+        view3.tag = 226
+        let view3Element = try XCTUnwrap(view3.asViewElement())
+        XCTAssertEqual(view3Element.displayName, "UIView (tag 226)")
+
+        let view4 = UIButton()
+        view4.accessibilityLabel = "My Button"
+        let view4Element = try XCTUnwrap(view4.asViewElement())
+        XCTAssertEqual(view4Element.displayName, "UIButton (My Button)")
+
+        let view5 = UIView()
+        let view5Element = try XCTUnwrap(view5.asViewElement())
+        XCTAssertNil(view5Element.displayName)
+    }
 }
 
 extension UIView {


### PR DESCRIPTION
The `displayName` property in the init must be optional so that it's not a breaking change, and then swift convention dictates that optional init parameters are last in the list.

I reworked `asViewElement(in:)` a bit to avoid recomputing the selector or type determination.