### PR TITLE
WIP: Refactor ExperienceRenderer to support multiple ExperienceStateMach ine instances for non-modal Experiences

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// An object that manages Appcues tracking and rendering of experience content, for your app.
 @objc(Appcues)
@@ -238,6 +239,24 @@ public class Appcues: NSObject {
         guard #available(iOS 13.0, *) else { return }
 
         actionRegistry.register(action: action)
+    }
+
+    /// Registers the given embed view to be available for targeting embedded Appcues experience content.
+    /// - Parameters:
+    ///   - frameID: The unique identifier for the embedded ``AppcuesFrame``.
+    ///   - view: The AppcuesView to register for hosting embedded content.
+    ///   - viewController: The `UIViewController` that owns the provided ``AppcuesFrame`` instance.
+    @objc
+    public func register(frameID: String, for view: AppcuesFrame, on parentViewController: UIViewController) {
+        guard #available(iOS 13.0, *) else {
+            config.logger.error("iOS 13 or above is required to render embedded experiences")
+            return
+        }
+
+        view.configure(parentViewController: parentViewController)
+
+        let experienceRenderer = container.resolve(ExperienceRendering.self)
+        experienceRenderer.start(owner: view, forContext: .embed(frameID: frameID))
     }
 
     /// Launches the Appcues debugger over your app's UI.

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -130,7 +130,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                     error: error
                 )
             }
-            experienceRenderer.show(qualifiedExperiences: qualifiedExperienceData, completion: nil)
+            experienceRenderer.processAndShow(qualifiedExperiences: qualifiedExperienceData)
         }
     }
 }

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -48,7 +48,8 @@ internal struct FailedExperience: Decodable {
             traits: [],
             steps: [],
             redirectURL: nil,
-            nextContentID: nil
+            nextContentID: nil,
+            renderContext: .modal
         )
     }
 }
@@ -146,6 +147,8 @@ internal struct Experience {
 
     /// Unique ID to disambiguate the same experience flowing through the system from different origins.
     let instanceID = UUID()
+
+    let renderContext: RenderContext
 }
 
 extension Experience: Decodable {
@@ -170,6 +173,8 @@ extension Experience: Decodable {
         steps = try container.decode([Step].self, forKey: .steps)
         redirectURL = try? container.decode(URL.self, forKey: .redirectURL)
         nextContentID = try? container.decode(String.self, forKey: .nextContentID)
+
+        renderContext = .modal
     }
 }
 
@@ -187,6 +192,7 @@ extension Experience {
             if let nextContentID = nextContentID {
                 actions.append(AppcuesLaunchExperienceAction(
                     appcues: appcues,
+                    renderContext: self.renderContext,
                     experienceID: nextContentID,
                     trigger: .experienceCompletionAction(fromExperienceID: self.id)
                 ))

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -174,7 +174,13 @@ extension Experience: Decodable {
         redirectURL = try? container.decode(URL.self, forKey: .redirectURL)
         nextContentID = try? container.decode(String.self, forKey: .nextContentID)
 
-        renderContext = .modal
+        if #available(iOS 13.0, *),
+           let embedTrait = self.traits.first(where: { $0.type == AppcuesEmbeddedTrait.type }),
+           let config = embedTrait.configDecoder.decode(AppcuesEmbeddedTrait.Config.self){
+            renderContext = .embed(frameID: config.frameID)
+        } else {
+            renderContext = .modal
+        }
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -65,9 +65,19 @@ internal class ActionRegistry {
 
     /// Enqueue an array of experience action data models to be executed. This version is for non-interactive action execution,
     /// such as actions that execute as part of the navigation to a step.
-    func enqueue(actionModels: [Experience.Action], level: AppcuesExperiencePluginConfiguration.Level, completion: @escaping () -> Void) {
+    func enqueue(
+        actionModels: [Experience.Action],
+        level: AppcuesExperiencePluginConfiguration.Level,
+        renderContext: RenderContext,
+        completion: @escaping () -> Void
+    ) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level, appcues: appcues))
+            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration(
+                $0.configDecoder,
+                level: level,
+                renderContext: renderContext,
+                appcues: appcues
+            ))
         }
         execute(transformQueue(actionInstances), completion: completion)
     }
@@ -84,11 +94,17 @@ internal class ActionRegistry {
     func enqueue(
         actionModels: [Experience.Action],
         level: AppcuesExperiencePluginConfiguration.Level,
+        renderContext: RenderContext,
         interactionType: String,
         viewDescription: String?
     ) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level, appcues: appcues))
+            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration(
+                $0.configDecoder,
+                level: level,
+                renderContext: renderContext,
+                appcues: appcues
+            ))
         }
 
         // As a heuristic, take the last action that's `InteractionLoggingAction`, since that's most likely
@@ -96,6 +112,7 @@ internal class ActionRegistry {
         let primaryAction = actionInstances.reversed().compactMapFirst { $0 as? InteractionLoggingAction }
         let interactionAction = AppcuesStepInteractionAction(
             appcues: appcues,
+            renderContext: renderContext,
             interactionType: interactionType,
             viewDescription: viewDescription ?? "",
             category: primaryAction?.category ?? "",

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
@@ -18,11 +18,13 @@ internal class AppcuesCloseAction: AppcuesExperienceAction {
     static let type = "@appcues/close"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     private let markComplete: Bool
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         appcues = configuration.appcues
+        renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         markComplete = config?.markComplete ?? false
@@ -32,6 +34,6 @@ internal class AppcuesCloseAction: AppcuesExperienceAction {
         guard let appcues = appcues else { return completion() }
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
-        experienceRenderer.dismissCurrentExperience(markComplete: markComplete) { _ in completion() }
+        experienceRenderer.dismiss(inContext: renderContext, markComplete: markComplete) { _ in completion() }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
@@ -19,11 +19,13 @@ internal class AppcuesContinueAction: AppcuesExperienceAction {
     static let type = "@appcues/continue"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let stepReference: StepReference
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         appcues = configuration.appcues
+        renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         if let index = config?.index {
@@ -42,6 +44,6 @@ internal class AppcuesContinueAction: AppcuesExperienceAction {
         guard let appcues = appcues else { return completion() }
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
-        experienceRenderer.show(stepInCurrentExperience: stepReference, completion: completion)
+        experienceRenderer.show(step: stepReference, inContext: renderContext, completion: completion)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -17,20 +17,23 @@ internal class AppcuesLaunchExperienceAction: AppcuesExperienceAction {
     static let type = "@appcues/launch-experience"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let experienceID: String
     private let trigger: ExperienceTrigger?
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        self.renderContext = configuration.renderContext
 
         guard let config = configuration.decode(Config.self) else { return nil }
         self.experienceID = config.experienceID
         self.trigger = nil
     }
 
-    init(appcues: Appcues?, experienceID: String, trigger: ExperienceTrigger) {
+    init(appcues: Appcues?, renderContext: RenderContext, experienceID: String, trigger: ExperienceTrigger) {
         self.appcues = appcues
+        self.renderContext = renderContext
         self.experienceID = experienceID
 
         // This is used when a flow is triggered as a post flow action from another flow.
@@ -57,7 +60,7 @@ internal class AppcuesLaunchExperienceAction: AppcuesExperienceAction {
 
     private func launchExperienceTrigger(_ appcues: Appcues) -> ExperienceTrigger {
         let experienceRendering = appcues.container.resolve(ExperienceRendering.self)
-        let currentExperienceId = experienceRendering.getCurrentExperienceData()?.id
+        let currentExperienceId = experienceRendering.experienceData(forContext: renderContext)?.id
         return .launchExperienceAction(fromExperienceID: currentExperienceId)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
@@ -15,6 +15,7 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
     static let type = "@appcues/step_interaction"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let interactionType: String
     let viewDescription: String
@@ -26,8 +27,9 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
         return nil
     }
 
-    init(appcues: Appcues?, interactionType: String, viewDescription: String, category: String, destination: String) {
+    init(appcues: Appcues?, renderContext: RenderContext, interactionType: String, viewDescription: String, category: String, destination: String) {
         self.appcues = appcues
+        self.renderContext = renderContext
         self.interactionType = interactionType
         self.viewDescription = viewDescription
         self.category = category
@@ -49,8 +51,8 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
             ]
         ]
 
-        if let experienceData = experienceRenderer.getCurrentExperienceData(),
-           let stepIndex = experienceRenderer.getCurrentStepIndex() {
+        if let experienceData = experienceRenderer.experienceData(forContext: renderContext),
+           let stepIndex = experienceRenderer.stepIndex(forContext: renderContext) {
             interactionProperties = LifecycleEvent.properties(experienceData, stepIndex).merging(interactionProperties)
         }
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -17,11 +17,13 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
     static let type = "@appcues/submit-form"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let skipValidation: Bool
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         self.skipValidation = config?.skipValidation ?? false
@@ -37,8 +39,8 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
         let analyticsPublisher = appcues.container.resolve(AnalyticsPublishing.self)
 
-        guard let experienceData = experienceRenderer.getCurrentExperienceData(),
-              let stepIndex = experienceRenderer.getCurrentStepIndex(),
+        guard let experienceData = experienceRenderer.experienceData(forContext: renderContext),
+              let stepIndex = experienceRenderer.stepIndex(forContext: renderContext),
               let stepState = experienceData.state(for: stepIndex) else { return }
 
         let interactionProperties = LifecycleEvent.properties(experienceData, stepIndex).merging([
@@ -66,8 +68,8 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
 
-        guard let experienceData = experienceRenderer.getCurrentExperienceData(),
-              let stepIndex = experienceRenderer.getCurrentStepIndex(),
+        guard let experienceData = experienceRenderer.experienceData(forContext: renderContext),
+              let stepIndex = experienceRenderer.stepIndex(forContext: renderContext),
               let stepState = experienceData.state(for: stepIndex) else { return queue }
 
         if stepState.stepFormIsComplete {

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -151,8 +151,8 @@ extension UIDebugger: DebugViewDelegate {
     }
 
     private func captureScreen(authorization: Authorization) {
-        guard experienceRenderer.getCurrentExperienceData() == nil else {
-            experienceRenderer.dismissCurrentExperience(markComplete: false) { _ in
+        guard experienceRenderer.experienceData(forContext: .modal) == nil else {
+            experienceRenderer.dismiss(inContext: .modal, markComplete: false) { _ in
                 self.captureScreen(authorization: authorization)
             }
             return

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -10,22 +10,34 @@ import UIKit
 
 @available(iOS 13.0, *)
 internal protocol ExperienceRendering: AnyObject {
+    func start(owner: StateMachineOwning, forContext context: RenderContext)
+    func processAndShow(qualifiedExperiences: [ExperienceData])
     func show(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?)
-    func show(qualifiedExperiences: [ExperienceData], completion: ((Result<Void, Error>) -> Void)?)
-    func show(stepInCurrentExperience stepRef: StepReference, completion: (() -> Void)?)
-    func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?)
-    func getCurrentExperienceData() -> ExperienceData?
-    func getCurrentStepIndex() -> Experience.StepIndex?
+    func show(step stepRef: StepReference, inContext context: RenderContext, completion: (() -> Void)?)
+    func dismiss(inContext context: RenderContext, markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?)
+    func experienceData(forContext context: RenderContext) -> ExperienceData?
+    func stepIndex(forContext context: RenderContext) -> Experience.StepIndex?
+    func owner(forContext context: RenderContext) -> StateMachineOwning?
+}
+
+internal enum RenderContext: Hashable {
+    case embed(frameID: String)
+    case modal
 }
 
 internal enum ExperienceRendererError: Error {
+    case noStateMachine
     case experimentControl
 }
 
 @available(iOS 13.0, *)
-internal class ExperienceRenderer: ExperienceRendering {
+internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
-    private let stateMachine: ExperienceStateMachine
+    /// State machine for `RenderContext.modal`
+    var stateMachine: ExperienceStateMachine?
+
+    private var stateMachines = StateMachineDirectory()
+    private var potentiallyRenderableExperiences: [RenderContext: [ExperienceData]] = [:]
     private let analyticsObserver: ExperienceStateMachine.AnalyticsObserver
     private weak var appcues: Appcues?
     private let config: Appcues.Config
@@ -38,6 +50,44 @@ internal class ExperienceRenderer: ExperienceRendering {
         // are considered private implementation details of the ExperienceRenderer - helpers.
         self.stateMachine = ExperienceStateMachine(container: container)
         self.analyticsObserver = ExperienceStateMachine.AnalyticsObserver(container: container)
+
+        stateMachines[ownerFor: .modal] = self
+    }
+
+    func start(owner: StateMachineOwning, forContext context: RenderContext) {
+        guard let container = appcues?.container else { return }
+
+        owner.stateMachine = ExperienceStateMachine(container: container)
+        stateMachines[ownerFor: context] = owner
+        if let pendingExperiences = potentiallyRenderableExperiences[context] {
+            show(qualifiedExperiences: pendingExperiences, completion: nil)
+        }
+    }
+
+    // TODO: this only gets called when the array isnt empty (AnalyticsTracker does this), so we aren't clearing the cache unless there's at least one new thing.
+    func processAndShow(qualifiedExperiences: [ExperienceData]) {
+        let shouldClearCache = qualifiedExperiences.contains(where: { $0.trigger == .qualification(reason: .screenView) })
+        if shouldClearCache {
+            // TODO: error events for embeds that didn't show because there was no Frame
+            potentiallyRenderableExperiences = [:]
+            stateMachines.cleanup()
+        }
+
+        // Add new experiences, replacing any existing ones
+        let grouped = Dictionary(grouping: qualifiedExperiences) { $0.renderContext }
+        potentiallyRenderableExperiences = potentiallyRenderableExperiences.merging(grouped)
+
+        potentiallyRenderableExperiences.forEach { renderContext, qualifiedExperiences in
+            show(qualifiedExperiences: qualifiedExperiences) { result in
+                print(result)
+                if case .success = result {
+                    self.potentiallyRenderableExperiences.removeValue(forKey: renderContext)
+                }
+            }
+        }
+
+        // No caching required for modals since they can't be lazy-loaded.
+        potentiallyRenderableExperiences.removeValue(forKey: .modal)
     }
 
     func show(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?) {
@@ -45,6 +95,12 @@ internal class ExperienceRenderer: ExperienceRendering {
             DispatchQueue.main.async {
                 self.show(experience: experience, completion: completion)
             }
+            return
+        }
+
+        guard let stateMachine = stateMachines[experience.renderContext] else {
+            potentiallyRenderableExperiences[experience.renderContext] = [experience]
+            completion?(.failure(ExperienceRendererError.noStateMachine))
             return
         }
 
@@ -58,7 +114,7 @@ internal class ExperienceRenderer: ExperienceRendering {
         }
 
         if experience.priority == .normal && stateMachine.state != .idling {
-            dismissCurrentExperience(markComplete: false) { result in
+            dismiss(inContext: experience.renderContext, markComplete: false) { result in
                 switch result {
                 case .success:
                     self.show(experience: experience, completion: completion)
@@ -76,7 +132,7 @@ internal class ExperienceRenderer: ExperienceRendering {
         // only track analytics on published experiences (not previews)
         // and only add the observer if the state machine is idling, otherwise there's already another experience in-flight
         if experience.published && stateMachine.state == .idling {
-            self.stateMachine.addObserver(analyticsObserver)
+            stateMachine.addObserver(analyticsObserver)
         }
         stateMachine.clientAppcuesDelegate = appcues?.experienceDelegate
         stateMachine.transitionAndObserve(.startExperience(experience), filter: experience.instanceID) { result in
@@ -94,7 +150,7 @@ internal class ExperienceRenderer: ExperienceRendering {
         }
     }
 
-    func show(qualifiedExperiences: [ExperienceData], completion: ((Result<Void, Error>) -> Void)?) {
+    private func show(qualifiedExperiences: [ExperienceData], completion: ((Result<Void, Error>) -> Void)?) {
         guard let experience = qualifiedExperiences.first else {
             // If given an empty list of qualified experiences, complete with a success because this function has completed without error.
             // This function only recurses on a non-empty case, so this block only applies to the initial external call.
@@ -117,11 +173,16 @@ internal class ExperienceRenderer: ExperienceRendering {
         }
     }
 
-    func show(stepInCurrentExperience stepRef: StepReference, completion: (() -> Void)?) {
+    func show(step stepRef: StepReference, inContext context: RenderContext, completion: (() -> Void)?) {
         guard Thread.isMainThread else {
             DispatchQueue.main.async {
-                self.show(stepInCurrentExperience: stepRef, completion: completion)
+                self.show(step: stepRef, inContext: context, completion: completion)
             }
+            return
+        }
+
+        guard let stateMachine = stateMachines[context] else {
+            completion?()
             return
         }
 
@@ -149,11 +210,16 @@ internal class ExperienceRenderer: ExperienceRendering {
         }
     }
 
-    func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?) {
+    func dismiss(inContext context: RenderContext, markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?) {
         guard Thread.isMainThread else {
             DispatchQueue.main.async {
-                self.dismissCurrentExperience(markComplete: markComplete, completion: completion)
+                self.dismiss(inContext: context, markComplete: markComplete, completion: completion)
             }
+            return
+        }
+
+        guard let stateMachine = stateMachines[context] else {
+            completion?(.failure(ExperienceRendererError.noStateMachine))
             return
         }
 
@@ -166,7 +232,7 @@ internal class ExperienceRenderer: ExperienceRendering {
             // These two cases handle dismissing an experience that's in the process of presenting a step group.
             case .success(.renderingStep):
                 DispatchQueue.main.async { [weak self] in
-                    self?.dismissCurrentExperience(markComplete: markComplete, completion: completion)
+                    self?.dismiss(inContext: context, markComplete: markComplete, completion: completion)
                 }
                 return true
             case .failure(.noTransition(currentState: .beginningExperience)),
@@ -186,12 +252,16 @@ internal class ExperienceRenderer: ExperienceRendering {
         }
     }
 
-    func getCurrentExperienceData() -> ExperienceData? {
-        stateMachine.state.currentExperienceData
+    func experienceData(forContext context: RenderContext) -> ExperienceData? {
+        stateMachines[context]?.state.currentExperienceData
     }
 
-    func getCurrentStepIndex() -> Experience.StepIndex? {
-        stateMachine.state.currentStepIndex
+    func stepIndex(forContext context: RenderContext) -> Experience.StepIndex? {
+        stateMachines[context]?.state.currentStepIndex
+    }
+
+    func owner(forContext context: RenderContext) -> StateMachineOwning? {
+        stateMachines[ownerFor: context]
     }
 
     private func track(experiment: Experiment?) {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -223,7 +223,7 @@ extension ExperienceStateMachine {
             case .continuation(let action):
                 try machine.transition(action)
             case let .presentContainer(experience, stepIndex, package, actions):
-                machine.actionRegistry.enqueue(actionModels: actions, level: .group) {
+                machine.actionRegistry.enqueue(actionModels: actions, level: .group, renderContext: experience.renderContext) {
                     executePresentContainer(
                         machine: machine,
                         experience: experience,

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -110,7 +110,8 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
         switch state {
         case .endingExperience:
             experienceWillDisappear()
-        case let .renderingStep(_, _, package, _) where package.wrapperController.isBeingDismissed:
+        case let .renderingStep(_, _, package, _)
+            where package.wrapperController.isBeingDismissed || package.wrapperController.isMovingFromParent:
             experienceWillDisappear()
         default:
             break
@@ -121,7 +122,8 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
         switch state {
         case .endingExperience:
             experienceDidDisappear()
-        case let .renderingStep(_, _, package, _) where package.wrapperController.isBeingDismissed:
+        case let .renderingStep(_, _, package, _)
+            where package.wrapperController.isBeingDismissed || package.wrapperController.isMovingFromParent:
             experienceDidDisappear()
             // Update state in response to UI changes that have happened already (a call to UIViewController.dismiss).
             try? transition(.endExperience(markComplete: false))

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal enum ExperienceTrigger {
+internal enum ExperienceTrigger: Equatable {
     case qualification(reason: QualifyResponse.QualificationReason?)
     case experienceCompletionAction(fromExperienceID: UUID?)
     case launchExperienceAction(fromExperienceID: UUID?)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
@@ -1,0 +1,53 @@
+//
+//  StateMachineDirectory.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-06-15.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal protocol StateMachineOwning: AnyObject {
+    @available(iOS 13.0, *)
+    var stateMachine: ExperienceStateMachine? { get set }
+}
+
+// This class is intended to work like a `Dictionary<RenderContext, StateMachineOwning?>`,
+// while abstracting away the fact that it weakly references the value.
+@available(iOS 13.0, *)
+internal class StateMachineDirectory {
+    private var stateMachines: [RenderContext: WeakStateMachineOwning] = [:]
+
+    func cleanup() {
+        stateMachines = stateMachines.filter { _, weakRef in weakRef.value != nil }
+    }
+
+    func owner(forContext context: RenderContext) -> StateMachineOwning? {
+        stateMachines[context]?.value
+    }
+
+    /// Get the `ExperienceStateMachine` associated with the specified key.
+    subscript (_ key: RenderContext) -> ExperienceStateMachine? {
+        stateMachines[key]?.value?.stateMachine
+    }
+
+    subscript (ownerFor key: RenderContext) -> StateMachineOwning? {
+        get {
+            stateMachines[key]?.value
+        }
+        set(newValue) {
+            stateMachines[key] = WeakStateMachineOwning(newValue)
+        }
+    }
+
+}
+
+@available(iOS 13.0, *)
+private extension StateMachineDirectory {
+    class WeakStateMachineOwning {
+        weak var value: StateMachineOwning?
+
+        init (_ wrapping: StateMachineOwning?) { self.value = wrapping }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Extensions/UIView+Constrain.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIView+Constrain.swift
@@ -10,14 +10,14 @@ import UIKit
 
 extension UIView {
 
-     func pin(to view: UIView) {
+     func pin(to view: UIView, margins: NSDirectionalEdgeInsets = .zero) {
         self.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            self.topAnchor.constraint(equalTo: view.topAnchor),
-            self.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            self.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            self.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            self.topAnchor.constraint(equalTo: view.topAnchor, constant: margins.top),
+            self.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: margins.leading),
+            self.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -1.0 * margins.trailing),
+            self.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -1.0 * margins.bottom)
         ])
     }
 

--- a/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
@@ -9,13 +9,18 @@
 import UIKit
 
 extension UIViewController {
-    func embedChildViewController(_ childVC: UIViewController, inSuperview superview: UIView, respectLayoutMargins: Bool = false) {
+    func embedChildViewController(
+        _ childVC: UIViewController,
+        inSuperview superview: UIView,
+        margins: NSDirectionalEdgeInsets = .zero,
+        respectLayoutMargins: Bool = false
+    ) {
         addChild(childVC)
         superview.addSubview(childVC.view)
         if respectLayoutMargins {
             childVC.view.pin(to: superview.layoutMarginsGuide)
         } else {
-            childVC.view.pin(to: superview)
+            childVC.view.pin(to: superview, margins: margins)
         }
         childVC.didMove(toParent: self)
     }

--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
@@ -31,9 +31,12 @@ public class AppcuesExperiencePluginConfiguration: NSObject {
     /// The instance of the Appcues SDK where the plugin is being applied.
     public weak var appcues: Appcues?
 
-    init(_ decoder: PluginDecoder, level: Level, appcues: Appcues?) {
+    internal let renderContext: RenderContext
+
+    init(_ decoder: PluginDecoder, level: Level, renderContext: RenderContext, appcues: Appcues?) {
         self.decoder = decoder
         self.level = level
+        self.renderContext = renderContext
         self.appcues = appcues
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -18,12 +18,16 @@ internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, Appcue
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
+    private let renderContext: RenderContext
+
     private let level: AppcuesExperiencePluginConfiguration.Level
     private let content: ExperienceComponent
 
     private weak var backgroundViewController: UIViewController?
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
+        self.renderContext = configuration.renderContext
+
         guard let config = configuration.decode(Config.self) else { return nil }
 
         self.level = configuration.level
@@ -42,7 +46,7 @@ internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, Appcue
     func decorate(containerController: AppcuesExperienceContainerViewController) throws {
         guard level == .group || level == .experience else { return }
 
-        let emptyViewModel = ExperienceStepViewModel()
+        let emptyViewModel = ExperienceStepViewModel(renderContext: renderContext)
 
         backgroundViewController = applyBackground(with: emptyViewModel, parent: containerController)
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
@@ -1,0 +1,107 @@
+//
+//  AppcuesEmbeddedTrait.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 8/18/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
+
+    struct Config: Decodable {
+        let frameID: String
+        let style: ExperienceComponent.Style?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let animated: Bool?
+    }
+
+    static let type = "@appcues/embedded"
+
+    weak var metadataDelegate: AppcuesTraitMetadataDelegate?
+
+    private weak var appcues: Appcues?
+
+    // the title of the embed container
+    let frameID: String
+    private let style: ExperienceComponent.Style?
+    private let animated: Bool
+
+    // the view embedded somewhere in the customer application
+    weak var embedView: AppcuesFrame?
+
+    required init?(configuration: AppcuesExperiencePluginConfiguration) {
+        self.appcues = configuration.appcues
+
+        guard let config = configuration.decode(Config.self) else { return nil }
+        self.frameID = config.frameID
+        self.animated = config.animated ?? false
+        self.style = config.style
+    }
+
+    func decorate(stepController: UIViewController) throws {
+        // Need to cast for access to the padding property.
+        guard let stepController = stepController as? ExperienceStepViewController else { return }
+        stepController.padding = NSDirectionalEdgeInsets(
+            top: style?.paddingTop ?? 0,
+            leading: style?.paddingLeading ?? 0,
+            bottom: style?.paddingBottom ?? 0,
+            trailing: style?.paddingTrailing ?? 0
+        )
+    }
+
+    func createWrapper(around containerController: AppcuesExperienceContainerViewController) throws -> UIViewController {
+        applyStyle(style, to: containerController)
+        return containerController
+    }
+
+    func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {
+        // no backdrop on embeds
+    }
+
+    func present(viewController: UIViewController, completion: (() -> Void)?) throws {
+        let experienceRenderer = appcues?.container.resolve(ExperienceRendering.self)
+
+        self.embedView = experienceRenderer?.owner(forContext: .embed(frameID: frameID)) as? AppcuesFrame
+
+        guard let embedView = embedView else {
+            throw AppcuesTraitError(description: "No embed view with ID \(frameID) found")
+        }
+
+        // TODO: replace the old content if the experience is different?
+        guard embedView.subviews.isEmpty else {
+            throw AppcuesTraitError(description: "Embed view \(frameID) already in use")
+        }
+
+        let margins = NSDirectionalEdgeInsets(
+            top: style?.marginTop ?? 0,
+            leading: style?.marginLeading ?? 0,
+            bottom: style?.marginBottom ?? 0,
+            trailing: style?.marginTrailing ?? 0
+        )
+
+        embedView.embed(viewController, margins: margins, animated: animated, completion: completion)
+    }
+
+    func remove(viewController: UIViewController, completion: (() -> Void)?) {
+        embedView?.unembed(viewController, animated: animated, completion: completion)
+    }
+
+    private func applyStyle(_ style: ExperienceComponent.Style?, to container: UIViewController) {
+        container.view.backgroundColor = UIColor(dynamicColor: style?.backgroundColor)
+        container.view.layer.cornerRadius = style?.cornerRadius ?? 0
+        container.view.layer.borderColor = UIColor(dynamicColor: style?.borderColor)?.cgColor
+        if let borderWidth = CGFloat(style?.borderWidth) {
+            container.view.layer.borderWidth = borderWidth
+            container.view.layoutMargins = UIEdgeInsets(
+                top: borderWidth,
+                left: borderWidth,
+                bottom: borderWidth,
+                right: borderWidth
+            )
+        }
+    }
+
+}

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -22,6 +22,7 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     private let buttonAppearance: ButtonAppearance
     private let ignoreBackdropTap: Bool
@@ -33,6 +34,7 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        self.renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         self.buttonAppearance = config?.buttonAppearance ?? .default
@@ -78,7 +80,7 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
         guard let appcues = appcues else { return }
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
-        experienceRenderer.dismissCurrentExperience(markComplete: false, completion: nil)
+        experienceRenderer.dismiss(inContext: renderContext, markComplete: false, completion: nil)
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -24,6 +24,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     private let tapActions: [Experience.Action]
     private let longPressActions: [Experience.Action]
@@ -37,6 +38,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        self.renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         let actions = config?.actions ?? []
@@ -95,6 +97,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
         actionRegistry.enqueue(
             actionModels: tapActions,
             level: .step,
+            renderContext: renderContext,
             interactionType: "Target Tapped",
             viewDescription: "Target Rectangle"
         )
@@ -109,6 +112,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
         actionRegistry.enqueue(
             actionModels: longPressActions,
             level: .step,
+            renderContext: renderContext,
             interactionType: "Target Long Pressed",
             viewDescription: "Target Rectangle"
         )

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -38,25 +38,41 @@ internal class TraitComposer: TraitComposing {
         }
 
         // Start with experience-level traits
-        let decomposedTraits = DecomposedTraits(traits: traitRegistry.instances(for: experience.traits, level: .experience))
+        let decomposedTraits = DecomposedTraits(traits: traitRegistry.instances(
+            for: experience.traits,
+            level: .experience,
+            renderContext: experience.renderContext
+        ))
         var allTraitInstances = decomposedTraits.allTraitInstances
 
         // Add step-group-level traits and top-level-step traits
         switch experience.steps[stepIndex.group] {
         case .group(let stepGroup):
-            let decomposedGroupTraits = DecomposedTraits(traits: traitRegistry.instances(for: stepGroup.traits, level: .group))
+            let decomposedGroupTraits = DecomposedTraits(traits: traitRegistry.instances(
+                for: stepGroup.traits,
+                level: .group,
+                renderContext: experience.renderContext
+            ))
             decomposedTraits.append(contentsOf: decomposedGroupTraits)
             allTraitInstances.append(contentsOf: decomposedGroupTraits.allTraitInstances)
         case .child(let childStep):
             // Decorator traits and allTraitInstances for a single step are handled below with the stepModels.
             decomposedTraits.append(
-                contentsOf: DecomposedTraits(traits: traitRegistry.instances(for: childStep.traits, level: .step)),
+                contentsOf: DecomposedTraits(traits: traitRegistry.instances(
+                    for: childStep.traits,
+                    level: .step,
+                    renderContext: experience.renderContext
+                )),
                 ignoringDecorators: true
             )
         }
 
         let stepModelsWithTraits: [(step: Experience.Step.Child, decomposedTraits: DecomposedTraits)] = stepModels.map { stepModel in
-            let decomposedStepTraits = DecomposedTraits(traits: traitRegistry.instances(for: stepModel.traits, level: .step))
+            let decomposedStepTraits = DecomposedTraits(traits: traitRegistry.instances(
+                for: stepModel.traits,
+                level: .step,
+                renderContext: experience.renderContext
+            ))
             decomposedStepTraits.propagateDecorators(from: decomposedTraits)
             allTraitInstances.append(contentsOf: decomposedStepTraits.allTraitInstances)
             return (stepModel, decomposedStepTraits)
@@ -67,7 +83,7 @@ internal class TraitComposer: TraitComposing {
         allTraitInstances.forEach { $0.metadataDelegate = metadataDelegate }
 
         let stepControllers: [ExperienceStepViewController] = try stepModelsWithTraits.map {
-            let viewModel = ExperienceStepViewModel(step: $0.step, actionRegistry: actionRegistry)
+            let viewModel = ExperienceStepViewModel(step: $0.step, actionRegistry: actionRegistry, renderContext: experience.renderContext)
             let stepViewController = ExperienceStepViewController(
                 viewModel: viewModel,
                 stepState: experience.state(for: $0.step.id),

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -44,10 +44,19 @@ internal class TraitRegistry {
         traits[trait.type] = trait
     }
 
-    func instances(for models: [Experience.Trait], level: AppcuesExperiencePluginConfiguration.Level) -> [AppcuesExperienceTrait] {
+    func instances(
+        for models: [Experience.Trait],
+        level: AppcuesExperiencePluginConfiguration.Level,
+        renderContext: RenderContext
+    ) -> [AppcuesExperienceTrait] {
         models.compactMap { traitModel in
             traits[traitModel.type]?.init(
-                configuration: AppcuesExperiencePluginConfiguration(traitModel.configDecoder, level: level, appcues: appcues)
+                configuration: AppcuesExperiencePluginConfiguration(
+                    traitModel.configDecoder,
+                    level: level,
+                    renderContext: renderContext,
+                    appcues: appcues
+                )
             )
         }
     }

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -29,6 +29,7 @@ internal class TraitRegistry {
         register(trait: AppcuesTargetElementTrait.self)
         register(trait: AppcuesBackdropKeyholeTrait.self)
         register(trait: AppcuesTargetInteractionTrait.self)
+        register(trait: AppcuesEmbeddedTrait.self)
     }
 
     func register(trait: AppcuesExperienceTrait.Type) {

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
@@ -1,0 +1,128 @@
+//
+//  AppcuesFrame.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 8/18/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import UIKit
+
+public class AppcuesFrame: UIView, StateMachineOwning {
+    private var _stateMachine: Any?
+    @available(iOS 13.0, *)
+    internal var stateMachine: ExperienceStateMachine? {
+        get {
+            _stateMachine as? ExperienceStateMachine
+        }
+        set {
+            _stateMachine = newValue
+        }
+    }
+
+    private weak var parentViewController: UIViewController?
+
+    // when the view content is empty, we use this zero height constraint
+    private lazy var emptyHeightConstraint: NSLayoutConstraint = {
+        var constraint = heightAnchor.constraint(equalToConstant: 0)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    // when the view content is non-empty, we use a >= 1 height constraint to allow for dynamic
+    // sizing based on the content
+    private lazy var nonEmptyHeightConstraint: NSLayoutConstraint = {
+        var constraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 1)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    // when the view content is empty, we use this zero width constraint
+    private lazy var emptyWidthConstraint: NSLayoutConstraint = {
+        var constraint = widthAnchor.constraint(equalToConstant: 0)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    // when the view content is non-empty, we use a >= 1 width constraint to allow for dynamic
+    // sizing based on the content
+    private lazy var nonEmptyWidthConstraint: NSLayoutConstraint = {
+        var constraint = widthAnchor.constraint(greaterThanOrEqualToConstant: 1)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        isHidden = true
+        configureConstraints(isEmpty: true)
+    }
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        isHidden = true
+        configureConstraints(isEmpty: true)
+    }
+
+    private func configureConstraints(isEmpty: Bool) {
+        emptyHeightConstraint.isActive = isEmpty
+        nonEmptyHeightConstraint.isActive = !isEmpty
+        emptyWidthConstraint.isActive = isEmpty
+        nonEmptyWidthConstraint.isActive = !isEmpty
+    }
+
+    // this will only get called on iOS 13+ from the Appcues class during registration
+    internal func configure(parentViewController: UIViewController) {
+        self.parentViewController = parentViewController
+    }
+
+    internal func embed(_ experienceController: UIViewController, margins: NSDirectionalEdgeInsets, animated: Bool, completion: (() -> Void)?) {
+        guard let viewController = parentViewController else { return }
+
+        configureConstraints(isEmpty: false)
+
+        viewController.embedChildViewController(experienceController, inSuperview: self, margins: margins)
+
+        if animated {
+            UIView.animate(
+                withDuration: 0.3,
+                animations: {
+                    // possibly have a delegate for these embeds that would allow the host app to have more control over this?
+                    self.isHidden = false
+                },
+                completion: { _ in
+                    completion?()
+                }
+            )
+        } else {
+            isHidden = false
+            completion?()
+        }
+    }
+
+    internal func unembed(_ experienceController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        if animated {
+            UIView.animate(
+                withDuration: 0.3,
+                animations: {
+                    // possibly have a delegate for these embeds that would allow the host app to have more control over this?
+                    self.isHidden = true
+                },
+                completion: { _ in
+                    self.parentViewController?.unembedChildViewController(experienceController)
+                    self.configureConstraints(isEmpty: true)
+                    completion?()
+                }
+            )
+        } else {
+            isHidden = true
+            parentViewController?.unembedChildViewController(experienceController)
+            configureConstraints(isEmpty: true)
+            completion?()
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -19,8 +19,9 @@ internal class ExperienceStepViewModel: ObservableObject {
     let step: Experience.Step.Child
     private let actions: [UUID: [Experience.Action]]
     private let actionRegistry: ActionRegistry?
+    private let renderContext: RenderContext
 
-    init(step: Experience.Step.Child, actionRegistry: ActionRegistry) {
+    init(step: Experience.Step.Child, actionRegistry: ActionRegistry, renderContext: RenderContext) {
         self.step = step
         // Update the action list to be keyed by the UUID.
         self.actions = step.actions.reduce(into: [:]) { dict, item in
@@ -28,10 +29,11 @@ internal class ExperienceStepViewModel: ObservableObject {
             dict[uuidKey] = item.value
         }
         self.actionRegistry = actionRegistry
+        self.renderContext = renderContext
     }
 
     // Create an empty view model for contexts that require an `ExperienceStepViewModel` but aren't in a step context.
-    init() {
+    init(renderContext: RenderContext) {
         self.step = Experience.Step.Child(
             id: UUID(),
             type: "",
@@ -45,12 +47,14 @@ internal class ExperienceStepViewModel: ObservableObject {
         )
         self.actions = [:]
         self.actionRegistry = nil
+        self.renderContext = renderContext
     }
 
     func enqueueActions(_ actions: [Experience.Action], type: String, viewDescription: String?) {
         actionRegistry?.enqueue(
             actionModels: actions,
             level: .step,
+            renderContext: renderContext,
             interactionType: type,
             viewDescription: viewDescription
         )


### PR DESCRIPTION
Revisiting #415... This branch is off of the `2.1.0` tag and so ignores the changes from #415 (hence the merge conflict) to make it easier to see what's changing in ExperienceRenderer, since lots of things are closer the way they were. The second commit here is the POC embed view stuff, included here so you can see why everything is needed and how it all works.

Yesterday I merged my PR for multiple state machines, but I think what we need instead of a state machine associated with an embed experience, is a state machine associated with an embed frame. I'm putting this here now so we can review the approach before I finish off the details and split it into appropriately reviewable chunks.

To start, all the places from #415 that used `InstanceID` are now using `RenderContext`. Then the idea is that the `ExperienceRenderer` holds a dictionary `var stateMachines = [RenderContext: ExperienceStateMachine]`. How it's ended up though is there's a `StateMachineDirectory`.

### About `StateMachineDirectory`

One of the tricky things is how we tie the memory lifecycle of state machine for an embed to an `AppcuesFrame`. My solution is that the frame holds the only strong reference to the state machine. That would mean we'd want a dictionary like `[RenderContext: AppcuesFrame]`, and then we'd do something like, `stateMachines[context]?.stateMachine`.

However, that's oddly coupled to the implementation of embeds, and what about the main modal state machine. My solution here is to introduce a `StateMachineOwning` protocol that `AppcuesFrame` conforms to, as well as `ExperienceRenderer` to hold the modal state machine. So that leaves us with `[RenderContext: StateMachineOwning]`.

But doing that means we have a retain cycle on `ExperienecRenderer` and strong references to `AppcuesFrame`, both of which we don't want, so `StateMachineDirectory` actually uses `[RenderContext: WeakStateMachineOwning]`. The weak wrapper pattern is what we already use for `AnalyticsDecorating` and `AnalyticsSubscribing`.

`StateMachineDirectory` uses subscripts to make it easy for `ExperienceRenderer` to just get/set the stateMachine instances it cares about without having to worry about all the details above.

### Experience caching

This isn't fully fleshed out yet, but there's `potentiallyRenderableExperiences: [RenderContext: [ExperienceData]]`. When the new `ExperienceRendering.processAndShow()` method is called, it groups the experiences by `RenderContext` and saves them to `potentiallyRenderableExperiences`. Then for each `RenderContext` key in that dictionary, we try showing the content, removing the key if it succeeded.

The cool thing here is `ExperienceRenderer` doesn't need to worry about modal or non-modal, it just tries to show the list of experiences it's given.

### How it all connects

When an embed is registered in `Appcues`, it calls `ExperienceRenderer` which spins up a state machine and checks if there's any cached content to try showing. Alternatively, if the embed is already registered and we qualify for content, we try showing using the state machine that already exists.

The state machine tries to present using the `AppcuesEmbeddedTrait` which looks up the `StateMachineOwning` instance matching its `frameID` (which, recall, is the `AppcuesFrame`), and then does what it did in the POC.

When an `AppcuesFrame` is removed from memory (ie its VC is dismissed), the weak reference in `StateMachineDirectory` is lost clearer. Additionally, the state machine that it owned is deinited. I periodically call `cleanup()` to remove these `nil` references, but in general the lifecycle is coupled exactly how we'd want.

### Tricky bits remaining

Right now the `ExperienceRenderer` is only called by `AnalyticsTracker` if there's content to show. That means there's not a proper way for `ExperienceRenderer` to clear its content cache on a `screen_view`. We'll have to add a new method to do that.