### PR TITLE
Refactor ExperienceRenderer to support multiple ExperienceStateMachine instances

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -94,28 +94,20 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
         activityProcessor.process(activity) { [weak self] result in
             switch result {
             case .success(let qualifyResponse):
-                if !qualifyResponse.experiences.isEmpty {
-                    if #available(iOS 13.0, *) {
-                        let experienceRenderer = self?.container?.resolve(ExperienceRendering.self)
-                        experienceRenderer?.processAndShow(
-                            qualifiedExperiences: self?.process(qualifyResponse: qualifyResponse, activity: activity) ?? [],
-                            reason: .qualification(reason: qualifyResponse.qualificationReason)
-                        )
-                    } else {
-                        self?.config.logger.info("iOS 13 or above is required to render an Appcues experience")
-                        // nothing will render, we can remove tracking
+                if #available(iOS 13.0, *) {
+                    let experienceRenderer = self?.container?.resolve(ExperienceRendering.self)
+                    experienceRenderer?.processAndShow(
+                        qualifiedExperiences: self?.process(qualifyResponse: qualifyResponse, activity: activity) ?? [],
+                        reason: .qualification(reason: qualifyResponse.qualificationReason)
+                    )
+
+                    if qualifyResponse.experiences.isEmpty {
+                        // common case, nothing qualified - we know there was nothing to render, so just remove tracking
                         SdkMetrics.remove(activity.requestID)
                     }
                 } else {
-                    if #available(iOS 13.0, *) {
-                        let experienceRenderer = self?.container?.resolve(ExperienceRendering.self)
-                        experienceRenderer?.processAndShow(
-                            qualifiedExperiences: [],
-                            reason: .qualification(reason: qualifyResponse.qualificationReason)
-                        )
-                    }
-
-                    // common case, nothing qualified - we know there was nothing to render, so just remove tracking
+                    self?.config.logger.info("iOS 13 or above is required to render an Appcues experience")
+                    // nothing will render, we can remove tracking
                     SdkMetrics.remove(activity.requestID)
                 }
             case .failure(let error):

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -48,7 +48,8 @@ internal struct FailedExperience: Decodable {
             traits: [],
             steps: [],
             redirectURL: nil,
-            nextContentID: nil
+            nextContentID: nil,
+            renderContext: .modal
         )
     }
 }
@@ -146,6 +147,8 @@ internal struct Experience {
 
     /// Unique ID to disambiguate the same experience flowing through the system from different origins.
     let instanceID = UUID()
+
+    let renderContext: RenderContext
 }
 
 extension Experience: Decodable {
@@ -170,6 +173,7 @@ extension Experience: Decodable {
         steps = try container.decode([Step].self, forKey: .steps)
         redirectURL = try? container.decode(URL.self, forKey: .redirectURL)
         nextContentID = try? container.decode(String.self, forKey: .nextContentID)
+        renderContext = .modal
     }
 }
 
@@ -187,6 +191,7 @@ extension Experience {
             if let nextContentID = nextContentID {
                 actions.append(AppcuesLaunchExperienceAction(
                     appcues: appcues,
+                    renderContext: self.renderContext,
                     experienceID: nextContentID,
                     trigger: .experienceCompletionAction(fromExperienceID: self.id)
                 ))

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -65,9 +65,19 @@ internal class ActionRegistry {
 
     /// Enqueue an array of experience action data models to be executed. This version is for non-interactive action execution,
     /// such as actions that execute as part of the navigation to a step.
-    func enqueue(actionModels: [Experience.Action], level: AppcuesExperiencePluginConfiguration.Level, completion: @escaping () -> Void) {
+    func enqueue(
+        actionModels: [Experience.Action],
+        level: AppcuesExperiencePluginConfiguration.Level,
+        renderContext: RenderContext,
+        completion: @escaping () -> Void
+    ) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level, appcues: appcues))
+            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration(
+                $0.configDecoder,
+                level: level,
+                renderContext: renderContext,
+                appcues: appcues
+            ))
         }
         execute(transformQueue(actionInstances), completion: completion)
     }
@@ -84,11 +94,17 @@ internal class ActionRegistry {
     func enqueue(
         actionModels: [Experience.Action],
         level: AppcuesExperiencePluginConfiguration.Level,
+        renderContext: RenderContext,
         interactionType: String,
         viewDescription: String?
     ) {
         let actionInstances = actionModels.compactMap {
-            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration($0.configDecoder, level: level, appcues: appcues))
+            actions[$0.type]?.init(configuration: AppcuesExperiencePluginConfiguration(
+                $0.configDecoder,
+                level: level,
+                renderContext: renderContext,
+                appcues: appcues
+            ))
         }
 
         // As a heuristic, take the last action that's `InteractionLoggingAction`, since that's most likely
@@ -96,6 +112,7 @@ internal class ActionRegistry {
         let primaryAction = actionInstances.reversed().compactMapFirst { $0 as? InteractionLoggingAction }
         let interactionAction = AppcuesStepInteractionAction(
             appcues: appcues,
+            renderContext: renderContext,
             interactionType: interactionType,
             viewDescription: viewDescription ?? "",
             category: primaryAction?.category ?? "",

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
@@ -18,11 +18,13 @@ internal class AppcuesCloseAction: AppcuesExperienceAction {
     static let type = "@appcues/close"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     private let markComplete: Bool
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         appcues = configuration.appcues
+        renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         markComplete = config?.markComplete ?? false
@@ -32,6 +34,6 @@ internal class AppcuesCloseAction: AppcuesExperienceAction {
         guard let appcues = appcues else { return completion() }
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
-        experienceRenderer.dismissCurrentExperience(markComplete: markComplete) { _ in completion() }
+        experienceRenderer.dismiss(inContext: renderContext, markComplete: markComplete) { _ in completion() }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
@@ -19,11 +19,13 @@ internal class AppcuesContinueAction: AppcuesExperienceAction {
     static let type = "@appcues/continue"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let stepReference: StepReference
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         appcues = configuration.appcues
+        renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         if let index = config?.index {
@@ -42,6 +44,6 @@ internal class AppcuesContinueAction: AppcuesExperienceAction {
         guard let appcues = appcues else { return completion() }
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
-        experienceRenderer.show(stepInCurrentExperience: stepReference, completion: completion)
+        experienceRenderer.show(step: stepReference, inContext: renderContext, completion: completion)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -17,20 +17,23 @@ internal class AppcuesLaunchExperienceAction: AppcuesExperienceAction {
     static let type = "@appcues/launch-experience"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let experienceID: String
     private let trigger: ExperienceTrigger?
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        self.renderContext = configuration.renderContext
 
         guard let config = configuration.decode(Config.self) else { return nil }
         self.experienceID = config.experienceID
         self.trigger = nil
     }
 
-    init(appcues: Appcues?, experienceID: String, trigger: ExperienceTrigger) {
+    init(appcues: Appcues?, renderContext: RenderContext, experienceID: String, trigger: ExperienceTrigger) {
         self.appcues = appcues
+        self.renderContext = renderContext
         self.experienceID = experienceID
 
         // This is used when a flow is triggered as a post flow action from another flow.
@@ -57,7 +60,7 @@ internal class AppcuesLaunchExperienceAction: AppcuesExperienceAction {
 
     private func launchExperienceTrigger(_ appcues: Appcues) -> ExperienceTrigger {
         let experienceRendering = appcues.container.resolve(ExperienceRendering.self)
-        let currentExperienceId = experienceRendering.getCurrentExperienceData()?.id
+        let currentExperienceId = experienceRendering.experienceData(forContext: renderContext)?.id
         return .launchExperienceAction(fromExperienceID: currentExperienceId)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
@@ -15,6 +15,7 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
     static let type = "@appcues/step_interaction"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let interactionType: String
     let viewDescription: String
@@ -26,8 +27,9 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
         return nil
     }
 
-    init(appcues: Appcues?, interactionType: String, viewDescription: String, category: String, destination: String) {
+    init(appcues: Appcues?, renderContext: RenderContext, interactionType: String, viewDescription: String, category: String, destination: String) {
         self.appcues = appcues
+        self.renderContext = renderContext
         self.interactionType = interactionType
         self.viewDescription = viewDescription
         self.category = category
@@ -49,8 +51,8 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
             ]
         ]
 
-        if let experienceData = experienceRenderer.getCurrentExperienceData(),
-           let stepIndex = experienceRenderer.getCurrentStepIndex() {
+        if let experienceData = experienceRenderer.experienceData(forContext: renderContext),
+           let stepIndex = experienceRenderer.stepIndex(forContext: renderContext) {
             interactionProperties = LifecycleEvent.properties(experienceData, stepIndex).merging(interactionProperties)
         }
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -17,11 +17,13 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
     static let type = "@appcues/submit-form"
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     let skipValidation: Bool
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         self.skipValidation = config?.skipValidation ?? false
@@ -37,8 +39,8 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
         let analyticsPublisher = appcues.container.resolve(AnalyticsPublishing.self)
 
-        guard let experienceData = experienceRenderer.getCurrentExperienceData(),
-              let stepIndex = experienceRenderer.getCurrentStepIndex(),
+        guard let experienceData = experienceRenderer.experienceData(forContext: renderContext),
+              let stepIndex = experienceRenderer.stepIndex(forContext: renderContext),
               let stepState = experienceData.state(for: stepIndex) else { return }
 
         let interactionProperties = LifecycleEvent.properties(experienceData, stepIndex).merging([
@@ -66,8 +68,8 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
 
-        guard let experienceData = experienceRenderer.getCurrentExperienceData(),
-              let stepIndex = experienceRenderer.getCurrentStepIndex(),
+        guard let experienceData = experienceRenderer.experienceData(forContext: renderContext),
+              let stepIndex = experienceRenderer.stepIndex(forContext: renderContext),
               let stepState = experienceData.state(for: stepIndex) else { return queue }
 
         if stepState.stepFormIsComplete {

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -151,8 +151,8 @@ extension UIDebugger: DebugViewDelegate {
     }
 
     private func captureScreen(authorization: Authorization) {
-        guard experienceRenderer.getCurrentExperienceData() == nil else {
-            experienceRenderer.dismissCurrentExperience(markComplete: false) { _ in
+        guard experienceRenderer.experienceData(forContext: .modal) == nil else {
+            experienceRenderer.dismiss(inContext: .modal, markComplete: false) { _ in
                 self.captureScreen(authorization: authorization)
             }
             return

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -223,7 +223,7 @@ extension ExperienceStateMachine {
             case .continuation(let action):
                 try machine.transition(action)
             case let .presentContainer(experience, stepIndex, package, actions):
-                machine.actionRegistry.enqueue(actionModels: actions, level: .group) {
+                machine.actionRegistry.enqueue(actionModels: actions, level: .group, renderContext: experience.renderContext) {
                     executePresentContainer(
                         machine: machine,
                         experience: experience,

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal enum ExperienceTrigger {
+internal enum ExperienceTrigger: Equatable {
     case qualification(reason: QualifyResponse.QualificationReason?)
     case experienceCompletionAction(fromExperienceID: UUID?)
     case launchExperienceAction(fromExperienceID: UUID?)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
@@ -1,0 +1,53 @@
+//
+//  StateMachineDirectory.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-06-15.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal protocol StateMachineOwning: AnyObject {
+    @available(iOS 13.0, *)
+    var stateMachine: ExperienceStateMachine? { get set }
+}
+
+// This class is intended to work like a `Dictionary<RenderContext, StateMachineOwning?>`,
+// while abstracting away the fact that it weakly references the value.
+@available(iOS 13.0, *)
+internal class StateMachineDirectory {
+    private var stateMachines: [RenderContext: WeakStateMachineOwning] = [:]
+
+    func cleanup() {
+        stateMachines = stateMachines.filter { _, weakRef in weakRef.value != nil }
+    }
+
+    func owner(forContext context: RenderContext) -> StateMachineOwning? {
+        stateMachines[context]?.value
+    }
+
+    /// Get the `ExperienceStateMachine` associated with the specified key.
+    subscript (_ key: RenderContext) -> ExperienceStateMachine? {
+        stateMachines[key]?.value?.stateMachine
+    }
+
+    subscript (ownerFor key: RenderContext) -> StateMachineOwning? {
+        get {
+            stateMachines[key]?.value
+        }
+        set(newValue) {
+            stateMachines[key] = WeakStateMachineOwning(newValue)
+        }
+    }
+
+}
+
+@available(iOS 13.0, *)
+private extension StateMachineDirectory {
+    class WeakStateMachineOwning {
+        weak var value: StateMachineOwning?
+
+        init (_ wrapping: StateMachineOwning?) { self.value = wrapping }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
@@ -31,9 +31,12 @@ public class AppcuesExperiencePluginConfiguration: NSObject {
     /// The instance of the Appcues SDK where the plugin is being applied.
     public weak var appcues: Appcues?
 
-    init(_ decoder: PluginDecoder, level: Level, appcues: Appcues?) {
+    internal let renderContext: RenderContext
+
+    init(_ decoder: PluginDecoder, level: Level, renderContext: RenderContext, appcues: Appcues?) {
         self.decoder = decoder
         self.level = level
+        self.renderContext = renderContext
         self.appcues = appcues
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -18,12 +18,16 @@ internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, Appcue
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
+    private let renderContext: RenderContext
+
     private let level: AppcuesExperiencePluginConfiguration.Level
     private let content: ExperienceComponent
 
     private weak var backgroundViewController: UIViewController?
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
+        self.renderContext = configuration.renderContext
+
         guard let config = configuration.decode(Config.self) else { return nil }
 
         self.level = configuration.level
@@ -42,7 +46,7 @@ internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, Appcue
     func decorate(containerController: AppcuesExperienceContainerViewController) throws {
         guard level == .group || level == .experience else { return }
 
-        let emptyViewModel = ExperienceStepViewModel()
+        let emptyViewModel = ExperienceStepViewModel(renderContext: renderContext)
 
         backgroundViewController = applyBackground(with: emptyViewModel, parent: containerController)
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -22,6 +22,7 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     private let buttonAppearance: ButtonAppearance
     private let ignoreBackdropTap: Bool
@@ -33,6 +34,7 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        self.renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         self.buttonAppearance = config?.buttonAppearance ?? .default
@@ -78,7 +80,7 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
         guard let appcues = appcues else { return }
 
         let experienceRenderer = appcues.container.resolve(ExperienceRendering.self)
-        experienceRenderer.dismissCurrentExperience(markComplete: false, completion: nil)
+        experienceRenderer.dismiss(inContext: renderContext, markComplete: false, completion: nil)
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -24,6 +24,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
     private weak var appcues: Appcues?
+    private let renderContext: RenderContext
 
     private let tapActions: [Experience.Action]
     private let longPressActions: [Experience.Action]
@@ -37,6 +38,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
+        self.renderContext = configuration.renderContext
 
         let config = configuration.decode(Config.self)
         let actions = config?.actions ?? []
@@ -95,6 +97,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
         actionRegistry.enqueue(
             actionModels: tapActions,
             level: .step,
+            renderContext: renderContext,
             interactionType: "Target Tapped",
             viewDescription: "Target Rectangle"
         )
@@ -109,6 +112,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
         actionRegistry.enqueue(
             actionModels: longPressActions,
             level: .step,
+            renderContext: renderContext,
             interactionType: "Target Long Pressed",
             viewDescription: "Target Rectangle"
         )

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -38,25 +38,41 @@ internal class TraitComposer: TraitComposing {
         }
 
         // Start with experience-level traits
-        let decomposedTraits = DecomposedTraits(traits: traitRegistry.instances(for: experience.traits, level: .experience))
+        let decomposedTraits = DecomposedTraits(traits: traitRegistry.instances(
+            for: experience.traits,
+            level: .experience,
+            renderContext: experience.renderContext
+        ))
         var allTraitInstances = decomposedTraits.allTraitInstances
 
         // Add step-group-level traits and top-level-step traits
         switch experience.steps[stepIndex.group] {
         case .group(let stepGroup):
-            let decomposedGroupTraits = DecomposedTraits(traits: traitRegistry.instances(for: stepGroup.traits, level: .group))
+            let decomposedGroupTraits = DecomposedTraits(traits: traitRegistry.instances(
+                for: stepGroup.traits,
+                level: .group,
+                renderContext: experience.renderContext
+            ))
             decomposedTraits.append(contentsOf: decomposedGroupTraits)
             allTraitInstances.append(contentsOf: decomposedGroupTraits.allTraitInstances)
         case .child(let childStep):
             // Decorator traits and allTraitInstances for a single step are handled below with the stepModels.
             decomposedTraits.append(
-                contentsOf: DecomposedTraits(traits: traitRegistry.instances(for: childStep.traits, level: .step)),
+                contentsOf: DecomposedTraits(traits: traitRegistry.instances(
+                    for: childStep.traits,
+                    level: .step,
+                    renderContext: experience.renderContext
+                )),
                 ignoringDecorators: true
             )
         }
 
         let stepModelsWithTraits: [(step: Experience.Step.Child, decomposedTraits: DecomposedTraits)] = stepModels.map { stepModel in
-            let decomposedStepTraits = DecomposedTraits(traits: traitRegistry.instances(for: stepModel.traits, level: .step))
+            let decomposedStepTraits = DecomposedTraits(traits: traitRegistry.instances(
+                for: stepModel.traits,
+                level: .step,
+                renderContext: experience.renderContext
+            ))
             decomposedStepTraits.propagateDecorators(from: decomposedTraits)
             allTraitInstances.append(contentsOf: decomposedStepTraits.allTraitInstances)
             return (stepModel, decomposedStepTraits)
@@ -67,7 +83,7 @@ internal class TraitComposer: TraitComposing {
         allTraitInstances.forEach { $0.metadataDelegate = metadataDelegate }
 
         let stepControllers: [ExperienceStepViewController] = try stepModelsWithTraits.map {
-            let viewModel = ExperienceStepViewModel(step: $0.step, actionRegistry: actionRegistry)
+            let viewModel = ExperienceStepViewModel(step: $0.step, actionRegistry: actionRegistry, renderContext: experience.renderContext)
             let stepViewController = ExperienceStepViewController(
                 viewModel: viewModel,
                 stepState: experience.state(for: $0.step.id),

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -44,10 +44,19 @@ internal class TraitRegistry {
         traits[trait.type] = trait
     }
 
-    func instances(for models: [Experience.Trait], level: AppcuesExperiencePluginConfiguration.Level) -> [AppcuesExperienceTrait] {
+    func instances(
+        for models: [Experience.Trait],
+        level: AppcuesExperiencePluginConfiguration.Level,
+        renderContext: RenderContext
+    ) -> [AppcuesExperienceTrait] {
         models.compactMap { traitModel in
             traits[traitModel.type]?.init(
-                configuration: AppcuesExperiencePluginConfiguration(traitModel.configDecoder, level: level, appcues: appcues)
+                configuration: AppcuesExperiencePluginConfiguration(
+                    traitModel.configDecoder,
+                    level: level,
+                    renderContext: renderContext,
+                    appcues: appcues
+                )
             )
         }
     }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -19,8 +19,9 @@ internal class ExperienceStepViewModel: ObservableObject {
     let step: Experience.Step.Child
     private let actions: [UUID: [Experience.Action]]
     private let actionRegistry: ActionRegistry?
+    private let renderContext: RenderContext
 
-    init(step: Experience.Step.Child, actionRegistry: ActionRegistry) {
+    init(step: Experience.Step.Child, actionRegistry: ActionRegistry, renderContext: RenderContext) {
         self.step = step
         // Update the action list to be keyed by the UUID.
         self.actions = step.actions.reduce(into: [:]) { dict, item in
@@ -28,10 +29,11 @@ internal class ExperienceStepViewModel: ObservableObject {
             dict[uuidKey] = item.value
         }
         self.actionRegistry = actionRegistry
+        self.renderContext = renderContext
     }
 
     // Create an empty view model for contexts that require an `ExperienceStepViewModel` but aren't in a step context.
-    init() {
+    init(renderContext: RenderContext) {
         self.step = Experience.Step.Child(
             id: UUID(),
             type: "",
@@ -45,12 +47,14 @@ internal class ExperienceStepViewModel: ObservableObject {
         )
         self.actions = [:]
         self.actionRegistry = nil
+        self.renderContext = renderContext
     }
 
     func enqueueActions(_ actions: [Experience.Action], type: String, viewDescription: String?) {
         actionRegistry?.enqueue(
             actionModels: actions,
             level: .step,
+            renderContext: renderContext,
             interactionType: type,
             viewDescription: viewDescription
         )

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -36,6 +36,7 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.enqueue(
             actionModels: [actionModel],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
         waitForExpectations(timeout: 1)
@@ -58,6 +59,7 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.enqueue(
             actionModels: [actionModel],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
         waitForExpectations(timeout: 1)
@@ -84,6 +86,7 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.enqueue(
             actionModels: [actionModel],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
         waitForExpectations(timeout: 1)
@@ -104,6 +107,7 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.enqueue(
             actionModels: [actionModel, actionModel, actionModel, actionModel, actionModel],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -132,6 +136,7 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.enqueue(
             actionModels: [delayedActionModel],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -139,6 +144,7 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.enqueue(
             actionModels: [actionModel, actionModel, actionModel, actionModel],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "Another Button")
 
@@ -166,6 +172,7 @@ class ActionRegistryTests: XCTestCase {
         actionRegistry.enqueue(
             actionModels: [actionModel, actionModel, actionModel2, actionModel, actionModel],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 

--- a/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
@@ -31,7 +31,7 @@ class AppcuesCloseActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var dismissCount = 0
-        appcues.experienceRenderer.onDismissCurrentExperience = { markComplete, completion in
+        appcues.experienceRenderer.onDismiss = { _, markComplete, completion in
             XCTAssertFalse(markComplete)
             dismissCount += 1
             completion?(.success(()))
@@ -50,7 +50,7 @@ class AppcuesCloseActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var dismissCount = 0
-        appcues.experienceRenderer.onDismissCurrentExperience = { markComplete, completion in
+        appcues.experienceRenderer.onDismiss = { _, markComplete, completion in
             XCTAssertTrue(markComplete)
             dismissCount += 1
             completion?(.success(()))

--- a/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
@@ -62,7 +62,7 @@ class AppcuesContinueActionTests: XCTestCase {
         // Arrange
         var completionCount = 0
         var showStepCount = 0
-        appcues.experienceRenderer.onShowStep = { stepRef, completion in
+        appcues.experienceRenderer.onShowStep = { stepRef, _, completion in
             if case .offset(1) = stepRef {
                 showStepCount += 1
             }

--- a/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
@@ -32,10 +32,10 @@ class AppcuesStepInteractionActionTests: XCTestCase {
         // Arrange
         var mostRecentUpdate: TrackingUpdate?
 
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mock
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             .initial
         }
 
@@ -54,6 +54,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                     config: AppcuesTrackAction.Config(eventName: "Some event"))
             ],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -96,6 +97,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                     config: AppcuesTrackAction.Config(eventName: "Some event"))
             ],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -130,6 +132,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                     config: AppcuesLinkAction.Config(url: URL(string: "https://appcues.com")!, openExternally: nil))
             ],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -164,6 +167,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                     config: AppcuesLaunchExperienceAction.Config(experienceID: "c1d5336f-6416-4805-9e82-4073c9b8cdb8"))
             ],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -194,6 +198,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                     config: AppcuesCloseAction.Config(markComplete: true))
             ],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -224,6 +229,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                     config: AppcuesContinueAction.Config(index: nil, offset: nil, stepID: UUID(uuidString: "c1ba5af5-df15-4e38-834b-c7c33ee91e44")))
             ],
             level: .step,
+            renderContext: .modal,
             interactionType: "Button Tapped",
             viewDescription: "My Button")
 
@@ -243,7 +249,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
     func testExecuteCompletesWithoutAppcuesInstance() throws {
         // Arrange
         var completionCount = 0
-        let action = try XCTUnwrap(AppcuesStepInteractionAction(appcues: nil, interactionType: "String", viewDescription: "String", category: "String", destination: "String"))
+        let action = try XCTUnwrap(AppcuesStepInteractionAction(appcues: nil, renderContext: .modal, interactionType: "String", viewDescription: "String", category: "String", destination: "String"))
 
         // Act
         action.execute(completion: { completionCount += 1 })

--- a/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
@@ -48,10 +48,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
         var completionCount = 0
         var updates: [TrackingUpdate] = []
 
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mockWithForm(defaultValue: "default value")
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             .initial
         }
         appcues.analyticsPublisher.onPublish = { trackingUpdate in
@@ -96,10 +96,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
         var completionCount = 0
         var updates: [TrackingUpdate] = []
 
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mockWithForm(defaultValue: nil)
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             // Invalid step index causes failure and early return
             Experience.StepIndex(group: 2, item: 2)
         }
@@ -132,10 +132,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
 
     func testTransformQueueEarlyReturn() throws {
         // Arrange
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mockWithForm(defaultValue: nil)
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             // Invalid step index causes failure and early return
             Experience.StepIndex(group: 2, item: 2)
         }
@@ -155,10 +155,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
 
     func testTransformQueueValidForm() throws {
         // Arrange
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mockWithForm(defaultValue: "123")
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             .initial
         }
 
@@ -177,10 +177,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
 
     func testTransformQueueInvalidForm() throws {
         // Arrange
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mockWithForm(defaultValue: nil)
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             .initial
         }
 
@@ -200,10 +200,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
 
     func testTransformQueueInvalidFormSkipValidation() throws {
         // Arrange
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mockWithForm(defaultValue: nil)
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             .initial
         }
 
@@ -228,10 +228,10 @@ class AppcuesSubmitFormActionTests: XCTestCase {
         // Arrange
         var updates: [TrackingUpdate] = []
 
-        appcues.experienceRenderer.onGetCurrentExperienceData = {
+        appcues.experienceRenderer.onExperienceData = { _ in
             ExperienceData.mockWithForm(defaultValue: "default value", attributeName: "myAttribute")
         }
-        appcues.experienceRenderer.onGetCurrentStepIndex = {
+        appcues.experienceRenderer.onStepIndex = { _ in
             .initial
         }
         appcues.analyticsPublisher.onPublish = { trackingUpdate in

--- a/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
@@ -46,7 +46,7 @@ class AppcuesUpdateProfileActionTests: XCTestCase {
 
         let action = try XCTUnwrap(JSONDecoder().decode(Experience.Action.self, from: modelData))
         let instance = try XCTUnwrap(AppcuesUpdateProfileAction(
-            configuration: AppcuesExperiencePluginConfiguration(action.configDecoder, level: .step, appcues: appcues)
+            configuration: AppcuesExperiencePluginConfiguration(action.configDecoder, level: .step, renderContext: .modal, appcues: appcues)
         ))
 
         XCTAssertEqual(instance.properties.count, 4)

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -366,7 +366,7 @@ class ActivityProcessorTests: XCTestCase {
         return Activity(accountID: "00000", userID: userID, events: [event], profileUpdate: nil, groupID: nil, groupUpdate: nil, userSignature: userSignature)
     }
 
-    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
+    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil, renderContext: .modal)
 
 }
 

--- a/Tests/AppcuesKitTests/ExperiencePluginConfiguration+Testable.swift
+++ b/Tests/AppcuesKitTests/ExperiencePluginConfiguration+Testable.swift
@@ -11,8 +11,8 @@ import XCTest
 @testable import AppcuesKit
 
 extension AppcuesExperiencePluginConfiguration {
-    convenience init(_ config: Any?, level: Level = .step, appcues: Appcues? = nil) {
-        self.init(FakePluginDecoder(config), level: level, appcues: appcues)
+    convenience init(_ config: Any?, level: Level = .step, context: RenderContext = .modal, appcues: Appcues? = nil) {
+        self.init(FakePluginDecoder(config), level: level, renderContext: context, appcues: appcues)
     }
 }
 

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -170,9 +170,8 @@ class ExperienceRendererTests: XCTestCase {
 
     func testShowQualifiedExperiences() throws {
         // Arrange
-        let completionExpectation = expectation(description: "Completion called")
-
         let presentExpectation = expectation(description: "Experience presented")
+
         let brokenExperience = ExperienceData.mock
         let validExperience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = validExperience.package(presentExpectation: presentExpectation)
@@ -190,14 +189,10 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(qualifiedExperiences: [
-            ExperienceData(brokenExperience.model, trigger: .qualification(reason: nil), priority: .low),
-            ExperienceData(validExperience.model, trigger: .qualification(reason: nil), priority: .low)]) { result in
-            print(result)
-            if case .success = result {
-                completionExpectation.fulfill()
-            }
-        }
+        experienceRenderer.processAndShow(qualifiedExperiences: [
+            ExperienceData(brokenExperience.model, trigger: .qualification(reason: .screenView), priority: .low),
+            ExperienceData(validExperience.model, trigger: .qualification(reason: .screenView), priority: .low)
+        ], reason: .qualification(reason: .screenView))
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -222,7 +217,7 @@ class ExperienceRendererTests: XCTestCase {
         let targetID = try XCTUnwrap(UUID(uuidString: "03652bd5-f0cb-44f0-9274-e95b4441d857"))
 
         // Act
-        experienceRenderer.show(stepInCurrentExperience: .stepID(targetID)) {
+        experienceRenderer.show(step: .stepID(targetID), inContext: .modal) {
             completionExpectation.fulfill()
         }
 
@@ -243,7 +238,7 @@ class ExperienceRendererTests: XCTestCase {
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
-        experienceRenderer.dismissCurrentExperience(markComplete: false) { _ in
+        experienceRenderer.dismiss(inContext: .modal, markComplete: false) { _ in
             completionExpectation.fulfill()
         }
 
@@ -266,7 +261,7 @@ class ExperienceRendererTests: XCTestCase {
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
-        experienceRenderer.dismissCurrentExperience(markComplete: false) { _ in
+        experienceRenderer.dismiss(inContext: .modal, markComplete: false) { _ in
             completionExpectation.fulfill()
         }
 
@@ -329,7 +324,7 @@ class ExperienceRendererTests: XCTestCase {
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
-        experienceRenderer.show(stepInCurrentExperience: .offset(1)) {
+        experienceRenderer.show(step: .offset(1), inContext: .modal) {
             completionExpectation.fulfill()
         }
 

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -418,7 +418,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsIdling_whenStartExperienceWithNoSteps_noTransition() throws {
         // Arrange
-        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil)
+        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil, renderContext: .modal)
         let initialState: State = .idling
         let action: Action = .startExperience(ExperienceData(experience, trigger: .showCall))
         let stateMachine = givenState(is: initialState)

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -125,36 +125,46 @@ class MockExperienceLoader: ExperienceLoading {
 
 @available(iOS 13.0, *) // due to reference to ExperienceData
 class MockExperienceRenderer: ExperienceRendering {
+    var onStart: ((StateMachineOwning, RenderContext) -> Void)?
+    func start(owner: StateMachineOwning, forContext context: RenderContext) {
+        onStart?(owner, context)
+    }
+
+    var onProcessAndShow: (([ExperienceData], ExperienceTrigger) -> Void)?
+    func processAndShow(qualifiedExperiences: [ExperienceData], reason: ExperienceTrigger) {
+        onProcessAndShow?(qualifiedExperiences, reason)
+    }
 
     var onShowExperience: ((ExperienceData, ((Result<Void, Error>) -> Void)?) -> Void)?
     func show(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?) {
         onShowExperience?(experience, completion)
     }
 
-    var onShowStep: ((StepReference, (() -> Void)?) -> Void)?
-    func show(stepInCurrentExperience stepRef: StepReference, completion: (() -> Void)?) {
-        onShowStep?(stepRef, completion)
+    var onShowStep: ((StepReference, RenderContext, (() -> Void)?) -> Void)?
+    func show(step stepRef: StepReference, inContext context: RenderContext, completion: (() -> Void)?) {
+        onShowStep?(stepRef, context, completion)
     }
 
-    var onShowQualifiedExperiences: (([ExperienceData], ((Result<Void, Error>) -> Void)?) -> Void)?
-    func show(qualifiedExperiences: [ExperienceData], completion: ((Result<Void, Error>) -> Void)?) {
-        onShowQualifiedExperiences?(qualifiedExperiences, completion)
+    var onDismiss: ((RenderContext, Bool, ((Result<Void, Error>) -> Void)?) -> Void)?
+    func dismiss(inContext context: RenderContext, markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?) {
+        onDismiss?(context, markComplete, completion)
     }
 
-    var onDismissCurrentExperience: ((Bool, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func dismissCurrentExperience(markComplete: Bool, completion: ((Result<Void, Error>) -> Void)?) {
-        onDismissCurrentExperience?(markComplete, completion)
+    var onExperienceData: ((RenderContext) -> ExperienceData)?
+    func experienceData(forContext context: RenderContext) -> ExperienceData? {
+        onExperienceData?(context)
     }
 
-    var onGetCurrentExperienceData: (() -> ExperienceData)?
-    func getCurrentExperienceData() -> ExperienceData? {
-        onGetCurrentExperienceData?()
+    var onStepIndex: ((RenderContext) -> Experience.StepIndex)?
+    func stepIndex(forContext context: RenderContext) -> Experience.StepIndex? {
+        onStepIndex?(context)
     }
 
-    var onGetCurrentStepIndex: (() -> Experience.StepIndex)?
-    func getCurrentStepIndex() -> AppcuesKit.Experience.StepIndex? {
-        onGetCurrentStepIndex?()
+    var onOwner: ((RenderContext) -> StateMachineOwning)?
+    func owner(forContext context: RenderContext) -> StateMachineOwning? {
+        onOwner?(context)
     }
+
 }
 
 class MockSessionMonitor: SessionMonitoring {

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -69,7 +69,8 @@ extension Experience {
                 )
             ],
             redirectURL: nil,
-            nextContentID: "abc")
+            nextContentID: "abc",
+            renderContext: .modal)
     }
 
     static var singleStepMock: Experience {
@@ -88,7 +89,8 @@ extension Experience {
                 )
             ],
             redirectURL: nil,
-            nextContentID: nil)
+            nextContentID: nil,
+            renderContext: .modal)
     }
 
     static func mockWithForm(defaultValue: String?, attributeName: String?) -> Experience {
@@ -107,7 +109,8 @@ extension Experience {
                 )
             ],
             redirectURL: nil,
-            nextContentID: "abc")
+            nextContentID: "abc",
+            renderContext: .modal)
     }
 
     static func mockWithStepActions(actions: [Experience.Action]) -> Experience {
@@ -134,7 +137,8 @@ extension Experience {
                 )
             ],
             redirectURL: nil,
-            nextContentID: nil)
+            nextContentID: nil,
+            renderContext: .modal)
     }
 }
 

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -55,7 +55,8 @@ class TraitComposerTests: XCTestCase {
                 .child(Experience.Step.Child(traits: []))
             ],
             redirectURL: nil,
-            nextContentID: nil)
+            nextContentID: nil,
+            renderContext: .modal)
         let stepIndex = Experience.StepIndex(group: 0, item: 0)
         let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: stepIndex)
 
@@ -213,7 +214,8 @@ class TraitComposerTests: XCTestCase {
                 ))
             ],
             redirectURL: nil,
-            nextContentID: nil)
+            nextContentID: nil,
+            renderContext: .modal)
 
         let stepIndex = Experience.StepIndex(group: 0, item: 0)
         let package = try traitComposer.package(experience: ExperienceData(experience, trigger: .showCall), stepIndex: stepIndex)
@@ -266,7 +268,8 @@ class TraitComposerTests: XCTestCase {
                 .child(Experience.Step.Child(traits: []))
             ],
             redirectURL: nil,
-            nextContentID: nil)
+            nextContentID: nil,
+            renderContext: .modal)
 
 
         // Act
@@ -304,7 +307,8 @@ class TraitComposerTests: XCTestCase {
                 ))
             ],
             redirectURL: nil,
-            nextContentID: nil)
+            nextContentID: nil,
+            renderContext: .modal)
         let experienceData = ExperienceData(experience, trigger: .showCall)
 
         // Act
@@ -447,7 +451,8 @@ class TraitComposerTests: XCTestCase {
                 ]))
             ],
             redirectURL: nil,
-            nextContentID: nil)
+            nextContentID: nil,
+            renderContext: .modal)
     }
 }
 

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -28,7 +28,7 @@ class TraitRegistryTests: XCTestCase {
         traitRegistry.register(trait: TestTrait.self)
 
         // Assert
-        let traitInstances = traitRegistry.instances(for: [traitModel], level: .group)
+        let traitInstances = traitRegistry.instances(for: [traitModel], level: .group, renderContext: .modal)
         XCTAssertEqual(traitInstances.count, 1)
     }
 
@@ -40,7 +40,7 @@ class TraitRegistryTests: XCTestCase {
         traitRegistry.register(trait: TestTrait.self)
 
         // Assert
-        let traitInstances = traitRegistry.instances(for: [traitModel], level: .group)
+        let traitInstances = traitRegistry.instances(for: [traitModel], level: .group, renderContext: .modal)
         XCTAssertEqual(traitInstances.count, 0)
     }
 
@@ -54,7 +54,7 @@ class TraitRegistryTests: XCTestCase {
         traitRegistry.register(trait: TestTrait.self)
 
         // Assert
-        let traitInstances = traitRegistry.instances(for: [traitModel], level: .group)
+        let traitInstances = traitRegistry.instances(for: [traitModel], level: .group, renderContext: .modal)
         XCTAssertEqual(traitInstances.count, 1)
     }
 }


### PR DESCRIPTION
Back on track here...
This is the scope of #415 with the approach of #416 so we can move forward with finalizing the rest of the changes in #416.

### Changes from #416
- `AnalyticsTracker` now calls `ExperienceRenderer` every time it gets a qualify response, addressing [this todo/comment](https://github.com/appcues/appcues-ios-sdk/pull/416#discussion_r1232330446)
- Removed the clearing of the cache on displaying content ([comment](https://github.com/appcues/appcues-ios-sdk/pull/416#discussion_r1232332194))
- The `Experience` model hardcodes `renderContext = .modal`. The change to support embeds will be in a future PR