### PR TITLE
Add custom NSDirectionalEdgeInsets initializers for convenience

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/NSDirectionalEdgeInsets+Style.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/NSDirectionalEdgeInsets+Style.swift
@@ -1,0 +1,32 @@
+//
+//  NSDirectionalEdgeInsets+Style.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-06-20.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+extension NSDirectionalEdgeInsets {
+    @available(iOS 13.0, *)
+    init(paddingFrom style: ExperienceComponent.Style?) {
+        self.init(
+            top: style?.paddingTop ?? 0,
+            leading: style?.paddingLeading ?? 0,
+            bottom: style?.paddingBottom ?? 0,
+            trailing: style?.paddingTrailing ?? 0
+        )
+    }
+
+    @available(iOS 13.0, *)
+    init(marginFrom style: ExperienceComponent.Style?) {
+        self.init(
+            top: style?.marginTop ?? 0,
+            leading: style?.marginLeading ?? 0,
+            bottom: style?.marginBottom ?? 0,
+            trailing: style?.marginTrailing ?? 0
+        )
+    }
+
+}

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -31,12 +31,7 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
     func decorate(stepController: UIViewController) throws {
         // Need to cast for access to the padding property.
         guard let stepController = stepController as? ExperienceStepViewController else { return }
-        stepController.padding = NSDirectionalEdgeInsets(
-            top: modalStyle?.paddingTop ?? 0,
-            leading: modalStyle?.paddingLeading ?? 0,
-            bottom: modalStyle?.paddingBottom ?? 0,
-            trailing: modalStyle?.paddingTrailing ?? 0
-        )
+        stepController.padding = NSDirectionalEdgeInsets(paddingFrom: modalStyle)
     }
 
     func createWrapper(around containerController: AppcuesExperienceContainerViewController) throws -> UIViewController {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
@@ -32,12 +32,7 @@ internal class AppcuesPagingDotsTrait: AppcuesContainerDecoratingTrait {
 
         let pageWrapView = UIView()
         pageWrapView.translatesAutoresizingMaskIntoConstraints = false
-        pageWrapView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: style?.marginTop ?? 0,
-            leading: style?.marginLeading ?? 0,
-            bottom: style?.marginBottom ?? 0,
-            trailing: style?.marginTrailing ?? 0
-        )
+        pageWrapView.directionalLayoutMargins = NSDirectionalEdgeInsets(marginFrom: style)
 
         let pageControl = UIPageControl()
         pageControl.currentPageIndicatorTintColor = UIColor(dynamicColor: style?.foregroundColor) ?? .secondaryLabel

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -100,12 +100,7 @@ private extension UIViewController {
         let dismissWrapView = UIView()
         dismissWrapView.translatesAutoresizingMaskIntoConstraints = false
         // 8px default margins for backwards compatibility
-        dismissWrapView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: style?.marginTop ?? 8,
-            leading: style?.marginLeading ?? 8,
-            bottom: style?.marginBottom ?? 8,
-            trailing: style?.marginTrailing ?? 8
-        )
+        dismissWrapView.directionalLayoutMargins = NSDirectionalEdgeInsets(marginFrom: style)
 
         let dismissButton = CloseButton(style: style, isMinimal: appearance == .minimal)
         dismissButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
@@ -39,12 +39,7 @@ internal class AppcuesTooltipTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCr
     func decorate(stepController: UIViewController) throws {
         // Need to cast for access to the padding property.
         guard let stepController = stepController as? ExperienceStepViewController else { return }
-        stepController.padding = NSDirectionalEdgeInsets(
-            top: tooltipStyle?.paddingTop ?? 0,
-            leading: tooltipStyle?.paddingLeading ?? 0,
-            bottom: tooltipStyle?.paddingBottom ?? 0,
-            trailing: tooltipStyle?.paddingTrailing ?? 0
-        )
+        stepController.padding = NSDirectionalEdgeInsets(paddingFrom: tooltipStyle)
     }
 
     func createWrapper(around containerController: AppcuesExperienceContainerViewController) throws -> UIViewController {


### PR DESCRIPTION
Realized I was going to use the `NSDirectionalEdgeInsets` snippets again for embeds, so adding an extension to init from `ExperienceComponent.Style`.