### PR TITLE
Add support for text scaling

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -43,6 +43,8 @@ public extension Appcues {
 
         var enableUniversalLinks = true
 
+        var enableTextScaling = false
+
         /// Create an Appcues SDK configuration
         /// - Parameter accountID: Appcues Account ID - a string containing an integer, copied from the Account settings page in Studio.
         /// - Parameter applicationID: Appcues Application ID - a string containing a UUID,
@@ -171,6 +173,22 @@ public extension Appcues {
         @objc
         public func enableUniversalLinks(_ enabled: Bool) -> Self {
             self.enableUniversalLinks = enabled
+            return self
+        }
+
+        /// Set the text scaling preference for the configuration.
+        ///
+        /// When this option is enabled, Appcues content rendered by the SDK will support Dynamic Type, and adjust
+        /// to the user's preferred reading size, set in system settings.
+        ///
+        /// The default value for this configuration is `false`.
+        ///
+        /// - Parameter enabled: Whether text scaling is enabled.
+        /// - Returns: The `Configuration` object.
+        @discardableResult
+        @objc
+        public func enableTextScaling(_ enabled: Bool) -> Self {
+            self.enableTextScaling = enabled
             return self
         }
     }

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/Font+Double.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/Font+Double.swift
@@ -13,8 +13,12 @@ extension Font {
     /// Init `Font` from an experience JSON model values.
     init?(name: String?, size: Double?) {
         guard let size = CGFloat(size) else { return nil }
+
+        // scaling the size here to support dynamic type
+        let scaledSize = UIFontMetrics.default.scaledValue(for: size)
+
         guard let name = name else {
-            self = .system(size: size)
+            self = .system(size: scaledSize)
             return
         }
 
@@ -24,15 +28,19 @@ extension Font {
             let parts = name.split(separator: " ")
             if parts.count == 3 {
                 self = .system(
-                    size: size,
+                    size: scaledSize,
                     weight: Font.Weight(string: String(parts[2])) ?? .regular,
                     design: Font.Design(string: String(parts[1])) ?? .default
                 )
             } else {
-                self = .system(size: size)
+                self = .system(size: scaledSize)
             }
         } else {
-            self = .custom(name, size: size)
+            if #available(iOS 14.0, *) {
+                self = .custom(name, fixedSize: scaledSize)
+            } else {
+                self = .custom(name, size: size)
+            }
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -18,12 +18,14 @@ internal class TraitComposer: TraitComposing {
 
     private let traitRegistry: TraitRegistry
     private let actionRegistry: ActionRegistry
+    private let config: Appcues.Config
     private let notificationCenter: NotificationCenter
 
     init(container: DIContainer) {
         traitRegistry = container.resolve(TraitRegistry.self)
         actionRegistry = container.resolve(ActionRegistry.self)
         notificationCenter = container.resolve(NotificationCenter.self)
+        config = container.resolve(Appcues.Config.self)
     }
 
     // swiftlint:disable:next function_body_length
@@ -83,7 +85,12 @@ internal class TraitComposer: TraitComposing {
         allTraitInstances.forEach { $0.metadataDelegate = metadataDelegate }
 
         let stepControllers: [ExperienceStepViewController] = try stepModelsWithTraits.map {
-            let viewModel = ExperienceStepViewModel(step: $0.step, actionRegistry: actionRegistry, renderContext: experience.renderContext)
+            let viewModel = ExperienceStepViewModel(
+                step: $0.step,
+                actionRegistry: actionRegistry,
+                renderContext: experience.renderContext,
+                config: config
+            )
             let stepViewController = ExperienceStepViewController(
                 viewModel: viewModel,
                 stepState: experience.state(for: $0.step.id),

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -21,7 +21,7 @@ internal struct AppcuesText: View {
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 
-        Text(textModel: model)
+        Text(textModel: model, scaled: viewModel.enableTextScaling)
             .applyTextStyle(style, model: model)
             .setupActions(on: viewModel, for: model)
             .applyAllAppcues(style)
@@ -31,7 +31,7 @@ internal struct AppcuesText: View {
 
 @available(iOS 13.0, *)
 extension Text {
-    init(textModel: ExperienceComponent.TextModel, skipColor: Bool = false) {
+    init(textModel: ExperienceComponent.TextModel, skipColor: Bool = false, scaled: Bool = false) {
         self.init("")
 
         // Note: a ViewBuilder approach here doesn't work because the requirement that we operate strictly on `Text`
@@ -41,7 +41,8 @@ extension Text {
 
             if let font = Font(
                 name: span.style?.fontName ?? textModel.style?.fontName,
-                size: span.style?.fontSize ?? textModel.style?.fontSize ?? UIFont.labelFontSize
+                size: span.style?.fontSize ?? textModel.style?.fontSize ?? UIFont.labelFontSize,
+                scaled: scaled
             ) {
                 text = text.font(font)
             }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -14,6 +14,10 @@ internal struct AppcuesText: View {
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
 
+    // this is to support dynamic type
+    // https://stackoverflow.com/a/70800548
+    @Environment(\.sizeCategory) var sizeCategory
+
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -18,7 +18,7 @@ internal struct TintedTextView: View {
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 
-        Text(textModel: model, skipColor: tintColor != nil)
+        Text(textModel: model, skipColor: tintColor != nil, scaled: viewModel.enableTextScaling)
             .applyTextStyle(style, model: model)
             .setupActions(on: viewModel, for: model)
             .ifLet(tintColor) { view, val in

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -15,6 +15,10 @@ internal struct TintedTextView: View {
 
     @EnvironmentObject var viewModel: ExperienceStepViewModel
 
+    // this is to support dynamic type
+    // https://stackoverflow.com/a/70800548
+    @Environment(\.sizeCategory) var sizeCategory
+
     var body: some View {
         let style = AppcuesStyle(from: model.style)
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -16,15 +16,11 @@ internal class ExperienceStepViewModel: ObservableObject {
         case longPress
     }
 
-    var enableTextScaling: Bool {
-        return config?.enableTextScaling ?? false
-    }
-
     let step: Experience.Step.Child
+    let enableTextScaling: Bool
     private let actions: [UUID: [Experience.Action]]
     private let actionRegistry: ActionRegistry?
     private let renderContext: RenderContext
-    private let config: Appcues.Config?
 
     init(step: Experience.Step.Child, actionRegistry: ActionRegistry, renderContext: RenderContext, config: Appcues.Config?) {
         self.step = step
@@ -35,7 +31,7 @@ internal class ExperienceStepViewModel: ObservableObject {
         }
         self.actionRegistry = actionRegistry
         self.renderContext = renderContext
-        self.config = config
+        self.enableTextScaling = config?.enableTextScaling ?? false
     }
 
     // Create an empty view model for contexts that require an `ExperienceStepViewModel` but aren't in a step context.
@@ -54,7 +50,7 @@ internal class ExperienceStepViewModel: ObservableObject {
         self.actions = [:]
         self.actionRegistry = nil
         self.renderContext = renderContext
-        self.config = nil
+        self.enableTextScaling = false
     }
 
     func enqueueActions(_ actions: [Experience.Action], type: String, viewDescription: String?) {

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -16,12 +16,17 @@ internal class ExperienceStepViewModel: ObservableObject {
         case longPress
     }
 
+    var enableTextScaling: Bool {
+        return config?.enableTextScaling ?? false
+    }
+
     let step: Experience.Step.Child
     private let actions: [UUID: [Experience.Action]]
     private let actionRegistry: ActionRegistry?
     private let renderContext: RenderContext
+    private let config: Appcues.Config?
 
-    init(step: Experience.Step.Child, actionRegistry: ActionRegistry, renderContext: RenderContext) {
+    init(step: Experience.Step.Child, actionRegistry: ActionRegistry, renderContext: RenderContext, config: Appcues.Config?) {
         self.step = step
         // Update the action list to be keyed by the UUID.
         self.actions = step.actions.reduce(into: [:]) { dict, item in
@@ -30,6 +35,7 @@ internal class ExperienceStepViewModel: ObservableObject {
         }
         self.actionRegistry = actionRegistry
         self.renderContext = renderContext
+        self.config = config
     }
 
     // Create an empty view model for contexts that require an `ExperienceStepViewModel` but aren't in a step context.
@@ -48,6 +54,7 @@ internal class ExperienceStepViewModel: ObservableObject {
         self.actions = [:]
         self.actionRegistry = nil
         self.renderContext = renderContext
+        self.config = nil
     }
 
     func enqueueActions(_ actions: [Experience.Action], type: String, viewDescription: String?) {

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -30,6 +30,7 @@ class PublicAPITests: XCTestCase {
             .anonymousIDFactory({ UUID().uuidString })
             .additionalAutoProperties(["test": "value"])
             .enableUniversalLinks(true)
+            .enableTextScaling(true)
 
         let appcuesInstance = Appcues(config: config)
 


### PR DESCRIPTION
aka Dynamic Type accessibility

This approach would provide a config option to `.enableTextScaling(enabled)`. This option would then auto scale the font size given in the model to meet the users current desired text size scale. Since we can't map directly between our builder font sizes and the iOS TextStyle options for scaling, we use a simple mapping for 3 scale levels - effectively small / medium / large, to give a reasonable result.

This change sets this option false by default, and removes the previous accidental text scaling on custom fonts. Previously, custom fonts would scale and system fonts would not. Now they both scale only when this option is enabled.

This example has a custom Lato-Black headline and then system text below. The OS setting is for a larger font size than the default.

| disabled | enabled |
| ---- | ---- |
| ![Screenshot 2023-06-20 at 3 30 09 PM](https://github.com/appcues/appcues-ios-sdk/assets/19266448/b6c75baf-ccf4-4690-b994-7ef74ae23f54) | ![Screenshot 2023-06-20 at 3 30 30 PM](https://github.com/appcues/appcues-ios-sdk/assets/19266448/480f03e2-04bc-4e53-934c-a3ed7f151da0) |

