### PR TITLE
Update podspec to exclude documentation snippets

### DIFF
--- a/Appcues.podspec
+++ b/Appcues.podspec
@@ -19,6 +19,8 @@ A Swift library for sending user properties and events to the Appcues API and re
   s.ios.deployment_target = '11.0'
 
   s.source_files = 'Sources/AppcuesKit/**/*.swift'
+  s.exclude_files = 'Sources/AppcuesKit/AppcuesKit.docc'
+
   s.resource_bundles = {
       'Appcues' => ['Sources/AppcuesKit/**/*.xcassets']
   }

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/NSDirectionalEdgeInsets+Style.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/NSDirectionalEdgeInsets+Style.swift
@@ -10,22 +10,22 @@ import UIKit
 
 extension NSDirectionalEdgeInsets {
     @available(iOS 13.0, *)
-    init(paddingFrom style: ExperienceComponent.Style?) {
+    init(paddingFrom style: ExperienceComponent.Style?, fallback: CGFloat = 0) {
         self.init(
-            top: style?.paddingTop ?? 0,
-            leading: style?.paddingLeading ?? 0,
-            bottom: style?.paddingBottom ?? 0,
-            trailing: style?.paddingTrailing ?? 0
+            top: style?.paddingTop ?? fallback,
+            leading: style?.paddingLeading ?? fallback,
+            bottom: style?.paddingBottom ?? fallback,
+            trailing: style?.paddingTrailing ?? fallback
         )
     }
 
     @available(iOS 13.0, *)
-    init(marginFrom style: ExperienceComponent.Style?) {
+    init(marginFrom style: ExperienceComponent.Style?, fallback: CGFloat = 0) {
         self.init(
-            top: style?.marginTop ?? 0,
-            leading: style?.marginLeading ?? 0,
-            bottom: style?.marginBottom ?? 0,
-            trailing: style?.marginTrailing ?? 0
+            top: style?.marginTop ?? fallback,
+            leading: style?.marginLeading ?? fallback,
+            bottom: style?.marginBottom ?? fallback,
+            trailing: style?.marginTrailing ?? fallback
         )
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -100,7 +100,7 @@ private extension UIViewController {
         let dismissWrapView = UIView()
         dismissWrapView.translatesAutoresizingMaskIntoConstraints = false
         // 8px default margins for backwards compatibility
-        dismissWrapView.directionalLayoutMargins = NSDirectionalEdgeInsets(marginFrom: style)
+        dismissWrapView.directionalLayoutMargins = NSDirectionalEdgeInsets(marginFrom: style, fallback: 8)
 
         let dismissButton = CloseButton(style: style, isMinimal: appearance == .minimal)
         dismissButton.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
EAS builds via React Native pick up the DocC snippets as actual code to be compiled. This makes sure those files are excluded. 

Also, I noticed #420 missed the default margin for the skippable button was non-zero, so fixing that here too. Not sure why the Circle snapshot tests didn't catch that since running them locally did.