### PR TITLE
Add link to new Anchored Tooltip section in index at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The SDK is a Swift library for sending user properties and events to the Appcues
       - [Supporting Debugging and Experience Previewing](#supporting-debugging-and-experience-previewing)
     - [Identifying Users](#identifying-users)
     - [Tracking Screens and Events](#tracking-screens-and-events)
+    - [Anchored Tooltips](#anchored-tooltips)
   - [🛠 Customization](#-customization)
   - [📝 Documentation](#-documentation)
   - [🎬 Examples](#-examples)


### PR DESCRIPTION
Right after I merged https://github.com/appcues/appcues-ios-sdk/pull/424 I realized I missed this one detail.