### PR TITLE
Update embed rendering logic

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
@@ -155,7 +155,7 @@ internal class DebugViewModel: ObservableObject {
                 // Convert from zero-based to be human readable
                 subtitle = "Group \(stepIndex.group + 1) step \(stepIndex.item + 1)"
             }
-        case .stepInteraction, .stepCompleted, .stepRecovered, .experienceStarted:
+        case .stepInteraction, .stepCompleted, .stepRecovered, .experienceStarted, .experienceRecovered:
             status = .verified
             title = "Showing \(properties.experienceName)"
         case .experienceCompleted, .experienceDismissed:

--- a/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
@@ -47,7 +47,7 @@ internal class ExperienceLoader: ExperienceLoading {
         ) { [weak self] (result: Result<Experience, Error>) in
             switch result {
             case .success(let experience):
-                self?.experienceRenderer.show(
+                self?.experienceRenderer.processAndShow(
                     experience: ExperienceData(experience, trigger: trigger, priority: .normal, published: published),
                     completion: completion
                 )

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -113,5 +113,22 @@ extension ExperienceStateMachine {
                 isInternal: true
             ))
         }
+
+        func trackRecoverableError(experience: ExperienceData, message: String) {
+            guard experience.published else { return }
+
+            let errorID = UUID.create()
+            experience.recoverableErrorID = errorID
+            let errorProperties = LifecycleEvent.properties(experience, error: LifecycleEvent.ErrorBody(message: message, id: errorID))
+            trackLifecycleEvent(.experienceError, errorProperties)
+        }
+
+        func trackErrorRecovery(ifErrorOn experience: ExperienceData) {
+            guard experience.published, let errorID = experience.recoverableErrorID else { return }
+
+            let errorProperties = LifecycleEvent.properties(experience, error: LifecycleEvent.ErrorBody(message: nil, id: errorID))
+            trackLifecycleEvent(.experienceRecovered, errorProperties)
+            experience.recoverableErrorID = nil
+        }
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
@@ -18,6 +18,7 @@ internal enum LifecycleEvent: String, CaseIterable {
     case experienceCompleted = "appcues:v2:experience_completed"
     case experienceDismissed = "appcues:v2:experience_dismissed"
     case experienceError = "appcues:v2:experience_error"
+    case experienceRecovered = "appcues:v2:experience_recovered"
 
     private init?(trackingType: TrackingUpdate.TrackingType) {
         if case .event(let name, _) = trackingType, let val = Self(rawValue: name) {
@@ -71,10 +72,10 @@ internal enum LifecycleEvent: String, CaseIterable {
 extension LifecycleEvent {
 
     struct ErrorBody: ExpressibleByStringInterpolation {
-        let message: String
+        let message: String?
         let id: UUID
 
-        init(message: String, id: UUID = UUID.create()) {
+        init(message: String?, id: UUID = UUID.create()) {
             self.message = message
             self.id = id
         }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -20,6 +20,8 @@ internal class ExperienceData {
     let trigger: ExperienceTrigger
     private let formState: FormState
 
+    var recoverableErrorID: UUID?
+
     internal init(
         _ experience: Experience,
         trigger: ExperienceTrigger,

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -29,7 +29,7 @@ class ExperienceLoaderTests: XCTestCase {
             )
             return .success(Experience.mock)
         }
-        appcues.experienceRenderer.onShowExperience = { experience, completion in
+        appcues.experienceRenderer.onProcessAndShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
             XCTAssertTrue(experience.published)
             guard case .showCall = experience.trigger else { return XCTFail() }
@@ -58,7 +58,7 @@ class ExperienceLoaderTests: XCTestCase {
             )
             return .success(Experience.mock)
         }
-        appcues.experienceRenderer.onShowExperience = { experience, completion in
+        appcues.experienceRenderer.onProcessAndShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
             XCTAssertFalse(experience.published)
             guard case .preview = experience.trigger else { return XCTFail() }

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -35,7 +35,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -60,7 +60,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -68,7 +68,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -94,7 +94,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -103,7 +103,7 @@ class ExperienceRendererTests: XCTestCase {
         // NOTE: No waiting for initial .show() to complete like the test case above does.
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .normal, published: true)) { result in
             print(result)
             if case .success = result {
                 completionExpectation.fulfill()
@@ -124,7 +124,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Set up first experience
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 preconditionExpectation.fulfill()
             }
@@ -132,7 +132,7 @@ class ExperienceRendererTests: XCTestCase {
         XCTAssertEqual(XCTWaiter().wait(for: [preconditionExpectation, presentExpectation], timeout: 1), .completed)
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true)) { result in
             print(result)
             if case .failure(ExperienceStateMachine.ExperienceError.experienceAlreadyActive) = result {
                 failureExpectation.fulfill()
@@ -158,7 +158,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.analyticsPublisher.onPublish = { _ in eventExpectation.fulfill() }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: false)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: false)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -206,7 +206,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         var preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Now that we've shown the first step, set the expectation for the 2nd step transition that we're testing
@@ -234,7 +234,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.mock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -256,7 +256,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         appcues.analyticsPublisher.onPublish = { update in updates.append(update) }
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
@@ -286,13 +286,13 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(firstExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(firstExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
         }
 
-        experienceRenderer.show(experience: ExperienceData(secondExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(secondExperienceInstance.model, trigger: .showCall, priority: .low, published: true)) { result in
             if case let .failure(error) = result {
                 XCTAssertEqual(
                     error as! ExperienceStateMachine.ExperienceError,
@@ -320,7 +320,7 @@ class ExperienceRendererTests: XCTestCase {
         let experience = ExperienceData.singleStepMock
         let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
         wait(for: [preconditionPresentExpectation], timeout: 1)
 
         // Act
@@ -344,7 +344,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
             if case .failure = result {
                 failureExpectation.fulfill()
             }
@@ -365,7 +365,7 @@ class ExperienceRendererTests: XCTestCase {
         appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment)) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -399,7 +399,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)
@@ -430,7 +430,7 @@ class ExperienceRendererTests: XCTestCase {
         }
 
         // Act
-        experienceRenderer.show(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true, experiment: experiment), completion: nil)
 
         // Assert
         waitForExpectations(timeout: 1)

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -135,9 +135,9 @@ class MockExperienceRenderer: ExperienceRendering {
         onProcessAndShow?(qualifiedExperiences, reason)
     }
 
-    var onShowExperience: ((ExperienceData, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func show(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?) {
-        onShowExperience?(experience, completion)
+    var onProcessAndShowExperience: ((ExperienceData, ((Result<Void, Error>) -> Void)?) -> Void)?
+    func processAndShow(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?) {
+        onProcessAndShowExperience?(experience, completion)
     }
 
     var onShowStep: ((StepReference, RenderContext, (() -> Void)?) -> Void)?


### PR DESCRIPTION
1. properly cache a single experience from ExperienceLoader (previously it was only caching on an error, which is wrong because we want to handle the disappear/reappear scenario, and because the `show()` function is used internally by `ExperienceRenderer`, it was replacing multiple cached items with the single one)
2. handle cache clearing on dismissal (there's an open question [here](https://github.com/appcues/appcues-mobile-experience-spec/pull/194#discussion_r1243704479), but I've implemented the approach that I thought made sense)
3. avoid attempting to render multiple experiences when no context is available (special case to avoid trying and failing every embed)
4. add `experience_error` and `experience_recovered` handling