### PR TITLE
Add @appcues/embedded trait and AppcuesFrameView

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// An object that manages Appcues tracking and rendering of experience content, for your app.
 @objc(Appcues)
@@ -238,6 +239,24 @@ public class Appcues: NSObject {
         guard #available(iOS 13.0, *) else { return }
 
         actionRegistry.register(action: action)
+    }
+
+    /// Registers the specified frame to be available to host qualified embedded Appcues experience content.
+    /// - Parameters:
+    ///   - frameID: The unique identifier for the embedded ``AppcuesFrameView``.
+    ///   - view: The ``AppcuesFrameView`` to register for hosting embedded content.
+    ///   - viewController: The `UIViewController` that owns the provided ``AppcuesFrameView`` instance.
+    @objc
+    public func register(frameID: String, for view: AppcuesFrameView, on parentViewController: UIViewController) {
+        guard #available(iOS 13.0, *) else {
+            config.logger.error("iOS 13 or above is required to render embedded experiences")
+            return
+        }
+
+        view.configure(parentViewController: parentViewController)
+
+        let experienceRenderer = container.resolve(ExperienceRendering.self)
+        experienceRenderer.start(owner: view, forContext: .embed(frameID: frameID))
     }
 
     /// Launches the Appcues debugger over your app's UI.

--- a/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
@@ -24,6 +24,10 @@ A Swift library for sending user properties and events to the Appcues API and re
 - <doc:UniversalLinking>
 - ``AppcuesNavigationDelegate``
 
+### Embeds
+- ``AppcuesFrameView``
+- ``AppcuesFrame``
+
 ### Managing Experiences
 
 - ``AppcuesExperienceDelegate``

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -173,7 +173,15 @@ extension Experience: Decodable {
         steps = try container.decode([Step].self, forKey: .steps)
         redirectURL = try? container.decode(URL.self, forKey: .redirectURL)
         nextContentID = try? container.decode(String.self, forKey: .nextContentID)
-        renderContext = .modal
+
+        // Check for an experience-level embed trait
+        if #available(iOS 13.0, *),
+           let embedTrait = self.traits.first(where: { $0.type == AppcuesEmbeddedTrait.type }),
+           let config = embedTrait.configDecoder.decode(AppcuesEmbeddedTrait.Config.self) {
+            renderContext = .embed(frameID: config.frameID)
+        } else {
+            renderContext = .modal
+        }
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -22,6 +22,7 @@ internal protocol ExperienceRendering: AnyObject {
 
 internal enum RenderContext: Hashable {
     case modal
+    case embed(frameID: String)
 }
 
 internal enum ExperienceRendererError: Error {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -110,7 +110,8 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
         switch state {
         case .endingExperience:
             experienceWillDisappear()
-        case let .renderingStep(_, _, package, _) where package.wrapperController.isBeingDismissed:
+        case let .renderingStep(_, _, package, _)
+            where package.wrapperController.isBeingDismissed || package.wrapperController.isMovingFromParent:
             experienceWillDisappear()
         default:
             break
@@ -121,7 +122,8 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
         switch state {
         case .endingExperience:
             experienceDidDisappear()
-        case let .renderingStep(_, _, package, _) where package.wrapperController.isBeingDismissed:
+        case let .renderingStep(_, _, package, _)
+            where package.wrapperController.isBeingDismissed || package.wrapperController.isMovingFromParent:
             experienceDidDisappear()
             // Update state in response to UI changes that have happened already (a call to UIViewController.dismiss).
             try? transition(.endExperience(markComplete: false))

--- a/Sources/AppcuesKit/Presentation/Extensions/UIView+Constrain.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIView+Constrain.swift
@@ -10,14 +10,14 @@ import UIKit
 
 extension UIView {
 
-     func pin(to view: UIView) {
+     func pin(to view: UIView, margins: NSDirectionalEdgeInsets = .zero) {
         self.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            self.topAnchor.constraint(equalTo: view.topAnchor),
-            self.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            self.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            self.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            self.topAnchor.constraint(equalTo: view.topAnchor, constant: margins.top),
+            self.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: margins.leading),
+            self.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -1.0 * margins.trailing),
+            self.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -1.0 * margins.bottom)
         ])
     }
 

--- a/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
@@ -9,13 +9,18 @@
 import UIKit
 
 extension UIViewController {
-    func embedChildViewController(_ childVC: UIViewController, inSuperview superview: UIView, respectLayoutMargins: Bool = false) {
+    func embedChildViewController(
+        _ childVC: UIViewController,
+        inSuperview superview: UIView,
+        margins: NSDirectionalEdgeInsets = .zero,
+        respectLayoutMargins: Bool = false
+    ) {
         addChild(childVC)
         superview.addSubview(childVC.view)
         if respectLayoutMargins {
             childVC.view.pin(to: superview.layoutMarginsGuide)
         } else {
-            childVC.view.pin(to: superview)
+            childVC.view.pin(to: superview, margins: margins)
         }
         childVC.didMove(toParent: self)
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
@@ -1,0 +1,89 @@
+//
+//  AppcuesEmbeddedTrait.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-06-13.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
+
+    struct Config: Decodable {
+        let frameID: String
+        let style: ExperienceComponent.Style?
+        let transition: AppcuesFrameView.Transition?
+    }
+
+    static let type = "@appcues/embedded"
+
+    weak var metadataDelegate: AppcuesTraitMetadataDelegate?
+
+    private weak var appcues: Appcues?
+
+    private let frameID: String
+    private let transition: AppcuesFrameView.Transition
+    private let style: ExperienceComponent.Style?
+
+    // The view embedded in the customer application
+    weak var embedView: AppcuesFrameView?
+
+    required init?(configuration: AppcuesExperiencePluginConfiguration) {
+        self.appcues = configuration.appcues
+
+        guard let config = configuration.decode(Config.self) else { return nil }
+        self.frameID = config.frameID
+        self.transition = config.transition ?? .none
+        self.style = config.style
+    }
+
+    func decorate(stepController: UIViewController) throws {
+        // Need to cast for access to the padding property.
+        guard let stepController = stepController as? ExperienceStepViewController else { return }
+        stepController.padding = NSDirectionalEdgeInsets(paddingFrom: style)
+    }
+
+    func createWrapper(around containerController: AppcuesExperienceContainerViewController) throws -> UIViewController {
+        applyStyle(style, to: containerController)
+        return containerController
+    }
+
+    func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {
+        // no backdrop on embeds
+    }
+
+    func present(viewController: UIViewController, completion: (() -> Void)?) throws {
+        let experienceRenderer = appcues?.container.resolve(ExperienceRendering.self)
+
+        self.embedView = experienceRenderer?.owner(forContext: .embed(frameID: frameID)) as? AppcuesFrameView
+
+        guard let embedView = embedView else {
+            throw AppcuesTraitError(description: "No AppcuesFrameView registered for ID \(frameID)")
+        }
+
+        let margins = NSDirectionalEdgeInsets(marginFrom: style)
+        embedView.embed(viewController, margins: margins, transition: transition, completion: completion)
+    }
+
+    func remove(viewController: UIViewController, completion: (() -> Void)?) {
+        embedView?.unembed(viewController, transition: transition, completion: completion)
+    }
+
+    private func applyStyle(_ style: ExperienceComponent.Style?, to container: UIViewController) {
+        container.view.backgroundColor = UIColor(dynamicColor: style?.backgroundColor)
+        container.view.layer.cornerRadius = style?.cornerRadius ?? 0
+        container.view.layer.borderColor = UIColor(dynamicColor: style?.borderColor)?.cgColor
+        if let borderWidth = CGFloat(style?.borderWidth) {
+            container.view.layer.borderWidth = borderWidth
+            container.view.layoutMargins = UIEdgeInsets(
+                top: borderWidth,
+                left: borderWidth,
+                bottom: borderWidth,
+                right: borderWidth
+            )
+        }
+    }
+
+}

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -29,6 +29,7 @@ internal class TraitRegistry {
         register(trait: AppcuesTargetElementTrait.self)
         register(trait: AppcuesBackdropKeyholeTrait.self)
         register(trait: AppcuesTargetInteractionTrait.self)
+        register(trait: AppcuesEmbeddedTrait.self)
     }
 
     func register(trait: AppcuesExperienceTrait.Type) {

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
@@ -1,0 +1,67 @@
+//
+//  AppcuesFrame.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-07-07.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+/// A SwiftUI view that displays an Appcues experience.
+@available(iOS 13.0, *)
+public struct AppcuesFrame: UIViewControllerRepresentable {
+    weak var appcues: Appcues?
+    let frameID: String
+
+    /// Creates a frame with the given identifier.
+    public init(appcues: Appcues?, frameID: String) {
+        self.appcues = appcues
+        self.frameID = frameID
+    }
+
+    /// Creates the view controller object and configures its initial state.
+    public func makeUIViewController(context: Context) -> UIViewController {
+        let viewController = AppcuesFrameVC()
+        appcues?.register(frameID: frameID, for: viewController.frameView, on: viewController)
+        return viewController
+    }
+
+    /// Updates the state of the specified view controller with new information from SwiftUI.
+    public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        // no-op
+    }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesFrame {
+    class AppcuesFrameVC: UIViewController {
+        lazy var frameView = AppcuesFrameView()
+
+        override func loadView() {
+            view = frameView
+        }
+
+        override func viewWillLayoutSubviews() {
+            super.viewWillLayoutSubviews()
+
+            // When the view is hidden, we want to collapse it down from whatever previous size it had,
+            // but keep it >0 so new content can properly begin to layout.
+            if view.isHidden {
+                preferredContentSize = CGSize(width: 0, height: 1)
+            }
+        }
+
+        override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+            super.preferredContentSizeDidChange(forChildContentContainer: container)
+
+            // if this container has opted out of updating size, for example background content containers, do not update
+            // this view controller's preferredContentSize
+            if let dynamicSizing = container as? DynamicContentSizing, !dynamicSizing.updatesPreferredContentSize {
+                return
+            }
+
+            preferredContentSize = container.preferredContentSize
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -1,0 +1,137 @@
+//
+//  AppcuesFrameView.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 8/18/22.
+//  Copyright © 2022 Appcues. All rights reserved.
+//
+
+import UIKit
+
+/// A UIKit view that displays an Appcues experience.
+public class AppcuesFrameView: UIView, StateMachineOwning {
+
+    enum Transition: String, Decodable {
+        case none
+        case fade
+    }
+
+    private var _stateMachine: Any?
+    @available(iOS 13.0, *)
+    internal var stateMachine: ExperienceStateMachine? {
+        get { _stateMachine as? ExperienceStateMachine }
+        set { _stateMachine = newValue }
+    }
+
+    private weak var parentViewController: UIViewController?
+
+    // when the view content is empty, we use this zero height constraint
+    private lazy var emptyHeightConstraint: NSLayoutConstraint = {
+        var constraint = heightAnchor.constraint(equalToConstant: 0)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    // when the view content is non-empty, we use a >= 1 height constraint to allow for dynamic
+    // sizing based on the content
+    private lazy var nonEmptyHeightConstraint: NSLayoutConstraint = {
+        var constraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 1)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    // when the view content is empty, we use this zero width constraint
+    private lazy var emptyWidthConstraint: NSLayoutConstraint = {
+        var constraint = widthAnchor.constraint(equalToConstant: 0)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    // when the view content is non-empty, we use a >= 1 width constraint to allow for dynamic
+    // sizing based on the content
+    private lazy var nonEmptyWidthConstraint: NSLayoutConstraint = {
+        var constraint = widthAnchor.constraint(greaterThanOrEqualToConstant: 1)
+        constraint.priority = .defaultLow
+        constraint.isActive = false
+        return constraint
+    }()
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        isHidden = true
+        configureConstraints(isEmpty: true)
+    }
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        isHidden = true
+        configureConstraints(isEmpty: true)
+    }
+
+    private func configureConstraints(isEmpty: Bool) {
+        emptyHeightConstraint.isActive = isEmpty
+        nonEmptyHeightConstraint.isActive = !isEmpty
+        emptyWidthConstraint.isActive = isEmpty
+        nonEmptyWidthConstraint.isActive = !isEmpty
+    }
+
+    // this will only get called on iOS 13+ from the Appcues class during registration
+    internal func configure(parentViewController: UIViewController) {
+        self.parentViewController = parentViewController
+    }
+
+    internal func embed(
+        _ experienceController: UIViewController,
+        margins: NSDirectionalEdgeInsets,
+        transition: Transition,
+        completion: (() -> Void)?
+    ) {
+        guard let viewController = parentViewController else { return }
+
+        configureConstraints(isEmpty: false)
+
+        viewController.embedChildViewController(experienceController, inSuperview: self, margins: margins)
+
+        switch transition {
+        case .none:
+            isHidden = false
+            completion?()
+        case .fade:
+            UIView.animate(
+                withDuration: 0.3,
+                animations: {
+                    self.isHidden = false
+                },
+                completion: { _ in
+                    completion?()
+                }
+            )
+        }
+    }
+
+    internal func unembed(_ experienceController: UIViewController, transition: Transition, completion: (() -> Void)?) {
+        switch transition {
+        case .none:
+            isHidden = true
+            parentViewController?.unembedChildViewController(experienceController)
+            configureConstraints(isEmpty: true)
+            completion?()
+        case .fade:
+            UIView.animate(
+                withDuration: 0.3,
+                animations: {
+                    // possibly have a delegate for these embeds that would allow the host app to have more control over this?
+                    self.isHidden = true
+                },
+                completion: { _ in
+                    self.parentViewController?.unembedChildViewController(experienceController)
+                    self.configureConstraints(isEmpty: true)
+                    completion?()
+                }
+            )
+        }
+    }
+}

--- a/Tests/AppcuesKitTests/Experiences/EmbedExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/EmbedExperienceRendererTests.swift
@@ -1,0 +1,251 @@
+//
+//  EmbedExperienceRendererTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-07-05.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class EmbedExperienceRendererTests: XCTestCase {
+
+    let screenTrigger = ExperienceTrigger.qualification(reason: .screenView)
+
+    var appcues: MockAppcues!
+    var experienceRenderer: ExperienceRenderer!
+
+    override func setUpWithError() throws {
+        appcues = MockAppcues()
+        experienceRenderer = ExperienceRenderer(container: appcues.container)
+    }
+
+    /// Tests the basic scenario where a frame is registered and a screen view qualification returns an embedded experience for the frame.
+    func testQualifyIntoExistingFrame() throws {
+        // Arrange
+        let experience = ExperienceData.mockEmbed(frameID: "frame1", trigger: screenTrigger)
+
+        let presentExpectation = expectation(description: "Experience presented")
+        let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
+        appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
+
+        let eventExpectation = expectation(description: "experience started")
+        appcues.analyticsPublisher.onPublish = { update in
+            if case .event(name: "appcues:v2:experience_started", interactive: false) = update.type {
+                eventExpectation.fulfill()
+            }
+        }
+
+        let frame = AppcuesFrameView()
+        // Simulate the relevant part of Appcues.register(frameID:)
+        experienceRenderer.start(owner: frame, forContext: .embed(frameID: "frame1"))
+
+        // Act
+        experienceRenderer.processAndShow(qualifiedExperiences: [experience], reason: screenTrigger)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    /// Tests the basic scenario where a screen view qualification returns an embedded experience for the frame AND THEN a frame is subsequently registered.
+    /// For example, a below-the-fold frame.
+    func testLoadFromCacheIntoNewFrame() throws {
+        // Arrange
+        let experience = ExperienceData.mockEmbed(frameID: "frame1", trigger: screenTrigger)
+
+        let presentExpectation = expectation(description: "Experience presented")
+        let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
+        appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
+
+        let errorExpectation = expectation(description: "experience error event")
+        let recoveredExpectation = expectation(description: "experience recovered event")
+        let eventExpectation = expectation(description: "experience started")
+        appcues.analyticsPublisher.onPublish = { update in
+            switch update.type {
+            case .event(name: "appcues:v2:experience_error", interactive: false):
+                errorExpectation.fulfill()
+            case .event(name: "appcues:v2:experience_recovered", interactive: false):
+                recoveredExpectation.fulfill()
+            case .event(name: "appcues:v2:experience_started", interactive: false):
+                eventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+
+        experienceRenderer.processAndShow(qualifiedExperiences: [experience], reason: screenTrigger)
+
+        // Act
+
+        // Side test: non-screenView qualifications shouldn't affect the cache. See testScreenViewClearsCache() below for the screenView test.
+        experienceRenderer.processAndShow(qualifiedExperiences: [], reason: .qualification(reason: .eventTrigger))
+        experienceRenderer.processAndShow(qualifiedExperiences: [], reason: .showCall)
+        experienceRenderer.processAndShow(qualifiedExperiences: [], reason: .preview)
+        experienceRenderer.processAndShow(qualifiedExperiences: [], reason: .deepLink)
+        experienceRenderer.processAndShow(qualifiedExperiences: [], reason: .launchExperienceAction(fromExperienceID: UUID()))
+        experienceRenderer.processAndShow(qualifiedExperiences: [], reason: .experienceCompletionAction(fromExperienceID: UUID()))
+
+        let frame = AppcuesFrameView()
+        // Simulate the relevant part of Appcues.register(frameID:)
+        experienceRenderer.start(owner: frame, forContext: .embed(frameID: "frame1"))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    /// Tests the case where a new screen view clears the cache of embedded experiences, so nothing loads into the frame.
+    func testScreenViewClearsCache() throws {
+        // Arrange
+        let experience = ExperienceData.mockEmbed(frameID: "frame1", trigger: screenTrigger)
+
+        let presentExpectation = expectation(description: "Experience presented")
+        let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
+        appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
+
+        let eventExpectation = expectation(description: "experience started")
+        appcues.analyticsPublisher.onPublish = { update in
+            if case .event(name: "appcues:v2:experience_started", interactive: false) = update.type {
+                eventExpectation.fulfill()
+            }
+        }
+
+        experienceRenderer.processAndShow(qualifiedExperiences: [experience], reason: screenTrigger)
+
+        // Act
+        experienceRenderer.processAndShow(qualifiedExperiences: [], reason: .qualification(reason: .screenView))
+        // Expect nothing since the cache should be cleared
+        presentExpectation.isInverted = true
+        eventExpectation.isInverted = true
+
+        let frame = AppcuesFrameView()
+        // Simulate the relevant part of Appcues.register(frameID:)
+        experienceRenderer.start(owner: frame, forContext: .embed(frameID: "frame1"))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    /// Tests the case where a frame shows an embed and then the same frameID is subsequently registered again and so loads the experience again.
+    /// For example, a frame inside a UITableViewCell.
+    func testShownEmbedNotRemovedFromCache() throws {
+        // Arrange
+        let experience = ExperienceData.mockEmbed(frameID: "frame1", trigger: screenTrigger)
+
+        let presentExpectation = expectation(description: "Experience presented")
+        let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
+        appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
+
+        let eventExpectation = expectation(description: "experience started")
+        appcues.analyticsPublisher.onPublish = { update in
+            if case .event(name: "appcues:v2:experience_started", interactive: false) = update.type {
+                eventExpectation.fulfill()
+            }
+        }
+
+        presentExpectation.expectedFulfillmentCount = 2
+        eventExpectation.expectedFulfillmentCount = 2
+
+        let frame = AppcuesFrameView()
+        // Simulate the relevant part of Appcues.register(frameID:)
+        experienceRenderer.start(owner: frame, forContext: .embed(frameID: "frame1"))
+
+        // Act
+        experienceRenderer.processAndShow(qualifiedExperiences: [experience], reason: screenTrigger)
+
+        // Same frame loads the content again
+        // Simulate the relevant part of Appcues.register(frameID:)
+        experienceRenderer.start(owner: frame, forContext: .embed(frameID: "frame1"))
+
+        // Dismiss the experience, removing it from the cache
+        let dismissExpectation = expectation(description: "experience dismissed")
+        experienceRenderer.dismiss(inContext: .embed(frameID: "frame1"), markComplete: false) { result in
+            if case .success() = result {
+                dismissExpectation.fulfill()
+            }
+        }
+        wait(for: [dismissExpectation], timeout: 1)
+
+        // Same frame registers again, but this time has no content available because it was completed above.
+        // Simulate the relevant part of Appcues.register(frameID:)
+        experienceRenderer.start(owner: frame, forContext: .embed(frameID: "frame1"))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+    
+
+    /// Tests the case where a frame is registered and the de-inited before an embed qualifies.
+    func testFrameMemoryRetain() throws {
+        // Arrange
+        let experience = ExperienceData.mockEmbed(frameID: "frame1", trigger: screenTrigger)
+
+        let presentExpectation = expectation(description: "Experience presented")
+        let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: presentExpectation)
+        appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
+
+        let eventExpectation = expectation(description: "experience started")
+        appcues.analyticsPublisher.onPublish = { update in
+            if case .event(name: "appcues:v2:experience_started", interactive: false) = update.type {
+                eventExpectation.fulfill()
+            }
+        }
+
+        var frame: AppcuesFrameView? = AppcuesFrameView()
+        // Simulate the relevant part of Appcues.register(frameID:)
+        experienceRenderer.start(owner: frame!, forContext: .embed(frameID: "frame1"))
+
+        // Act
+        
+        frame = nil
+
+        // Expect nothing since the render context for frame1 should be gone now
+        presentExpectation.isInverted = true
+        eventExpectation.isInverted = true
+
+        experienceRenderer.processAndShow(qualifiedExperiences: [experience], reason: screenTrigger)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+}
+
+extension Experience {
+    static func mockEmbed(frameID: String) -> Experience {
+        Experience(
+            id: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
+            name: "Mock embedded experience",
+            type: "mobile",
+            publishedAt: 1632142800000,
+            traits: [],
+            steps: [
+                Experience.Step(
+                    fixedID: "fb529214-3c78-4d6d-ba93-b55d22497ca1",
+                    children: [
+                        Step.Child(fixedID: "e03ae132-91b7-4cb0-9474-7d4a0e308a07")
+                    ]
+                )
+            ],
+            redirectURL: nil,
+            nextContentID: nil,
+            renderContext: .embed(frameID: frameID)
+        )
+    }
+}
+
+@available(iOS 13.0, *)
+extension ExperienceData {
+    static func mockEmbed(frameID: String, trigger: ExperienceTrigger) -> ExperienceData {
+        ExperienceData(
+            .mockEmbed(frameID: frameID),
+            trigger: trigger,
+            priority: .low,
+            published: true,
+            experiment: nil,
+            requestID: nil,
+            error: nil
+        )
+    }
+}

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -79,6 +79,13 @@ class PublicAPITests: XCTestCase {
         if #available(iOS 13.0, *) {
             _ = appcuesInstance.filterAndHandle(Set())
         }
+
+        let frameView = AppcuesFrameView(frame: .zero)
+        appcuesInstance.register(frameID: "frame1", for: frameView, on: UIViewController())
+
+        if #available(iOS 13.0, *) {
+            let frame = AppcuesFrame(appcues: appcuesInstance, frameID: "frame1")
+        }
     }
 }
 


### PR DESCRIPTION
Nothing substantially different from what we've reviewed before (https://github.com/appcues/appcues-ios-sdk/pull/416).

I've polished up a few places, added first-class SwiftUI support, and some tests for the different scenarios we're supporting.

As we play around with this more (both in terms of different experience configurations, and different app configurations), there will be rough edges that need fixing up. For example, I already spent a bunch of time fixing an issue where the carousel trait wouldn't display properly in the SwiftUI frame.