### PR TITLE
Update example apps with embed examples

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -12,10 +12,11 @@
 		160BF92965F22C6957DEB27C /* Mulish-Italic-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */; };
 		3EADA9762D050C3E2ED69514 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */; };
 		40A181AE1ED5DE1982FA05CC /* Mulish-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */; };
-		53460701BBF66F1D8B6A16A3 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3CA9FD0F1383224CF079AEE /* Pods_AppcuesCocoapodsExample.framework */; };
+		622C6559F57A6A19F18D46C4 /* EmbedTestHarnessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */; };
 		64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB61619365785F4544ED13D /* GroupViewController.swift */; };
 		68E596FD295BCC69F06AF0B4 /* DeepLinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5548F50894583A174A85628C /* DeepLinkNavigator.swift */; };
 		866AA363BEFB1A42C8C1D149 /* Lato-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 547A647EB6D311E97F592C7C /* Lato-Black.ttf */; };
+		8F7329B0046118A1DFA8B58D /* EmbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */; };
 		9E6FF9F4B22B8874E5AA6544 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93D50517BBE18B336D130E13 /* LaunchScreen.storyboard */; };
 		A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C713E67205D9507CE2DC80 /* AppDelegate.swift */; };
 		A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */; };
@@ -23,25 +24,28 @@
 		CD156254F042866368E77CC3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 024025AF9E2E0D38C368A6AC /* Main.storyboard */; };
 		DBE453F2B40A01B4818CB84E /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */; };
 		EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D26E6136C6539597C9E50A9 /* EventsViewController.swift */; };
+		F73753FF7D3ADD92B265B10F /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B873831BC36815B1F44FE56 /* Pods_AppcuesCocoapodsExample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		2777BD40C9776A5F0E012EE4 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		384497BA35A275E793B475C1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedViewController.swift; sourceTree = "<group>"; };
 		547A647EB6D311E97F592C7C /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
 		5548F50894583A174A85628C /* DeepLinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkNavigator.swift; sourceTree = "<group>"; };
 		5DC2B62290580560D162A8E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		76225932032FDA016ED2A5ED /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		82DED1437C1DA54F0C231566 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8663BEDD1883CC408AA4A302 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
-		8A15212BB9B2793762846A62 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
+		8B873831BC36815B1F44FE56 /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		925915F4923FF8E1B2479C94 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
+		97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedTestHarnessViewController.swift; sourceTree = "<group>"; };
 		9CB61619365785F4544ED13D /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		9D26E6136C6539597C9E50A9 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
 		AAD7ED9DCA5972361B3F5E67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		C3CA9FD0F1383224CF079AEE /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
 		CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		D2C0EC54920737EBD7E2961F /* AppcuesCocoapodsExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AppcuesCocoapodsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -49,17 +53,27 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		BF4055A3D93940BA0A718D5B /* Frameworks */ = {
+		AF4052F4A8F1AC8BA3830CBB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53460701BBF66F1D8B6A16A3 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
+				F73753FF7D3ADD92B265B10F /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		19CA390954037C3E9559C2FF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				925915F4923FF8E1B2479C94 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
+				2777BD40C9776A5F0E012EE4 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		3271BCB89D21367EC1AA9069 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -79,6 +93,8 @@
 				10C713E67205D9507CE2DC80 /* AppDelegate.swift */,
 				2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */,
 				5548F50894583A174A85628C /* DeepLinkNavigator.swift */,
+				97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */,
+				4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */,
 				9D26E6136C6539597C9E50A9 /* EventsViewController.swift */,
 				9CB61619365785F4544ED13D /* GroupViewController.swift */,
 				AAD7ED9DCA5972361B3F5E67 /* Info.plist */,
@@ -104,27 +120,17 @@
 			children = (
 				8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */,
 				C743E51709EACC21B03B3A23 /* Products */,
-				E1C92567E69B0F613FDDC180 /* Pods */,
-				CB4F9F5D4DCAF8E301154202 /* Frameworks */,
+				19CA390954037C3E9559C2FF /* Pods */,
+				E13BA9E22BAF00E1FA97280F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
-		CB4F9F5D4DCAF8E301154202 /* Frameworks */ = {
+		E13BA9E22BAF00E1FA97280F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C3CA9FD0F1383224CF079AEE /* Pods_AppcuesCocoapodsExample.framework */,
+				8B873831BC36815B1F44FE56 /* Pods_AppcuesCocoapodsExample.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E1C92567E69B0F613FDDC180 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				76225932032FDA016ED2A5ED /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
-				8A15212BB9B2793762846A62 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -134,12 +140,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7200554C7EB6F6E4E0D35C70 /* Build configuration list for PBXNativeTarget "AppcuesCocoapodsExample" */;
 			buildPhases = (
-				4C465A6830D2F916F60E50B5 /* [CP] Check Pods Manifest.lock */,
+				DCA7467F2C04F047D92D1523 /* [CP] Check Pods Manifest.lock */,
 				39C4F25C30C2C38F00378FED /* Sources */,
 				4B41B1A9E3D52747D92B7344 /* Resources */,
 				6D4DB9FBC4445D937FD94125 /* SwiftLint */,
-				BF4055A3D93940BA0A718D5B /* Frameworks */,
-				EA51D6999E9948CC1C03A546 /* [CP] Embed Pods Frameworks */,
+				AF4052F4A8F1AC8BA3830CBB /* Frameworks */,
+				3C5F22369007B4C7514515DD /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -161,7 +167,7 @@
 				};
 			};
 			buildConfigurationList = 95033167E7E129F199208F61 /* Build configuration list for PBXProject "AppcuesCocoapodsExample" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -197,7 +203,42 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4C465A6830D2F916F60E50B5 /* [CP] Check Pods Manifest.lock */ = {
+		3C5F22369007B4C7514515DD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6D4DB9FBC4445D937FD94125 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.50.3\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
+		};
+		DCA7467F2C04F047D92D1523 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -219,41 +260,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6D4DB9FBC4445D937FD94125 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.50.3\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
-		};
-		EA51D6999E9948CC1C03A546 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -263,6 +269,8 @@
 			files = (
 				A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */,
 				68E596FD295BCC69F06AF0B4 /* DeepLinkNavigator.swift in Sources */,
+				622C6559F57A6A19F18D46C4 /* EmbedTestHarnessViewController.swift in Sources */,
+				8F7329B0046118A1DFA8B58D /* EmbedViewController.swift in Sources */,
 				EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */,
 				64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */,
 				CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */,
@@ -295,7 +303,7 @@
 /* Begin XCBuildConfiguration section */
 		015038143918E0C7F9D7E873 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 76225932032FDA016ED2A5ED /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
+			baseConfigurationReference = 925915F4923FF8E1B2479C94 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -377,7 +385,7 @@
 		};
 		266E5C088CC8701B4117B193 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8A15212BB9B2793762846A62 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
+			baseConfigurationReference = 2777BD40C9776A5F0E012EE4 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
@@ -115,11 +115,29 @@
                         <segue destination="5i6-8x-7nf" kind="relationship" relationship="viewControllers" id="haS-vB-LEW"/>
                         <segue destination="FK3-TP-f03" kind="relationship" relationship="viewControllers" id="hwS-Sk-N0w"/>
                         <segue destination="XJ3-u7-yjq" kind="relationship" relationship="viewControllers" id="8zI-7k-vlH"/>
+                        <segue destination="zVG-YT-CE4" kind="relationship" relationship="viewControllers" id="toZ-yu-dsR"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VfC-g5-VX7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-314" y="175"/>
+        </scene>
+        <!--Embed-->
+        <scene sceneID="W5m-WR-dL0">
+            <objects>
+                <navigationController id="zVG-YT-CE4" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Embed" image="rectangle.portrait.topthird.inset.filled" catalog="system" id="Yd9-oc-M3j"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="tDD-bN-mNi">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="2UE-rA-lV6" kind="relationship" relationship="rootViewController" id="Bu4-Ki-Yaj"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="luJ-JQ-KbQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2009" y="1034"/>
         </scene>
         <!--Sign In-->
         <scene sceneID="tne-QT-ifu">
@@ -285,6 +303,159 @@
             </objects>
             <point key="canvasLocation" x="877" y="1732"/>
         </scene>
+        <!--Embed Experiences-->
+        <scene sceneID="4CY-rf-DwC">
+            <objects>
+                <viewController id="2UE-rA-lV6" customClass="EmbedViewController" customModule="AppcuesCocoapodsExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="RL9-5P-AOb">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NJ2-fh-Wo3">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="lLF-bg-0LD">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1997"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="phL-Ap-Txv" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" placeholder="YES" id="O4S-bx-s56"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AeE-4e-n5n">
+                                                <rect key="frame" x="0.0" y="120" width="414" height="237.5"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SHW-5O-z91">
+                                                        <rect key="frame" x="20" y="0.0" width="374" height="34.5"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="tinted" title="Show Test Harness Screen"/>
+                                                        <connections>
+                                                            <action selector="showTestHarness:" destination="2UE-rA-lV6" eventType="touchUpInside" id="PFv-Di-prJ"/>
+                                                        </connections>
+                                                    </button>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RP0-Wt-Ymd">
+                                                        <rect key="frame" x="20" y="54.5" width="374" height="183"/>
+                                                        <string key="text">Embedded Experiences, or Embeds for short, are experiences that are injected inline with the customer application views, rather than overlaid on top. Embeds can contain a variety of content. Any type of experience content you could show in a modal step could also be embedded into a non-modal view in the application. This pattern is commonly used for less obtrusive promotions or supplemental content, inline banners or help tips.</string>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="RP0-Wt-Ymd" secondAttribute="bottom" id="8X0-Hb-VTb"/>
+                                                    <constraint firstItem="RP0-Wt-Ymd" firstAttribute="leading" secondItem="AeE-4e-n5n" secondAttribute="leading" constant="20" id="AZn-Ou-H8G"/>
+                                                    <constraint firstAttribute="trailing" secondItem="RP0-Wt-Ymd" secondAttribute="trailing" constant="20" id="POC-EE-mi2"/>
+                                                    <constraint firstItem="RP0-Wt-Ymd" firstAttribute="top" secondItem="SHW-5O-z91" secondAttribute="bottom" constant="20" id="QIe-4u-pPi"/>
+                                                    <constraint firstAttribute="trailing" secondItem="SHW-5O-z91" secondAttribute="trailing" constant="20" id="Z6I-aT-yLT"/>
+                                                    <constraint firstItem="SHW-5O-z91" firstAttribute="leading" secondItem="AeE-4e-n5n" secondAttribute="leading" constant="20" id="Zfs-t3-KX7"/>
+                                                    <constraint firstItem="SHW-5O-z91" firstAttribute="top" secondItem="AeE-4e-n5n" secondAttribute="top" id="mTF-F1-7kP"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xUE-z3-DdK" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                <rect key="frame" x="0.0" y="377.5" width="414" height="100"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" placeholder="YES" id="Blb-Ul-lDy"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xov-5D-P80">
+                                                <rect key="frame" x="0.0" y="497.5" width="414" height="345"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DZM-Va-fhz">
+                                                        <rect key="frame" x="20" y="0.0" width="374" height="345"/>
+                                                        <mutableString key="text">Embeds are a low-code pattern, requiring customer application development work to be done to create and expose injectable view areas where Appcues content can reside. This involves creating and registering a special AppcuesFrame view types with the iOS and Android SDKs, and including those views in the customer app layouts. This concept of view embedding is analogous to products like the Google Ads SDKs for mobile display ads. The details of how the embed views are registered with the native SDKs are outside of the scope of this document, which focuses on the data model updates. SDK documentation will cover those other integration topics.</mutableString>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="DZM-Va-fhz" firstAttribute="leading" secondItem="xov-5D-P80" secondAttribute="leading" constant="20" id="7U8-gq-9ej"/>
+                                                    <constraint firstAttribute="trailing" secondItem="DZM-Va-fhz" secondAttribute="trailing" constant="20" id="9x9-Cr-mMo"/>
+                                                    <constraint firstAttribute="bottom" secondItem="DZM-Va-fhz" secondAttribute="bottom" id="tMO-Wf-5aZ"/>
+                                                    <constraint firstItem="DZM-Va-fhz" firstAttribute="top" secondItem="xov-5D-P80" secondAttribute="top" id="zS0-OR-7yA"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZrP-hS-qJ7" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                <rect key="frame" x="0.0" y="862.5" width="414" height="100"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" placeholder="YES" id="mr6-ad-KqD"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oi6-j5-7jx">
+                                                <rect key="frame" x="0.0" y="982.5" width="414" height="1014.5"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="rzm-Me-TGj">
+                                                        <rect key="frame" x="20" y="0.0" width="374" height="1014.5"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kqd-0G-DF3">
+                                                                <rect key="frame" x="0.0" y="0.0" width="254" height="1014.5"/>
+                                                                <mutableString key="text">Before mobile embeds were supported, the Appcues mobile SDKs could render a single mobile flow at a time, modally as an overlay. These experiences could have had modal or tooltip steps, but the response from the server qualification would return a prioritized list of mobile flows and the SDK would render the highest priority item possible.
+
+With embeds, this paradigm changes, and a qualification response may contain zero or more mobile embeds that can be rendered simultaneously, as well as zero or more mobile flows, which are handled just like before, rendering a single highest priority item. Mobile embeds and mobile flow pattern types are entirely mutually exclusive, meaning you cannot have tooltip mobile flow steps within an embed experience, for example. However, you can launch a mobile flow from a mobile embed with a button action.</mutableString>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="amZ-r8-fhe" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                                <rect key="frame" x="274" y="0.0" width="100" height="1014.5"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="100" id="4mR-3w-bvX"/>
+                                                                </constraints>
+                                                            </view>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="rzm-Me-TGj" secondAttribute="bottom" id="JP5-xu-R9F"/>
+                                                    <constraint firstAttribute="trailing" secondItem="rzm-Me-TGj" secondAttribute="trailing" constant="20" id="h01-pq-Y3j"/>
+                                                    <constraint firstItem="rzm-Me-TGj" firstAttribute="top" secondItem="Oi6-j5-7jx" secondAttribute="top" id="nVB-kj-MxY"/>
+                                                    <constraint firstItem="rzm-Me-TGj" firstAttribute="leading" secondItem="Oi6-j5-7jx" secondAttribute="leading" constant="20" id="q0U-fC-4dF"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="leading" secondItem="NJ2-fh-Wo3" secondAttribute="leading" id="1Ja-Mv-cvS"/>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="centerX" secondItem="NJ2-fh-Wo3" secondAttribute="centerX" id="EuZ-Ly-gql"/>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="width" secondItem="NJ2-fh-Wo3" secondAttribute="width" id="LPO-Bk-Nrx"/>
+                                    <constraint firstAttribute="bottom" secondItem="lLF-bg-0LD" secondAttribute="bottom" id="Swb-BK-xIw"/>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="top" secondItem="NJ2-fh-Wo3" secondAttribute="top" id="Zej-CC-tuT"/>
+                                    <constraint firstAttribute="trailing" secondItem="lLF-bg-0LD" secondAttribute="trailing" id="dle-8M-yz0"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="E4f-mL-fv2"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="9UQ-jo-QRs"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="DeF-Jy-Iew"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="NJ2-fh-Wo3" secondAttribute="bottom" id="9B2-de-i2M"/>
+                            <constraint firstAttribute="trailing" secondItem="NJ2-fh-Wo3" secondAttribute="trailing" id="KQ7-H0-5up"/>
+                            <constraint firstItem="NJ2-fh-Wo3" firstAttribute="top" secondItem="RL9-5P-AOb" secondAttribute="top" id="kcQ-aL-gQP"/>
+                            <constraint firstItem="NJ2-fh-Wo3" firstAttribute="leading" secondItem="RL9-5P-AOb" secondAttribute="leading" id="qmG-NV-Nzi"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Embed Experiences" id="t09-9b-ts7"/>
+                    <connections>
+                        <outlet property="appcuesFrame1" destination="phL-Ap-Txv" id="Lcx-4f-2SV"/>
+                        <outlet property="appcuesFrame2" destination="xUE-z3-DdK" id="M88-2g-6iX"/>
+                        <outlet property="appcuesFrame3" destination="ZrP-hS-qJ7" id="bEr-RW-21w"/>
+                        <outlet property="appcuesFrame4" destination="amZ-r8-fhe" id="MxW-ge-agg"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ani-2E-lor" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2008.6956521739132" y="1733.7053571428571"/>
+        </scene>
         <!--Trigger Events-->
         <scene sceneID="EYp-iv-EJ2">
             <objects>
@@ -325,8 +496,8 @@
                             <constraint firstItem="ftz-h7-czn" firstAttribute="leading" secondItem="aEO-X7-xEa" secondAttribute="leading" constant="20" id="tql-yd-qRq"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="Trigger Events" id="1Wg-Nt-6AG">
-                        <barButtonItem key="rightBarButtonItem" tag="1001" title="Debug" id="2EG-CO-a7g">
+                    <navigationItem key="navigationItem" title="Trigger Events" customizationIdentifier="eventsNavTitle" id="1Wg-Nt-6AG">
+                        <barButtonItem key="rightBarButtonItem" tag="1001" title="Debug" largeContentSizeImage="Debug" id="2EG-CO-a7g">
                             <connections>
                                 <action selector="debugTapped:" destination="IV4-7k-Qev" id="dwJ-yS-z6H"/>
                             </connections>
@@ -341,7 +512,7 @@
         <scene sceneID="wzk-0K-XBg">
             <objects>
                 <navigationController id="5i6-8x-7nf" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Events" image="recordingtape" catalog="system" id="uki-uJ-rK0">
+                    <tabBarItem key="tabBarItem" tag="1004" title="Events" image="recordingtape" catalog="system" id="uki-uJ-rK0">
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="tabEvents"/>
                         </userDefinedRuntimeAttributes>
@@ -360,12 +531,14 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="qoH-MI-PZN"/>
+        <segue reference="Jyl-aa-X5t"/>
     </inferredMetricsTieBreakers>
     <resources>
+        <image name="Debug" width="128" height="128"/>
         <image name="person" catalog="system" width="128" height="121"/>
         <image name="person.3" catalog="system" width="128" height="62"/>
         <image name="recordingtape" catalog="system" width="128" height="60"/>
+        <image name="rectangle.portrait.topthird.inset.filled" catalog="system" width="115" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/DeepLinkNavigator.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/DeepLinkNavigator.swift
@@ -20,6 +20,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
             case events
             case profile
             case group
+            case embed
 
             init?(path: String?) {
                 switch path?.lowercased() {
@@ -27,6 +28,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                 case "events": self = .events
                 case "profile": self = .profile
                 case "group": self = .group
+                case "embed": self = .embed
                 default: return nil
                 }
             }
@@ -38,6 +40,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                 case .events: return 0
                 case .profile: return 1
                 case .group: return 2
+                case .embed: return 3
                 }
             }
         }
@@ -71,6 +74,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
         case events(EventsViewController)
         case profile(ProfileViewController)
         case group(GroupViewController)
+        case embed(EmbedViewController)
 
         var controller: UIViewController {
             switch self {
@@ -78,6 +82,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
             case .events(let controller): return controller
             case .profile(let controller): return controller
             case .group(let controller): return controller
+            case .embed(let controller): return controller
             }
         }
 
@@ -96,6 +101,8 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                     screen = .profile(profileController)
                 } else if let groupController = rootController as? GroupViewController {
                     screen = .group(groupController)
+                } else if let embedController = rootController as? EmbedViewController {
+                    screen = .embed(embedController)
                 }
             }
 
@@ -173,7 +180,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
     private func navigate(from origin: AppScreen, to target: DeepLink, in window: UIWindow, completion: ((Bool) -> Void)?) {
 
         switch (origin, target.destination) {
-        case (.signIn, .signIn), (.events, .events), (.profile, .profile), (.group, .group):
+        case (.signIn, .signIn), (.events, .events), (.profile, .profile), (.group, .group), (.embed, .embed):
             // Linking to current screen, no changes needed
             break
         case (_, .signIn):

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedTestHarnessViewController.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedTestHarnessViewController.swift
@@ -1,0 +1,118 @@
+//
+//  EmbedTestHarnessViewController.swift
+//  AppcuesCocoapodsExample
+//
+//  Created by Matt on 2023-06-26.
+//
+
+import UIKit
+import AppcuesKit
+
+class EmbedTestHarnessView: UIScrollView {
+    weak var frame1: AppcuesFrameView?
+    weak var frame2: AppcuesFrameView?
+
+    let stackView: UIStackView = {
+        let view = UIStackView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.axis = .vertical
+        view.alignment = .fill
+        view.distribution = .fill
+        view.spacing = 12
+        return view
+    }()
+
+    init() {
+        super.init(frame: .zero)
+
+        backgroundColor = .systemBackground
+
+        addSubview(stackView)
+
+        stackView.addArrangedSubview(makeLabel("Embed Test Harness", textStyle: .title1))
+        stackView.addArrangedSubview(makeLabel("About this screen", textStyle: .title3))
+        // swiftlint:disable:next line_length
+        stackView.addArrangedSubview(makeLabel("This screen doesn't automatically track any Appcues screens or events. Not automatically tracking allows you to simulate different combinations of screens/events and how they impact the embed rendering lifecycle.", textStyle: .body))
+        stackView.addArrangedSubview(makeLabel("Use the 3 dots menu to trigger events and toggle embed frames.", textStyle: .body))
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: widthAnchor)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func makeLabel(_ text: String, textStyle: UIFont.TextStyle) -> UILabel {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = .preferredFont(forTextStyle: textStyle)
+        label.text = text
+
+        return label
+    }
+
+    func toggleFrame(id: String, viewController: UIViewController) {
+        if id == "frame1" {
+            if frame1 == nil {
+                let frame = AppcuesFrameView()
+                stackView.insertArrangedSubview(frame, at: 1)
+                frame1 = frame
+                Appcues.shared.register(frameID: id, for: frame, on: viewController)
+            } else {
+                frame1?.removeFromSuperview()
+            }
+        } else if id == "frame2" {
+            if frame2 == nil {
+                let frame = AppcuesFrameView()
+                stackView.insertArrangedSubview(frame, at: 3)
+                frame2 = frame
+                Appcues.shared.register(frameID: id, for: frame, on: viewController)
+            } else {
+                frame2?.removeFromSuperview()
+            }
+        }
+    }
+}
+
+class EmbedTestHarnessViewController: UIViewController {
+
+    lazy var testHarnessView = EmbedTestHarnessView()
+
+    override func loadView() {
+        view = testHarnessView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Embed Test Harness"
+
+        if #available(iOS 14.0, *) {
+            let menu = UIMenu(title: "", children: [
+                UIAction(title: "Track Screen", image: UIImage(systemName: "rectangle.portrait.on.rectangle.portrait")) { _ in
+                    Appcues.shared.screen(title: "Embed Harness")
+                },
+                UIAction(title: "Track Event", image: UIImage(systemName: "hand.tap")) { _ in
+                    Appcues.shared.track(name: "event3")
+                },
+                UIAction(title: "Toggle Frame 1", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                    guard let self = self else { return }
+                    self.testHarnessView.toggleFrame(id: "frame1", viewController: self)
+                },
+                UIAction(title: "Toggle Frame 2", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                    guard let self = self else { return }
+                    self.testHarnessView.toggleFrame(id: "frame2", viewController: self)
+                }
+            ])
+
+            navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), menu: menu)
+        }
+    }
+}

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedTestHarnessViewController.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedTestHarnessViewController.swift
@@ -102,11 +102,11 @@ class EmbedTestHarnessViewController: UIViewController {
                 UIAction(title: "Track Event", image: UIImage(systemName: "hand.tap")) { _ in
                     Appcues.shared.track(name: "event3")
                 },
-                UIAction(title: "Toggle Frame 1", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                UIAction(title: "Toggle 'frame1'", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
                     guard let self = self else { return }
                     self.testHarnessView.toggleFrame(id: "frame1", viewController: self)
                 },
-                UIAction(title: "Toggle Frame 2", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                UIAction(title: "Toggle 'frame2'", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
                     guard let self = self else { return }
                     self.testHarnessView.toggleFrame(id: "frame2", viewController: self)
                 }

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedViewController.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedViewController.swift
@@ -1,0 +1,37 @@
+//
+//  EmbedViewController.swift
+//  AppcuesCocoapodsExample
+//
+//  Created by James Ellis on 8/15/22.
+//
+
+import UIKit
+import AppcuesKit
+
+class EmbedViewController: UIViewController {
+
+    @IBOutlet private var appcuesFrame1: AppcuesFrameView!
+    @IBOutlet private var appcuesFrame2: AppcuesFrameView!
+    @IBOutlet private var appcuesFrame3: AppcuesFrameView!
+    @IBOutlet private var appcuesFrame4: AppcuesFrameView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        Appcues.shared.register(frameID: "frame1", for: appcuesFrame1, on: self)
+        Appcues.shared.register(frameID: "frame2", for: appcuesFrame2, on: self)
+        Appcues.shared.register(frameID: "frame3", for: appcuesFrame3, on: self)
+        Appcues.shared.register(frameID: "frame4", for: appcuesFrame4, on: self)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        Appcues.shared.screen(title: "Embed Container")
+    }
+
+    @IBAction private func showTestHarness(_ sender: UIButton) {
+        present(UINavigationController(rootViewController: EmbedTestHarnessViewController()), animated: true)
+    }
+
+}

--- a/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
@@ -3,16 +3,18 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B83F9E94137632FE3005F50 /* EmbedTestHarnessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7668CA3A542361436CA5C3B7 /* EmbedTestHarnessViewController.swift */; };
 		111D1F044CE5C429A13E377B /* Mulish-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D140F36AD3D06536C395A074 /* Mulish-VariableFont_wght.ttf */; };
 		62B165983718917D2D41BA5C /* Mulish-Italic-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 17D5A01020B551B33B447DC1 /* Mulish-Italic-VariableFont_wght.ttf */; };
 		64EFAB6E2ED72F70B75B98F1 /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7C790690C785694C7F24F8 /* EventsViewController.swift */; };
 		7013CDD44A5E7E6056595498 /* Lato-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 05539DC01B30BEB3C8796C56 /* Lato-Black.ttf */; };
 		702B963B624B5F8BB19F2468 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8757BA449145145EAF8FE061 /* Main.storyboard */; };
 		7A219B6092786F843A1A004A /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7A2AD399FBBF5EB8AEBE70BF /* Lato-Bold.ttf */; };
+		9EF6EF267BBE750196BB8852 /* EmbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC01F919D7C1743A7217373 /* EmbedViewController.swift */; };
 		A0C767D67BF836D241C38AB0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7203E757C2C6EA5D37C5E443 /* Assets.xcassets */; };
 		A23B377CAA8FFC989E6A9A73 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A540BC606C8E2160FB2B489 /* AppDelegate.swift */; };
 		AB4DA4AF52B5BC21308C439B /* AppcuesKit in Frameworks */ = {isa = PBXBuildFile; productRef = 781D0ABDB3436955E4EA34B9 /* AppcuesKit */; };
@@ -34,6 +36,7 @@
 		6FF4A6230C0803185A864738 /* AppcuesSPMExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AppcuesSPMExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7203E757C2C6EA5D37C5E443 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		723869D8744D77D8EC9B55F1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		7668CA3A542361436CA5C3B7 /* EmbedTestHarnessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedTestHarnessViewController.swift; sourceTree = "<group>"; };
 		7A2AD399FBBF5EB8AEBE70BF /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
 		7A540BC606C8E2160FB2B489 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7A931564B0DEB1FE780CD0A2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -44,6 +47,7 @@
 		C77616FC1B7BAE52C91F4FBD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		D140F36AD3D06536C395A074 /* Mulish-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		F46FEDAF7B878A4794848F30 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
+		FFC01F919D7C1743A7217373 /* EmbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +106,8 @@
 				7A540BC606C8E2160FB2B489 /* AppDelegate.swift */,
 				7203E757C2C6EA5D37C5E443 /* Assets.xcassets */,
 				91C043606EC23556B49010D3 /* DeepLinkNavigator.swift */,
+				7668CA3A542361436CA5C3B7 /* EmbedTestHarnessViewController.swift */,
+				FFC01F919D7C1743A7217373 /* EmbedViewController.swift */,
 				AF7C790690C785694C7F24F8 /* EventsViewController.swift */,
 				87C55D469D39EFF3296C5387 /* GroupViewController.swift */,
 				476767533B954304A7121A53 /* Info.plist */,
@@ -145,6 +151,8 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = 3307568C9084A060E694F2E4 /* Build configuration list for PBXProject "AppcuesSPMExample" */;
 			compatibilityVersion = "Xcode 11.0";
@@ -209,6 +217,8 @@
 			files = (
 				A23B377CAA8FFC989E6A9A73 /* AppDelegate.swift in Sources */,
 				B8DB7327A11245904C6B908F /* DeepLinkNavigator.swift in Sources */,
+				0B83F9E94137632FE3005F50 /* EmbedTestHarnessViewController.swift in Sources */,
+				9EF6EF267BBE750196BB8852 /* EmbedViewController.swift in Sources */,
 				64EFAB6E2ED72F70B75B98F1 /* EventsViewController.swift in Sources */,
 				EE6124C9BB7FB8ACF18B1503 /* GroupViewController.swift in Sources */,
 				F897157F45696443B145C383 /* ProfileViewController.swift in Sources */,

--- a/Examples/DeveloperSPMExample/SPMExample/Base.lproj/Main.storyboard
+++ b/Examples/DeveloperSPMExample/SPMExample/Base.lproj/Main.storyboard
@@ -115,11 +115,29 @@
                         <segue destination="5i6-8x-7nf" kind="relationship" relationship="viewControllers" id="haS-vB-LEW"/>
                         <segue destination="FK3-TP-f03" kind="relationship" relationship="viewControllers" id="hwS-Sk-N0w"/>
                         <segue destination="XJ3-u7-yjq" kind="relationship" relationship="viewControllers" id="8zI-7k-vlH"/>
+                        <segue destination="zVG-YT-CE4" kind="relationship" relationship="viewControllers" id="toZ-yu-dsR"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VfC-g5-VX7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-314" y="175"/>
+        </scene>
+        <!--Embed-->
+        <scene sceneID="W5m-WR-dL0">
+            <objects>
+                <navigationController id="zVG-YT-CE4" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Embed" image="rectangle.portrait.topthird.inset.filled" catalog="system" id="Yd9-oc-M3j"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="tDD-bN-mNi">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="2UE-rA-lV6" kind="relationship" relationship="rootViewController" id="Bu4-Ki-Yaj"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="luJ-JQ-KbQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2009" y="1034"/>
         </scene>
         <!--Sign In-->
         <scene sceneID="tne-QT-ifu">
@@ -285,6 +303,159 @@
             </objects>
             <point key="canvasLocation" x="877" y="1732"/>
         </scene>
+        <!--Embed Experiences-->
+        <scene sceneID="4CY-rf-DwC">
+            <objects>
+                <viewController id="2UE-rA-lV6" customClass="EmbedViewController" customModule="AppcuesSPMExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="RL9-5P-AOb">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NJ2-fh-Wo3">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="lLF-bg-0LD">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1997"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="phL-Ap-Txv" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" placeholder="YES" id="O4S-bx-s56"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AeE-4e-n5n">
+                                                <rect key="frame" x="0.0" y="120" width="414" height="237.5"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SHW-5O-z91">
+                                                        <rect key="frame" x="20" y="0.0" width="374" height="34.5"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="tinted" title="Show Test Harness Screen"/>
+                                                        <connections>
+                                                            <action selector="showTestHarness:" destination="2UE-rA-lV6" eventType="touchUpInside" id="PFv-Di-prJ"/>
+                                                        </connections>
+                                                    </button>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RP0-Wt-Ymd">
+                                                        <rect key="frame" x="20" y="54.5" width="374" height="183"/>
+                                                        <string key="text">Embedded Experiences, or Embeds for short, are experiences that are injected inline with the customer application views, rather than overlaid on top. Embeds can contain a variety of content. Any type of experience content you could show in a modal step could also be embedded into a non-modal view in the application. This pattern is commonly used for less obtrusive promotions or supplemental content, inline banners or help tips.</string>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="RP0-Wt-Ymd" secondAttribute="bottom" id="8X0-Hb-VTb"/>
+                                                    <constraint firstItem="RP0-Wt-Ymd" firstAttribute="leading" secondItem="AeE-4e-n5n" secondAttribute="leading" constant="20" id="AZn-Ou-H8G"/>
+                                                    <constraint firstAttribute="trailing" secondItem="RP0-Wt-Ymd" secondAttribute="trailing" constant="20" id="POC-EE-mi2"/>
+                                                    <constraint firstItem="RP0-Wt-Ymd" firstAttribute="top" secondItem="SHW-5O-z91" secondAttribute="bottom" constant="20" id="QIe-4u-pPi"/>
+                                                    <constraint firstAttribute="trailing" secondItem="SHW-5O-z91" secondAttribute="trailing" constant="20" id="Z6I-aT-yLT"/>
+                                                    <constraint firstItem="SHW-5O-z91" firstAttribute="leading" secondItem="AeE-4e-n5n" secondAttribute="leading" constant="20" id="Zfs-t3-KX7"/>
+                                                    <constraint firstItem="SHW-5O-z91" firstAttribute="top" secondItem="AeE-4e-n5n" secondAttribute="top" id="mTF-F1-7kP"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xUE-z3-DdK" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                <rect key="frame" x="0.0" y="377.5" width="414" height="100"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" placeholder="YES" id="Blb-Ul-lDy"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xov-5D-P80">
+                                                <rect key="frame" x="0.0" y="497.5" width="414" height="345"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DZM-Va-fhz">
+                                                        <rect key="frame" x="20" y="0.0" width="374" height="345"/>
+                                                        <mutableString key="text">Embeds are a low-code pattern, requiring customer application development work to be done to create and expose injectable view areas where Appcues content can reside. This involves creating and registering a special AppcuesFrame view types with the iOS and Android SDKs, and including those views in the customer app layouts. This concept of view embedding is analogous to products like the Google Ads SDKs for mobile display ads. The details of how the embed views are registered with the native SDKs are outside of the scope of this document, which focuses on the data model updates. SDK documentation will cover those other integration topics.</mutableString>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="DZM-Va-fhz" firstAttribute="leading" secondItem="xov-5D-P80" secondAttribute="leading" constant="20" id="7U8-gq-9ej"/>
+                                                    <constraint firstAttribute="trailing" secondItem="DZM-Va-fhz" secondAttribute="trailing" constant="20" id="9x9-Cr-mMo"/>
+                                                    <constraint firstAttribute="bottom" secondItem="DZM-Va-fhz" secondAttribute="bottom" id="tMO-Wf-5aZ"/>
+                                                    <constraint firstItem="DZM-Va-fhz" firstAttribute="top" secondItem="xov-5D-P80" secondAttribute="top" id="zS0-OR-7yA"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZrP-hS-qJ7" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                <rect key="frame" x="0.0" y="862.5" width="414" height="100"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" placeholder="YES" id="mr6-ad-KqD"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oi6-j5-7jx">
+                                                <rect key="frame" x="0.0" y="982.5" width="414" height="1014.5"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="rzm-Me-TGj">
+                                                        <rect key="frame" x="20" y="0.0" width="374" height="1014.5"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kqd-0G-DF3">
+                                                                <rect key="frame" x="0.0" y="0.0" width="254" height="1014.5"/>
+                                                                <mutableString key="text">Before mobile embeds were supported, the Appcues mobile SDKs could render a single mobile flow at a time, modally as an overlay. These experiences could have had modal or tooltip steps, but the response from the server qualification would return a prioritized list of mobile flows and the SDK would render the highest priority item possible.
+
+With embeds, this paradigm changes, and a qualification response may contain zero or more mobile embeds that can be rendered simultaneously, as well as zero or more mobile flows, which are handled just like before, rendering a single highest priority item. Mobile embeds and mobile flow pattern types are entirely mutually exclusive, meaning you cannot have tooltip mobile flow steps within an embed experience, for example. However, you can launch a mobile flow from a mobile embed with a button action.</mutableString>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="amZ-r8-fhe" customClass="AppcuesFrameView" customModule="AppcuesKit">
+                                                                <rect key="frame" x="274" y="0.0" width="100" height="1014.5"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="100" id="4mR-3w-bvX"/>
+                                                                </constraints>
+                                                            </view>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="rzm-Me-TGj" secondAttribute="bottom" id="JP5-xu-R9F"/>
+                                                    <constraint firstAttribute="trailing" secondItem="rzm-Me-TGj" secondAttribute="trailing" constant="20" id="h01-pq-Y3j"/>
+                                                    <constraint firstItem="rzm-Me-TGj" firstAttribute="top" secondItem="Oi6-j5-7jx" secondAttribute="top" id="nVB-kj-MxY"/>
+                                                    <constraint firstItem="rzm-Me-TGj" firstAttribute="leading" secondItem="Oi6-j5-7jx" secondAttribute="leading" constant="20" id="q0U-fC-4dF"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="leading" secondItem="NJ2-fh-Wo3" secondAttribute="leading" id="1Ja-Mv-cvS"/>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="centerX" secondItem="NJ2-fh-Wo3" secondAttribute="centerX" id="EuZ-Ly-gql"/>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="width" secondItem="NJ2-fh-Wo3" secondAttribute="width" id="LPO-Bk-Nrx"/>
+                                    <constraint firstAttribute="bottom" secondItem="lLF-bg-0LD" secondAttribute="bottom" id="Swb-BK-xIw"/>
+                                    <constraint firstItem="lLF-bg-0LD" firstAttribute="top" secondItem="NJ2-fh-Wo3" secondAttribute="top" id="Zej-CC-tuT"/>
+                                    <constraint firstAttribute="trailing" secondItem="lLF-bg-0LD" secondAttribute="trailing" id="dle-8M-yz0"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="E4f-mL-fv2"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="9UQ-jo-QRs"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="DeF-Jy-Iew"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="NJ2-fh-Wo3" secondAttribute="bottom" id="9B2-de-i2M"/>
+                            <constraint firstAttribute="trailing" secondItem="NJ2-fh-Wo3" secondAttribute="trailing" id="KQ7-H0-5up"/>
+                            <constraint firstItem="NJ2-fh-Wo3" firstAttribute="top" secondItem="RL9-5P-AOb" secondAttribute="top" id="kcQ-aL-gQP"/>
+                            <constraint firstItem="NJ2-fh-Wo3" firstAttribute="leading" secondItem="RL9-5P-AOb" secondAttribute="leading" id="qmG-NV-Nzi"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Embed Experiences" id="t09-9b-ts7"/>
+                    <connections>
+                        <outlet property="appcuesFrame1" destination="phL-Ap-Txv" id="Lcx-4f-2SV"/>
+                        <outlet property="appcuesFrame2" destination="xUE-z3-DdK" id="M88-2g-6iX"/>
+                        <outlet property="appcuesFrame3" destination="ZrP-hS-qJ7" id="bEr-RW-21w"/>
+                        <outlet property="appcuesFrame4" destination="amZ-r8-fhe" id="MxW-ge-agg"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ani-2E-lor" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2008.6956521739132" y="1733.7053571428571"/>
+        </scene>
         <!--Trigger Events-->
         <scene sceneID="EYp-iv-EJ2">
             <objects>
@@ -367,6 +538,7 @@
         <image name="person" catalog="system" width="128" height="121"/>
         <image name="person.3" catalog="system" width="128" height="62"/>
         <image name="recordingtape" catalog="system" width="128" height="60"/>
+        <image name="rectangle.portrait.topthird.inset.filled" catalog="system" width="115" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Examples/DeveloperSPMExample/SPMExample/DeepLinkNavigator.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/DeepLinkNavigator.swift
@@ -20,6 +20,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
             case events
             case profile
             case group
+            case embed
 
             init?(path: String?) {
                 switch path?.lowercased() {
@@ -27,6 +28,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                 case "events": self = .events
                 case "profile": self = .profile
                 case "group": self = .group
+                case "embed": self = .embed
                 default: return nil
                 }
             }
@@ -38,6 +40,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                 case .events: return 0
                 case .profile: return 1
                 case .group: return 2
+                case .embed: return 3
                 }
             }
         }
@@ -71,6 +74,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
         case events(EventsViewController)
         case profile(ProfileViewController)
         case group(GroupViewController)
+        case embed(EmbedViewController)
 
         var controller: UIViewController {
             switch self {
@@ -78,6 +82,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
             case .events(let controller): return controller
             case .profile(let controller): return controller
             case .group(let controller): return controller
+            case .embed(let controller): return controller
             }
         }
 
@@ -96,6 +101,8 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
                     screen = .profile(profileController)
                 } else if let groupController = rootController as? GroupViewController {
                     screen = .group(groupController)
+                } else if let embedController = rootController as? EmbedViewController {
+                    screen = .embed(embedController)
                 }
             }
 
@@ -173,7 +180,7 @@ class DeepLinkNavigator: AppcuesNavigationDelegate {
     private func navigate(from origin: AppScreen, to target: DeepLink, in window: UIWindow, completion: ((Bool) -> Void)?) {
 
         switch (origin, target.destination) {
-        case (.signIn, .signIn), (.events, .events), (.profile, .profile), (.group, .group):
+        case (.signIn, .signIn), (.events, .events), (.profile, .profile), (.group, .group), (.embed, .embed):
             // Linking to current screen, no changes needed
             break
         case (_, .signIn):

--- a/Examples/DeveloperSPMExample/SPMExample/EmbedTestHarnessViewController.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/EmbedTestHarnessViewController.swift
@@ -1,0 +1,118 @@
+//
+//  EmbedTestHarnessViewController.swift
+//  AppcuesSPMExample
+//
+//  Created by Matt on 2023-06-26.
+//
+
+import UIKit
+import AppcuesKit
+
+class EmbedTestHarnessView: UIScrollView {
+    weak var frame1: AppcuesFrameView?
+    weak var frame2: AppcuesFrameView?
+
+    let stackView: UIStackView = {
+        let view = UIStackView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.axis = .vertical
+        view.alignment = .fill
+        view.distribution = .fill
+        view.spacing = 12
+        return view
+    }()
+
+    init() {
+        super.init(frame: .zero)
+
+        backgroundColor = .systemBackground
+
+        addSubview(stackView)
+
+        stackView.addArrangedSubview(makeLabel("Embed Test Harness", textStyle: .title1))
+        stackView.addArrangedSubview(makeLabel("About this screen", textStyle: .title3))
+        // swiftlint:disable:next line_length
+        stackView.addArrangedSubview(makeLabel("This screen doesn't automatically track any Appcues screens or events. Not automatically tracking allows you to simulate different combinations of screens/events and how they impact the embed rendering lifecycle.", textStyle: .body))
+        stackView.addArrangedSubview(makeLabel("Use the 3 dots menu to trigger events and toggle embed frames.", textStyle: .body))
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: widthAnchor)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func makeLabel(_ text: String, textStyle: UIFont.TextStyle) -> UILabel {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = .preferredFont(forTextStyle: textStyle)
+        label.text = text
+
+        return label
+    }
+
+    func toggleFrame(id: String, viewController: UIViewController) {
+        if id == "frame1" {
+            if frame1 == nil {
+                let frame = AppcuesFrameView()
+                stackView.insertArrangedSubview(frame, at: 1)
+                frame1 = frame
+                Appcues.shared.register(frameID: id, for: frame, on: viewController)
+            } else {
+                frame1?.removeFromSuperview()
+            }
+        } else if id == "frame2" {
+            if frame2 == nil {
+                let frame = AppcuesFrameView()
+                stackView.insertArrangedSubview(frame, at: 3)
+                frame2 = frame
+                Appcues.shared.register(frameID: id, for: frame, on: viewController)
+            } else {
+                frame2?.removeFromSuperview()
+            }
+        }
+    }
+}
+
+class EmbedTestHarnessViewController: UIViewController {
+
+    lazy var testHarnessView = EmbedTestHarnessView()
+
+    override func loadView() {
+        view = testHarnessView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Embed Test Harness"
+
+        if #available(iOS 14.0, *) {
+            let menu = UIMenu(title: "", children: [
+                UIAction(title: "Track Screen", image: UIImage(systemName: "rectangle.portrait.on.rectangle.portrait")) { _ in
+                    Appcues.shared.screen(title: "Embed Harness")
+                },
+                UIAction(title: "Track Event", image: UIImage(systemName: "hand.tap")) { _ in
+                    Appcues.shared.track(name: "event3")
+                },
+                UIAction(title: "Toggle Frame 1", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                    guard let self = self else { return }
+                    self.testHarnessView.toggleFrame(id: "frame1", viewController: self)
+                },
+                UIAction(title: "Toggle Frame 2", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                    guard let self = self else { return }
+                    self.testHarnessView.toggleFrame(id: "frame2", viewController: self)
+                }
+            ])
+
+            navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), menu: menu)
+        }
+    }
+}

--- a/Examples/DeveloperSPMExample/SPMExample/EmbedTestHarnessViewController.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/EmbedTestHarnessViewController.swift
@@ -102,11 +102,11 @@ class EmbedTestHarnessViewController: UIViewController {
                 UIAction(title: "Track Event", image: UIImage(systemName: "hand.tap")) { _ in
                     Appcues.shared.track(name: "event3")
                 },
-                UIAction(title: "Toggle Frame 1", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                UIAction(title: "Toggle 'frame1'", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
                     guard let self = self else { return }
                     self.testHarnessView.toggleFrame(id: "frame1", viewController: self)
                 },
-                UIAction(title: "Toggle Frame 2", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
+                UIAction(title: "Toggle 'frame2'", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
                     guard let self = self else { return }
                     self.testHarnessView.toggleFrame(id: "frame2", viewController: self)
                 }

--- a/Examples/DeveloperSPMExample/SPMExample/EmbedViewController.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/EmbedViewController.swift
@@ -1,0 +1,37 @@
+//
+//  EmbedViewController.swift
+//  AppcuesSPMExample
+//
+//  Created by James Ellis on 8/15/22.
+//
+
+import UIKit
+import AppcuesKit
+
+class EmbedViewController: UIViewController {
+
+    @IBOutlet private var appcuesFrame1: AppcuesFrameView!
+    @IBOutlet private var appcuesFrame2: AppcuesFrameView!
+    @IBOutlet private var appcuesFrame3: AppcuesFrameView!
+    @IBOutlet private var appcuesFrame4: AppcuesFrameView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        Appcues.shared.register(frameID: "frame1", for: appcuesFrame1, on: self)
+        Appcues.shared.register(frameID: "frame2", for: appcuesFrame2, on: self)
+        Appcues.shared.register(frameID: "frame3", for: appcuesFrame3, on: self)
+        Appcues.shared.register(frameID: "frame4", for: appcuesFrame4, on: self)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        Appcues.shared.screen(title: "Embed Container")
+    }
+
+    @IBAction private func showTestHarness(_ sender: UIButton) {
+        present(UINavigationController(rootViewController: EmbedTestHarnessViewController()), animated: true)
+    }
+
+}


### PR DESCRIPTION
Updating the SPM and Cocoapods examples with the Embed tab and a sub-page that can be launched from the button. The main page has 4 frames (frame1-frame4). The subpage allows toggling 2 frame (frame1, frame2) and will be useful for playing with the most complex sequences.

New `appcues-example://embed` deep link also added.

|Main tab|Button detail screen|
|-|-|
|![Simulator Screenshot - iPhone 14 Pro - 2023-07-11 at 14 26 35](https://github.com/appcues/appcues-ios-sdk/assets/845681/904cd693-9116-4637-9eec-dfac9be6c9ee)|![Simulator Screenshot - iPhone 14 Pro - 2023-07-11 at 14 26 38](https://github.com/appcues/appcues-ios-sdk/assets/845681/c36b1696-20b6-4a18-b737-c60169895ba7)|