### PR TITLE
Set a minimum keyhole corner radius value

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
@@ -213,8 +213,8 @@ extension AppcuesBackdropKeyholeTrait {
             case "circle":
                 self = .circle(blurRadius: blurRadius ?? 0)
             default:
-                // fallback to a tiny value instead of 0 so the path can animate nicely to other values
-                self = .rectangle(cornerRadius: cornerRadius ?? .leastNonzeroMagnitude)
+                // use a tiny value instead of 0 so the path can animate nicely to other values
+                self = .rectangle(cornerRadius: max(cornerRadius ?? 0.0, .leastNonzeroMagnitude))
             }
         }
 


### PR DESCRIPTION
A value of 0 causes awkward transitions, so use `.leastNonZeroMagnitude` as a minimum value.

## Fixed

https://github.com/appcues/appcues-ios-sdk/assets/845681/4abba3ed-8e2f-4f1c-9d80-23f89bd381ed

## Before (broken)

https://github.com/appcues/appcues-ios-sdk/assets/845681/bc90434f-a6f3-4707-87a9-946b6670ec5d

