### PR TITLE
Ensure no empty strings are present in selector property values

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
@@ -145,11 +145,11 @@ internal extension UIView {
 
     private func getAppcuesSelector(autoTag: String? = nil) -> UIKitElementSelector? {
         return UIKitElementSelector(
-            appcuesID: (self as? AppcuesTargetView)?.appcuesID,
-            accessibilityIdentifier: accessibilityIdentifier,
-            accessibilityLabel: accessibilityLabel,
+            appcuesID: (self as? AppcuesTargetView)?.appcuesID.emptyToNil(),
+            accessibilityIdentifier: accessibilityIdentifier.emptyToNil(),
+            accessibilityLabel: accessibilityLabel.emptyToNil(),
             tag: tag != 0 ? "\(self.tag)" : nil,
-            autoTag: autoTag
+            autoTag: autoTag.emptyToNil()
         )
     }
 
@@ -195,5 +195,11 @@ internal extension UIView {
     // to generate the selector string representation
     private func getAutoTag(tabIndex: Int?) -> String? {
         return tabIndex.flatMap { "tab[\($0)]" }
+    }
+}
+
+private extension Optional where Wrapped == String {
+    func emptyToNil() -> String? {
+        self.flatMap { $0.isEmpty ? nil : $0 }
     }
 }

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
@@ -235,6 +235,16 @@ class AppcuesTargetElementTraitTests: XCTestCase {
         XCTAssertNil(view5Element.displayName)
     }
 
+    func testEmptySelectorValues() throws {
+        // empty string values for selector properties
+        // should be stripped out and made nil, resulting in no selector
+        let view1 = AppcuesTargetView(identifier: "")
+        view1.accessibilityIdentifier = ""
+        view1.accessibilityLabel = ""
+        let view1Element = try XCTUnwrap(view1.asViewElement())
+        XCTAssertNil(view1Element.selector)
+    }
+
     func testTabBarDisplayName() throws {
         let tabBarView = UITabBar()
         let tabBarButton1 = UITabBarButton()


### PR DESCRIPTION
Some customer data showed selectors with `""` values - we should ignore these and not create selectors that will not provide any unique value.