### PR TITLE
Add retry capability for target element selector matching

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -288,7 +288,6 @@ extension ExperienceStateMachine {
                 func presentStep(onError: @escaping (Error) -> Void) {
                     do {
                         try package.stepDecoratingTraitUpdater(stepIndex.item, nil)
-                        SdkMetrics.renderStart(experience.requestID)
                         try package.presenter {
                             try? machine.transition(.renderStep)
                         }
@@ -303,6 +302,10 @@ extension ExperienceStateMachine {
                         }
                     }
                 }
+
+                // Rendering metrics start now, and will include any time spent in error/retry of trait application
+                // inside of the presentStep local helper function.
+                SdkMetrics.renderStart(experience.requestID)
 
                 presentStep { error in
                     // on failure, report a fatal error and dismiss the experience

--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesTraitError.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesTraitError.swift
@@ -16,9 +16,16 @@ internal struct AppcuesTraitError: Error, CustomStringConvertible {
     /// This value will be logged to Appcues Studio.
     internal var description: String
 
+    /// When set, this value can indicate a number of milliseconds after which re-application
+    /// of traits can be attempted, to try to auto-recover from this error.
+    internal var retryMilliseconds: Int?
+
     /// Creates an instance of an error.
-    /// - Parameter description: A description of the nature of the error.
-    internal init(description: String) {
+    /// - Parameters:
+    ///   - description: A description of the nature of the error.
+    ///   - retryMilliseconds: The number of milliseconds to wait before attempting to re-apply traits after this error.
+    internal init(description: String, retryMilliseconds: Int? = nil) {
         self.description = description
+        self.retryMilliseconds = retryMilliseconds.flatMap { max(0, $0) } // coerce zero or positive value
     }
 }

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
@@ -323,12 +323,14 @@ extension AppcuesTargetElementTrait {
         appcues: Appcues?,
         selector: [String: String],
         contentPreferredPosition: ContentPosition? = nil,
-        contentDistanceFromTarget: Double? = nil
+        contentDistanceFromTarget: Double? = nil,
+        retryIntervals: [Int]? = nil
     ) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesTargetElementTrait.Config(
             contentPreferredPosition: contentPreferredPosition,
             contentDistanceFromTarget: contentDistanceFromTarget,
-            selector: selector
+            selector: selector,
+            retryIntervals: retryIntervals
         ), appcues: appcues))
     }
 }


### PR DESCRIPTION
This idea would support a `retryIntervals: [Int]?` on the trait config for the `@appcues/target-element` trait, which could optionally supply an array of millisecond delay values to support re-attempting trait application, if it failed with a `TraitError` due to a selector not being matched correctly. This could add more leniency for views that have animated loading or network bound loading that may affect the render performance when looking for an anchored element.

The default values would retry in certain failure scenarios at: 300ms, 900ms, 1800ms, and 3000ms, then report the standard step error if no target could be found after 3s. Having it in the trait config gives us server side control over these defaults, should we need in the future.

Not every type of failure would be retried - for instance, if the `strategy.inflateSelector(from: config.selector)` / "invalid selector" fails - we do not retry - it will never work with the same data model. But I selected the following cases that possibly _could_ succeed after view loading updates are completed:
* "Could not read application layout information" - some unexpected window/VC state
* "No view matching selector" - the common view not found item
* "Multiple non-distinct views matched" - likely not recoverable, but maybe, if a view is transitioning still into a final state where the match becomes unique

The retry happens in the state machine, which basically goes into a waiting state, attempting to present the next step, determining if it can move into rendering state or instead, throw the error. Currently, the error handling + retry is only done on the case of a new step container presentation (on load of a new screen) - and not on the transition to a new step within an existing container. Handling new steps inside the same container would have some additional complications that are out of scope at this point.