### PR TITLE
Embed enhancements

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -33,8 +33,10 @@ internal enum ExperienceRendererError: Error {
 @available(iOS 13.0, *)
 internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
+    // Conformance to `StateMachineOwning`.
     /// State machine for `RenderContext.modal`
     var stateMachine: ExperienceStateMachine?
+    var renderContext: RenderContext?
 
     private var stateMachines = StateMachineDirectory()
     private var potentiallyRenderableExperiences: [RenderContext: [ExperienceData]] = [:]
@@ -60,6 +62,12 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         // If there's already a frame for the context, reset it back to its unregistered state.
         if let existingFrameView = stateMachines[ownerFor: context] as? AppcuesFrameView {
             existingFrameView.reset()
+        }
+
+        // If the machine being started is already registered for a different context,
+        // reset it back to its unregistered state before potentially showing new content.
+        if owner.stateMachine != nil, let frameView = owner as? AppcuesFrameView {
+            frameView.reset()
         }
 
         owner.stateMachine = ExperienceStateMachine(container: container)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -57,6 +57,11 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
     func start(owner: StateMachineOwning, forContext context: RenderContext) {
         guard let container = appcues?.container else { return }
 
+        // If there's already a frame for the context, reset it back to its unregistered state.
+        if let existingFrameView = stateMachines[ownerFor: context] as? AppcuesFrameView {
+            existingFrameView.reset()
+        }
+
         owner.stateMachine = ExperienceStateMachine(container: container)
         stateMachines[ownerFor: context] = owner
         if let pendingExperiences = potentiallyRenderableExperiences[context] {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 internal protocol StateMachineOwning: AnyObject {
+    var renderContext: RenderContext? { get set }
     @available(iOS 13.0, *)
     var stateMachine: ExperienceStateMachine? { get set }
 }
@@ -37,7 +38,15 @@ internal class StateMachineDirectory {
             stateMachines[key]?.value
         }
         set(newValue) {
+            // Enforce uniqueness (a StateMachineOwning may only be registered for a single RenderContext).
+            if let oldRenderContext = newValue?.renderContext, oldRenderContext != key {
+                stateMachines.removeValue(forKey: oldRenderContext)
+            }
+
             stateMachines[key] = WeakStateMachineOwning(newValue)
+
+            // Save the current renderContext so it can be easily removed in the above uniqueness check.
+            newValue?.renderContext = key
         }
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -245,11 +245,18 @@ extension AppcuesCarouselTrait {
             super.init(frame: .zero)
 
             addSubview(collectionView)
+
+            let bottomConstraint = collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            bottomConstraint.priority = .init(999)
+
             NSLayoutConstraint.activate([
                 collectionView.topAnchor.constraint(equalTo: topAnchor),
                 collectionView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
                 collectionView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-                collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+                // this is required so the dialogView has an initial non-zero height, after which it can start sizing to the content.
+                collectionView.layoutMarginsGuide.bottomAnchor.constraint(greaterThanOrEqualTo: collectionView.layoutMarginsGuide.topAnchor, constant: 1),
+                // this has a non-required priority so the previous height constraint can take effect
+                bottomConstraint
             ])
         }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @available(iOS 13.0, *)
-internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
+internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesContainerDecoratingTrait, AppcuesPresentingTrait {
 
     struct Config: Decodable {
         let frameID: String
@@ -45,9 +45,12 @@ internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesWrapperC
         stepController.padding = NSDirectionalEdgeInsets(paddingFrom: style)
     }
 
-    func createWrapper(around containerController: AppcuesExperienceContainerViewController) throws -> UIViewController {
+    func decorate(containerController: AppcuesExperienceContainerViewController) throws {
         applyStyle(style, to: containerController)
-        return containerController
+    }
+
+    func undecorate(containerController: AppcuesExperienceContainerViewController) throws {
+        applyStyle(nil, to: containerController)
     }
 
     func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
@@ -45,12 +45,6 @@ internal class ExperienceWrapperView: UIView {
         contentWrapperView.pin(to: shadowWrappingView)
 
         NSLayoutConstraint.activate([
-            // this is required so the dialogView has an initial non-zero height, after which it can start sizing to the content.
-            contentWrapperView.layoutMarginsGuide.bottomAnchor.constraint(
-                greaterThanOrEqualTo: contentWrapperView.layoutMarginsGuide.topAnchor,
-                constant: 1
-            ),
-
             contentWrapperView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
             contentWrapperView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
 

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
@@ -45,10 +45,8 @@ extension AppcuesFrame {
         override func viewWillLayoutSubviews() {
             super.viewWillLayoutSubviews()
 
-            // When the view is hidden, we want to collapse it down from whatever previous size it had,
-            // but keep it >0 so new content can properly begin to layout.
             if view.isHidden {
-                preferredContentSize = CGSize(width: 0, height: 1)
+                preferredContentSize = .zero
             }
         }
 

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -37,27 +37,9 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
         return constraint
     }()
 
-    // when the view content is non-empty, we use a >= 1 height constraint to allow for dynamic
-    // sizing based on the content
-    private lazy var nonEmptyHeightConstraint: NSLayoutConstraint = {
-        var constraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 1)
-        constraint.priority = .defaultLow
-        constraint.isActive = false
-        return constraint
-    }()
-
     // when the view content is empty, we use this zero width constraint
     private lazy var emptyWidthConstraint: NSLayoutConstraint = {
         var constraint = widthAnchor.constraint(equalToConstant: 0)
-        constraint.priority = .defaultLow
-        constraint.isActive = false
-        return constraint
-    }()
-
-    // when the view content is non-empty, we use a >= 1 width constraint to allow for dynamic
-    // sizing based on the content
-    private lazy var nonEmptyWidthConstraint: NSLayoutConstraint = {
-        var constraint = widthAnchor.constraint(greaterThanOrEqualToConstant: 1)
         constraint.priority = .defaultLow
         constraint.isActive = false
         return constraint
@@ -77,9 +59,7 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
 
     private func configureConstraints(isEmpty: Bool) {
         emptyHeightConstraint.isActive = isEmpty
-        nonEmptyHeightConstraint.isActive = !isEmpty
         emptyWidthConstraint.isActive = isEmpty
-        nonEmptyWidthConstraint.isActive = !isEmpty
     }
 
     // this will only get called on iOS 13+ from the Appcues class during registration

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -16,6 +16,9 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
         case fade
     }
 
+    // Managed by the StateMachineDirectory
+    internal var renderContext: RenderContext?
+
     private var _stateMachine: Any?
     @available(iOS 13.0, *)
     internal var stateMachine: ExperienceStateMachine? {

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -24,6 +24,7 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
     }
 
     private weak var parentViewController: UIViewController?
+    private weak var experienceViewController: UIViewController?
 
     // when the view content is empty, we use this zero height constraint
     private lazy var emptyHeightConstraint: NSLayoutConstraint = {
@@ -94,6 +95,7 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
         configureConstraints(isEmpty: false)
 
         viewController.embedChildViewController(experienceController, inSuperview: self, margins: margins)
+        experienceViewController = experienceController
 
         switch transition {
         case .none:
@@ -133,5 +135,13 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
                 }
             )
         }
+    }
+
+    /// Set the Frame back to an unregistered state.
+    internal func reset() {
+        if let experienceViewController = experienceViewController {
+            unembed(experienceViewController, transition: .none, completion: nil)
+        }
+        _stateMachine = nil
     }
 }


### PR DESCRIPTION
1. For the case where a FrameView(id: A) is registered and then a different FrameView(id: A) is registered. Now We call `reset()` for the first FrameView which removes the appcues content and removes the state machine without triggering any analytics. This essential resets the first FrameView back to how it was before it was registered. This is ideal because the newly registered second frame replaces the first in the state machine directory.
2. `AppcuesFrame` (the SwiftUI implementation) doesn't need the non-zero `preferredContentSize`, and having it created an additional gap in the layout.
3. EDIT: There's also the case where the same FrameView is registered for multiple IDs. Previously that meant the same StateMachineOwning would be in the directory for multiple RenderContexts, causing all kinds of issues. Now if a frame is registered for a new ID, we reset the contents (if there was something showing for ID A, but the ID is now B, it shouldn't show the content for A. This is essentially the `prepareForReuse` scenario). We also enforce uniqueness in the `StateMachineDirectory`, removing the old RenderContext reference before adding the new one.