### PR TITLE
Fix embed rendering

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -245,11 +245,18 @@ extension AppcuesCarouselTrait {
             super.init(frame: .zero)
 
             addSubview(collectionView)
+
+            let bottomConstraint = collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            bottomConstraint.priority = .init(999)
+
             NSLayoutConstraint.activate([
                 collectionView.topAnchor.constraint(equalTo: topAnchor),
                 collectionView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
                 collectionView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-                collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+                // this is required so the dialogView has an initial non-zero height, after which it can start sizing to the content.
+                collectionView.layoutMarginsGuide.bottomAnchor.constraint(greaterThanOrEqualTo: collectionView.layoutMarginsGuide.topAnchor, constant: 1),
+                // this has a non-required priority so the previous height constraint can take effect
+                bottomConstraint
             ])
         }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @available(iOS 13.0, *)
-internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
+internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesContainerDecoratingTrait, AppcuesPresentingTrait {
 
     struct Config: Decodable {
         let frameID: String
@@ -45,9 +45,12 @@ internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesWrapperC
         stepController.padding = NSDirectionalEdgeInsets(paddingFrom: style)
     }
 
-    func createWrapper(around containerController: AppcuesExperienceContainerViewController) throws -> UIViewController {
+    func decorate(containerController: AppcuesExperienceContainerViewController) throws {
         applyStyle(style, to: containerController)
-        return containerController
+    }
+
+    func undecorate(containerController: AppcuesExperienceContainerViewController) throws {
+        applyStyle(nil, to: containerController)
     }
 
     func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
@@ -45,12 +45,6 @@ internal class ExperienceWrapperView: UIView {
         contentWrapperView.pin(to: shadowWrappingView)
 
         NSLayoutConstraint.activate([
-            // this is required so the dialogView has an initial non-zero height, after which it can start sizing to the content.
-            contentWrapperView.layoutMarginsGuide.bottomAnchor.constraint(
-                greaterThanOrEqualTo: contentWrapperView.layoutMarginsGuide.topAnchor,
-                constant: 1
-            ),
-
             contentWrapperView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
             contentWrapperView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
 

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -37,27 +37,9 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
         return constraint
     }()
 
-    // when the view content is non-empty, we use a >= 1 height constraint to allow for dynamic
-    // sizing based on the content
-    private lazy var nonEmptyHeightConstraint: NSLayoutConstraint = {
-        var constraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 1)
-        constraint.priority = .defaultLow
-        constraint.isActive = false
-        return constraint
-    }()
-
     // when the view content is empty, we use this zero width constraint
     private lazy var emptyWidthConstraint: NSLayoutConstraint = {
         var constraint = widthAnchor.constraint(equalToConstant: 0)
-        constraint.priority = .defaultLow
-        constraint.isActive = false
-        return constraint
-    }()
-
-    // when the view content is non-empty, we use a >= 1 width constraint to allow for dynamic
-    // sizing based on the content
-    private lazy var nonEmptyWidthConstraint: NSLayoutConstraint = {
-        var constraint = widthAnchor.constraint(greaterThanOrEqualToConstant: 1)
         constraint.priority = .defaultLow
         constraint.isActive = false
         return constraint
@@ -77,9 +59,7 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
 
     private func configureConstraints(isEmpty: Bool) {
         emptyHeightConstraint.isActive = isEmpty
-        nonEmptyHeightConstraint.isActive = !isEmpty
         emptyWidthConstraint.isActive = isEmpty
-        nonEmptyWidthConstraint.isActive = !isEmpty
     }
 
     // this will only get called on iOS 13+ from the Appcues class during registration


### PR DESCRIPTION
Adjusting the embed trait to be container decorating addresses [an issue](https://appcues.slack.com/archives/C031RLGS4F8/p1692023469654459) where the frame position and size would appear wonkily. This is caused by an early call to the containerVC.view, which triggers viewDidLoad early and means there's a dropped content size update. This change works because `AppcuesWrapperCreatingTrait` gets called early in the trait composer vs `AppcuesContainerDecoratingTrait` which gets called later.

In all my playing around trying to resolve the above issue, I also finally addressed the spots we have the "min size 1" requirement. That requirement was caused by the carousel trait, and so the fix for it should be self contained in the carousel trait rather than having code everywhere (including in the WIP [RN](https://github.com/appcues/appcues-react-native-module/blob/c4842074d4ee8b603a1876339fe1cc2921a79329/ios/AppcuesFrameViewManager.swift#L72-L79) and [Flutter](https://github.com/appcues/appcues-flutter-plugin/blob/77457d00c71ee5d3a4b8e470a1b2b91678a65d4d/ios/Classes/Embeds/AppcuesFrameViewFactory.swift#L119-L126) implementations) to make sure the view has its min size. (The RN and Flutter implementation should be able to do `let size = isHidden ? .zero : preferredContentSize` now.)