### PR TITLE
Session handling updates

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -33,7 +33,7 @@ public extension Appcues {
             UIDevice.identifier
         }
 
-        var sessionTimeout: UInt = 1_800 // 30 minutes by default
+        var sessionTimeout: UInt = 300 // 5 minutes by default
 
         var activityStorageMaxSize: UInt = 25
 
@@ -80,7 +80,7 @@ public extension Appcues {
         }
 
         /// Set the session timeout for the configuration. This timeout value is used to determine if a new session is started
-        /// upon the application returning to the foreground. The default value is 1800 seconds (30 minutes).
+        /// after a period of inactivity, in either foreground or background. The default value is 300 seconds (5 minutes).
         /// - Parameter sessionTimeout: The timeout length, in seconds.
         /// - Returns: The `Configuration` object.
         @discardableResult

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -162,7 +162,6 @@ public class Appcues: NSObject {
     /// Clears out the current user in this session. Can be used when the user logs out of your application.
     @objc
     public func reset() {
-        // call this first to close final analytics on the session
         sessionMonitor.reset()
 
         storage.userID = ""
@@ -337,9 +336,6 @@ public class Appcues: NSObject {
         // register the auto property decorator
         let autoPropDecorator = container.resolve(AutoPropertyDecorator.self)
         analyticsPublisher.register(decorator: autoPropDecorator)
-
-        // start session monitoring
-        sessionMonitor.start()
     }
 
     private func identify(isAnonymous: Bool, userID: String, properties: [String: Any]? = nil) {
@@ -355,7 +351,7 @@ public class Appcues: NSObject {
         storage.userSignature = properties?.removeValue(forKey: "appcues:user_id_signature") as? String
         if userChanged {
             // when the identified user changes from last known value, we must start a new session
-            sessionMonitor.start()
+            sessionMonitor.reset()
 
             // and clear any stored group information - will have to be reset as needed
             storage.groupID = nil

--- a/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
+++ b/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
@@ -10,15 +10,15 @@ import Foundation
 import UIKit
 
 internal protocol SessionMonitoring: AnyObject {
-    func start()
+    var isSessionExpired: Bool { get }
+
+    func start() -> Bool
+    func updateLastActivity()
     func reset()
 }
 
 internal enum SessionEvents: String, CaseIterable {
     case sessionStarted = "appcues:session_started"
-    case sessionSuspended = "appcues:session_suspended"
-    case sessionResumed = "appcues:session_resumed"
-    case sessionReset = "appcues:session_reset"
 
     static var allNames: [String] { allCases.map { $0.rawValue } }
 }
@@ -27,26 +27,24 @@ internal class SessionMonitor: SessionMonitoring {
 
     private weak var appcues: Appcues?
     private let storage: DataStoring
-    private let publisher: AnalyticsPublishing
     private let tracker: AnalyticsTracking
 
     private let sessionTimeout: UInt
 
-    private var applicationBackgrounded: Date?
+    private var lastActivityAt: Date?
+
+    var isSessionExpired: Bool {
+        guard let lastActivityAt = lastActivityAt else { return false }
+        let elapsed = Int(Date().timeIntervalSince(lastActivityAt))
+        return elapsed >= sessionTimeout
+    }
 
     init(container: DIContainer) {
         self.appcues = container.owner
-        self.publisher = container.resolve(AnalyticsPublishing.self)
         self.tracker = container.resolve(AnalyticsTracking.self)
         self.storage = container.resolve(DataStoring.self)
         self.sessionTimeout = container.resolve(Appcues.Config.self).sessionTimeout
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(applicationWillEnterForeground),
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
-        )
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(didEnterBackground),
@@ -56,42 +54,32 @@ internal class SessionMonitor: SessionMonitoring {
     }
 
     // called on (A) sdk init (B) user identity change
-    func start() {
+    func start() -> Bool {
         // if there is no user identified, we do not have a valid session
-        guard !storage.userID.isEmpty else { return }
-
+        guard !storage.userID.isEmpty else { return false }
         appcues?.sessionID = UUID()
-        publisher.track(SessionEvents.sessionStarted, properties: nil, interactive: true)
+        updateLastActivity()
+        return true
+    }
+
+    func updateLastActivity() {
+        guard appcues?.sessionID != nil else { return }
+
+        lastActivityAt = Date()
     }
 
     // called on reset(), user sign-out
     func reset() {
-        // this is interactive: true since a reset should flush to network immediately (with previous user ID)
-        // and the next session start will be sent in a new request, with the new user ID
-        publisher.track(SessionEvents.sessionReset, properties: nil, interactive: true)
+        // ensure any pending in-memory analytics get processed asap
+        tracker.flush()
+
         appcues?.sessionID = nil
-    }
-
-    @objc
-    func applicationWillEnterForeground(notification: Notification) {
-        guard appcues?.sessionID != nil, let applicationBackgrounded = applicationBackgrounded else { return }
-
-        let elapsed = Int(Date().timeIntervalSince(applicationBackgrounded))
-        self.applicationBackgrounded = nil
-
-        if elapsed >= sessionTimeout {
-            appcues?.sessionID = UUID()
-            publisher.track(SessionEvents.sessionStarted, properties: nil, interactive: true)
-        } else {
-            publisher.track(SessionEvents.sessionResumed, properties: nil, interactive: false)
-        }
+        lastActivityAt = nil
     }
 
     @objc
     func didEnterBackground(notification: Notification) {
         guard appcues?.sessionID != nil else { return }
-        applicationBackgrounded = Date()
-        publisher.track(SessionEvents.sessionSuspended, properties: nil, interactive: false)
 
         // ensure any pending in-memory analytics get processed asap
         tracker.flush()

--- a/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
+++ b/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
@@ -53,7 +53,8 @@ internal class SessionMonitor: SessionMonitoring {
         )
     }
 
-    // called on (A) sdk init (B) user identity change
+    // called by AnalyticsPublisher on-demand, when it recognizes no session
+    // exists, or the existing session has expired
     func start() -> Bool {
         // if there is no user identified, we do not have a valid session
         guard !storage.userID.isEmpty else { return false }

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -132,6 +132,8 @@ internal class UIDebugger: UIDebugging {
     @objc
     private func appcuesReset(notification: Notification) {
         self.viewModel.reset()
+        self.viewModel.currentUserID = self.storage.userID
+        self.viewModel.isAnonymous = self.storage.isAnonymous
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
@@ -68,7 +68,11 @@ internal class DeepLinkHandler: DeepLinkHandling {
 
     func didHandleURL(_ url: URL) -> Bool {
         guard let applicationID = config?.applicationID,
-              let action = Action(url: url, isSessionActive: container?.owner?.isActive ?? false, applicationID: applicationID) else {
+              let action = Action(
+                url: url,
+                isSessionActive: container?.owner?.isActive ?? false,
+                applicationID: applicationID
+              ) else {
             return false
         }
 

--- a/Tests/AppcuesKitTests/Analytics/SessionMonitorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/SessionMonitorTests.swift
@@ -22,71 +22,51 @@ class SessionMonitorTests: XCTestCase {
 
     override func tearDown() {
         // SessionMonitor uses the shared NotificationCenter.default when listening to system
-        // foreground/background notifications - we need to unhook these listners after each test
+        // foreground/background notifications - we need to unhook these listeners after each test
         // so that no instance lingers around and fulfills expectations more than once due to
         // that shared resource triggering additional events to flow through the system on older
         // Appcues instances from previous tests.
-        appcues.analyticsPublisher.onPublish = nil
         appcues.analyticsTracker.onFlush = nil
     }
 
     func testStart() throws {
         // Arrange
-        let onTrackExpectation = expectation(description: "session analytics tracked")
         appcues.storage.userID = "user123"
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case .event(SessionEvents.sessionStarted.rawValue, let interactive) = trackingUpdate.type {
-                XCTAssertTrue(interactive)
-                XCTAssertNil(trackingUpdate.properties)
-                onTrackExpectation.fulfill()
-            }
-        }
 
         // Act
-        sessionMonitor.start()
+        let sessionStarted = sessionMonitor.start()
 
         // Assert
-        waitForExpectations(timeout: 1)
+        XCTAssertTrue(sessionStarted)
         XCTAssertTrue(appcues.isActive)
     }
 
     func testStartNoUser() throws {
         // Arrange
-        let onTrackExpectation = expectation(description: "session analytics tracked")
-        onTrackExpectation.isInverted = true
         appcues.storage.userID = ""
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case .event(SessionEvents.sessionStarted.rawValue, _) = trackingUpdate.type {
-                onTrackExpectation.fulfill()
-            }
-        }
 
         // Act
-        sessionMonitor.start()
+        let sessionStarted = sessionMonitor.start()
 
         // Assert
-        waitForExpectations(timeout: 1)
+        XCTAssertFalse(sessionStarted)
         XCTAssertFalse(appcues.isActive)
     }
 
     func testReset() throws {
         // Arrange
         appcues.storage.userID = "user123"
-        sessionMonitor.start()
-        appcues.storage.userID = ""
-        let onTrackExpectation = expectation(description: "session analytics tracked")
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case .event(SessionEvents.sessionReset.rawValue, let interactive) = trackingUpdate.type {
-                XCTAssertTrue(interactive)
-                XCTAssertNil(trackingUpdate.properties)
-                onTrackExpectation.fulfill()
-            }
+        let sessionStarted = sessionMonitor.start()
+        let onFlushExpectation = expectation(description: "analytics tracker flushed")
+        appcues.analyticsTracker.onFlush = {
+            onFlushExpectation.fulfill()
         }
 
         // Act
         sessionMonitor.reset()
 
         // Assert
+        XCTAssertTrue(sessionStarted)
         waitForExpectations(timeout: 1)
         XCTAssertFalse(appcues.isActive)
     }
@@ -94,16 +74,8 @@ class SessionMonitorTests: XCTestCase {
     func testBackground() throws {
         // Arrange
         appcues.storage.userID = "user123"
-        sessionMonitor.start()
-        let onTrackExpectation = expectation(description: "session analytics tracked")
+        let sessionStarted = sessionMonitor.start()
         let onFlushExpectation = expectation(description: "analytics tracker flushed")
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case .event(SessionEvents.sessionSuspended.rawValue, let interactive) = trackingUpdate.type {
-                XCTAssertFalse(interactive)
-                XCTAssertNil(trackingUpdate.properties)
-                onTrackExpectation.fulfill()
-            }
-        }
         appcues.analyticsTracker.onFlush = {
             onFlushExpectation.fulfill()
         }
@@ -114,19 +86,13 @@ class SessionMonitorTests: XCTestCase {
         // Assert
         waitForExpectations(timeout: 1)
         XCTAssertTrue(appcues.isActive)
+        XCTAssertTrue(sessionStarted)
     }
 
     func testBackgroundNoSession() throws {
         // Arrange
-        let onTrackExpectation = expectation(description: "session analytics tracked")
         let onFlushExpectation = expectation(description: "analytics tracker flushed")
-        onTrackExpectation.isInverted = true
         onFlushExpectation.isInverted = true
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case .event(SessionEvents.sessionSuspended.rawValue, _) = trackingUpdate.type {
-                onTrackExpectation.fulfill()
-            }
-        }
         appcues.analyticsTracker.onFlush = {
             onFlushExpectation.fulfill()
         }
@@ -137,98 +103,5 @@ class SessionMonitorTests: XCTestCase {
         // Assert
         waitForExpectations(timeout: 1)
         XCTAssertFalse(appcues.isActive)
-    }
-
-    func testForegroundNoSession() throws {
-        // Arrange
-        appcues.storage.userID = "user123"
-        sessionMonitor.start()
-        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
-        sessionMonitor.reset()
-        let onTrackExpectation = expectation(description: "session analytics tracked")
-        onTrackExpectation.isInverted = true
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case let .event(name, _) = trackingUpdate.type, name == SessionEvents.sessionStarted.rawValue || name == SessionEvents.sessionResumed.rawValue {
-                onTrackExpectation.fulfill()
-            }
-        }
-
-        // Act
-        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
-
-        // Assert
-        waitForExpectations(timeout: 1)
-        XCTAssertFalse(appcues.isActive)
-    }
-
-    func testForegroundNoBackground() throws {
-        // Arrange
-        appcues.storage.userID = "user123"
-        sessionMonitor.start()
-        let onTrackExpectation = expectation(description: "session analytics tracked")
-        onTrackExpectation.isInverted = true
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case let .event(name, _) = trackingUpdate.type, name == SessionEvents.sessionStarted.rawValue || name == SessionEvents.sessionResumed.rawValue {
-                onTrackExpectation.fulfill()
-            }
-        }
-
-        // Act
-        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
-
-        // Assert
-        waitForExpectations(timeout: 1)
-        XCTAssertTrue(appcues.isActive)
-    }
-
-    func testForegroundResume() throws {
-        // Arrange
-        appcues = MockAppcues(config: Appcues.Config(accountID: "00000", applicationID: "abc").sessionTimeout(1_800))
-        sessionMonitor = SessionMonitor(container: appcues.container)
-        appcues.storage.userID = "user123"
-        sessionMonitor.start()
-        let initialSessionId = appcues.sessionID
-        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
-        let onTrackExpectation = expectation(description: "session analytics tracked")
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case .event(SessionEvents.sessionResumed.rawValue, _) = trackingUpdate.type {
-                let updatedSessionId = self.appcues.sessionID
-                XCTAssertNotNil(initialSessionId)
-                XCTAssertEqual(initialSessionId, updatedSessionId)
-                onTrackExpectation.fulfill()
-            }
-        }
-
-        // Act
-        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
-
-        // Assert
-        waitForExpectations(timeout: 1)
-    }
-
-    func testForegroundStartNewSession() throws {
-        // Arrange
-        appcues = MockAppcues(config: Appcues.Config(accountID: "00000", applicationID: "abc").sessionTimeout(0))
-        sessionMonitor = SessionMonitor(container: appcues.container)
-        appcues.storage.userID = "user123"
-        sessionMonitor.start()
-        let initialSessionId = appcues.sessionID
-        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: self, userInfo: nil)
-        let onTrackExpectation = expectation(description: "session analytics tracked")
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            if case .event(SessionEvents.sessionStarted.rawValue, _) = trackingUpdate.type {
-                let updatedSessionId = self.appcues.sessionID
-                XCTAssertNotNil(initialSessionId)
-                XCTAssertNotNil(updatedSessionId)
-                XCTAssertNotEqual(initialSessionId, updatedSessionId)
-                onTrackExpectation.fulfill()
-            }
-        }
-
-        // Act
-        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: self, userInfo: nil)
-
-        // Assert
-        waitForExpectations(timeout: 1)
     }
 }

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -31,9 +31,12 @@ class AppcuesTests: XCTestCase {
         realPublisher.register(subscriber: subscriber)
         
         appcues.sessionID = nil //start out with Appcues disabled - no user
+        appcues.storage.userID = ""
 
         appcues.sessionMonitor.onStart = {
+            guard !self.appcues.storage.userID.isEmpty else { return false }
             self.appcues.sessionID = UUID()
+            return true
         }
 
         appcues.sessionMonitor.onReset = {
@@ -42,15 +45,15 @@ class AppcuesTests: XCTestCase {
 
         // Act
         appcues.screen(title: "My test page") // not tracked
-        appcues.anonymous()                   // tracked - user
-        appcues.screen(title: "My test page") // tracked - screen
+        appcues.anonymous()                   // tracked 2 - session start + user
+        appcues.screen(title: "My test page") // tracked 1 - screen
         appcues.reset()                       // stop tracking
         appcues.screen(title: "My test page") // not tracked
-        appcues.identify(userID: "a-user-id") // tracked - user
-        appcues.screen(title: "My test page") // tracked - screen
+        appcues.identify(userID: "a-user-id") // tracked 2 - session start + user
+        appcues.screen(title: "My test page") // tracked 1 - screen
 
         // Assert
-        XCTAssertEqual(4, subscriber.trackedUpdates)
+        XCTAssertEqual(6, subscriber.trackedUpdates)
     }
 
     func testAnonymousUserIdPrefix() throws {

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -168,16 +168,24 @@ class MockExperienceRenderer: ExperienceRendering {
 }
 
 class MockSessionMonitor: SessionMonitoring {
-    var onStart: (() -> Void)?
+    var isSessionExpired: Bool = false
+
+    var onStart: (() -> Bool)?
+    var onUpdateLastActivity: (() -> Void)?
     var onReset: (() -> Void)?
 
-    func start() {
-        onStart?()
+    func start() -> Bool {
+        return onStart?() ?? true
     }
 
     func reset() {
         onReset?()
     }
+
+    func updateLastActivity() {
+        onUpdateLastActivity?()
+    }
+
 }
 
 class MockActivityProcessor: ActivityProcessing {


### PR DESCRIPTION
Similar to what was done in https://github.com/appcues/appcues-android-sdk/pull/452, but thankfully less invasive here. Aligning on Appcues session definition per [doc](https://www.notion.so/appcues/The-definition-of-a-session-at-Appcues-bbaa1c717e9146fcadddaa4a96daea5c?pvs=4)

high level: remove session events for suspend/resume/reset - only track session_start. Update the timeout default to 300 sec (was 1800), and check for timeout after any period of analytics inactivity, regardless of app background/foreground. No longer track background/foreground at all effectively.

One update to the dependency graph - `AnalyticsPublishing` now uses `SessionMonitoring`, rather than the other way around. The red arrow here thus had its direction flipped ([link to final result](https://whimsical.com/ios-sdk-dependency-graph-UHHdjHhVSixeGWttw3HZzH))

![Screenshot 2023-08-16 at 4 28 22 PM](https://github.com/appcues/appcues-ios-sdk/assets/19266448/102f0e24-7a95-4e3d-b639-5fad99dea069)

The bulk of the important logic here now is in `AnalyticsPublishing`, where every time a new tracking update comes in, it checks to see if we either don't have a session yet, or it has expired. In either case, it attempts to start a new one. This may fail, if no user. If it succeeds - a `session_started` event is immediately tracked and the new session begins.

`SessionMonitor` is simplified, and we no longer listen to foregrounding at all, and only listen to backgrounding to attempt flush analytics if possible. Some related tests become invalid now, and are removed, others updated for new changes.

