### PR TITLE
Add delay loaded button to test element targeting retry

### DIFF
--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
@@ -485,6 +485,16 @@ With embeds, this paradigm changes, and a qualification response may contain zer
                                             <action selector="buttonTwoTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="qQw-g3-9OR"/>
                                         </connections>
                                     </button>
+                                    <button hidden="YES" opaque="NO" tag="1004" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fEh-Ri-az9">
+                                        <rect key="frame" x="0.0" y="81" width="374" height="0.0"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="btnEvent3" label="Event 3"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="tinted" title="Trigger Event 3"/>
+                                        <connections>
+                                            <action selector="buttonThreeTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="0IW-1w-n08"/>
+                                            <action selector="buttonTwoTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="wca-R0-W5q"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                             </stackView>
                         </subviews>
@@ -503,6 +513,9 @@ With embeds, this paradigm changes, and a qualification response may contain zer
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="btnEvent3" destination="fEh-Ri-az9" id="bha-Kf-ufP"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="efB-wE-siV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/EventsViewController.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/EventsViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import AppcuesKit
 
 class EventsViewController: UIViewController {
+    @IBOutlet private var btnEvent3: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,10 +17,19 @@ class EventsViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        btnEvent3.isHidden = true
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         Appcues.shared.screen(title: "Trigger Events")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            self?.btnEvent3.isHidden = false
+        }
     }
 
     @IBAction private func buttonOneTapped(_ sender: UIButton) {
@@ -28,6 +38,10 @@ class EventsViewController: UIViewController {
 
     @IBAction private func buttonTwoTapped(_ sender: UIButton) {
         Appcues.shared.track(name: "event2")
+    }
+
+    @IBAction private func buttonThreeTapped(_ sender: UIButton) {
+        Appcues.shared.track(name: "event3")
     }
 
     @IBAction private func debugTapped(_ sender: Any) {

--- a/Examples/DeveloperSPMExample/SPMExample/Base.lproj/Main.storyboard
+++ b/Examples/DeveloperSPMExample/SPMExample/Base.lproj/Main.storyboard
@@ -485,6 +485,16 @@ With embeds, this paradigm changes, and a qualification response may contain zer
                                             <action selector="buttonTwoTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="qQw-g3-9OR"/>
                                         </connections>
                                     </button>
+                                    <button hidden="YES" opaque="NO" tag="1004" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9IM-zu-qaP">
+                                        <rect key="frame" x="0.0" y="81" width="374" height="0.0"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="btnEvent3" label="Event 3"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="tinted" title="Trigger Event 3"/>
+                                        <connections>
+                                            <action selector="buttonThreeTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="CgE-x1-GH2"/>
+                                            <action selector="buttonTwoTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="Mrc-oW-IJA"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                             </stackView>
                         </subviews>
@@ -503,6 +513,9 @@ With embeds, this paradigm changes, and a qualification response may contain zer
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="btnEvent3" destination="9IM-zu-qaP" id="b4x-GH-1t7"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="efB-wE-siV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/DeveloperSPMExample/SPMExample/EventsViewController.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/EventsViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import AppcuesKit
 
 class EventsViewController: UIViewController {
+    @IBOutlet private var btnEvent3: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,10 +17,19 @@ class EventsViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        btnEvent3.isHidden = true
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         Appcues.shared.screen(title: "Trigger Events")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            self?.btnEvent3.isHidden = false
+        }
     }
 
     @IBAction private func buttonOneTapped(_ sender: UIButton) {
@@ -28,6 +38,10 @@ class EventsViewController: UIViewController {
 
     @IBAction private func buttonTwoTapped(_ sender: UIButton) {
         Appcues.shared.track(name: "event2")
+    }
+
+    @IBAction private func buttonThreeTapped(_ sender: UIButton) {
+        Appcues.shared.track(name: "event3")
     }
 
     @IBAction private func debugTapped(_ sender: Any) {


### PR DESCRIPTION
Proposed idea to have a third button on the events page, which hides on initial render, then shows after two seconds. This allows for testing element targeting retry behavior recently introduced for delay loaded elements.

If we're happy with this idea, I can propagate to other test apps.

https://github.com/appcues/appcues-ios-sdk/assets/19266448/73f9856d-f8dc-4ce8-93f1-7eca5ab0942a
