### PR TITLE
Update ExperienceRenderer to reset on Appcues.reset()

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -168,6 +168,12 @@ public class Appcues: NSObject {
         storage.userSignature = nil
         storage.isAnonymous = true
         storage.groupID = nil
+
+        if #available(iOS 13.0, *) {
+            let experienceRenderer = container.resolve(ExperienceRendering.self)
+            experienceRenderer.resetAll()
+        }
+
         notificationCenter.post(name: .appcuesReset, object: self, userInfo: nil)
     }
 
@@ -345,17 +351,15 @@ public class Appcues: NSObject {
         }
 
         var properties = properties
+
         let userChanged = userID != storage.userID
+        if userChanged {
+            reset()
+        }
+
         storage.userID = userID
         storage.isAnonymous = isAnonymous
         storage.userSignature = properties?.removeValue(forKey: "appcues:user_id_signature") as? String
-        if userChanged {
-            // when the identified user changes from last known value, we must start a new session
-            sessionMonitor.reset()
-
-            // and clear any stored group information - will have to be reset as needed
-            storage.groupID = nil
-        }
         analyticsPublisher.publish(TrackingUpdate(type: .profile(interactive: true), properties: properties, isInternal: false))
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -18,6 +18,7 @@ internal protocol ExperienceRendering: AnyObject {
     func experienceData(forContext context: RenderContext) -> ExperienceData?
     func stepIndex(forContext context: RenderContext) -> Experience.StepIndex?
     func owner(forContext context: RenderContext) -> StateMachineOwning?
+    func resetAll()
 }
 
 internal enum RenderContext: Hashable, CustomStringConvertible {
@@ -300,6 +301,21 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
     func owner(forContext context: RenderContext) -> StateMachineOwning? {
         stateMachines[ownerFor: context]
+    }
+
+    func resetAll() {
+        pendingPreviewExperiences.removeAll()
+        potentiallyRenderableExperiences.removeAll()
+
+        stateMachines.forEach { _, stateMachineOwning in
+            stateMachineOwning.reset()
+        }
+    }
+
+    /// Reset only the owned `Self.stateMachine` instance in conformance to `StateMachineOwning`.
+    func reset() {
+        stateMachine?.removeObserver(analyticsObserver)
+        dismiss(inContext: .modal, markComplete: false, completion: nil)
     }
 
     private func track(experiment: Experiment?) {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -80,6 +80,10 @@ internal class ExperienceStateMachine {
     func addObserver(_ observer: ExperienceStateObserver) {
         stateObservers.append(observer)
     }
+
+    func removeObserver(_ observer: ExperienceStateObserver) {
+        stateObservers = stateObservers.filter { $0 !== observer }
+    }
 }
 
 // MARK: - AppcuesExperienceContainerEventHandler

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -437,6 +437,26 @@ class ExperienceRendererTests: XCTestCase {
         properties.verifyPropertiesMatch(experimentUpdate?.properties)
     }
 
+    func testReset() throws {
+        let preconditionPresentExpectation = expectation(description: "Experience presented")
+        let dismissExpectation = expectation(description: "Experience dismissed")
+        let experience = ExperienceData.mock
+        let preconditionPackage: ExperiencePackage = experience.package(presentExpectation: preconditionPresentExpectation, dismissExpectation: dismissExpectation)
+        appcues.traitComposer.onPackage = { _, _ in preconditionPackage }
+        experienceRenderer.processAndShow(experience: ExperienceData(experience.model, trigger: .showCall, priority: .low, published: true), completion: nil)
+        wait(for: [preconditionPresentExpectation], timeout: 1)
+
+        appcues.analyticsPublisher.onPublish = { update in
+            XCTFail("no analytics expected")
+        }
+
+        // Act
+        experienceRenderer.resetAll()
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
     func testDirectoryThreadSafety() throws {
         // Arrange
         let dispatchGroup = DispatchGroup()

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -165,6 +165,10 @@ class MockExperienceRenderer: ExperienceRendering {
         onOwner?(context)
     }
 
+    var onResetAll: (() -> Void)?
+    func resetAll() {
+        onResetAll?()
+    }
 }
 
 class MockSessionMonitor: SessionMonitoring {


### PR DESCRIPTION
Building on the `reset()` function already available in `AppcuesFrameView`, I added `reset()` to the `StateMachineOwning` protocol. To conform to that, `ExperienceRenderer` removes the analytics listener and dismisses the experience held in its state machine. Then the new `ExperienceRendering.resetAll()` loops through the current state machines and and calls the `reset()` for each.

Finally, I updated the private `Appcues.identify()` (which includes `anonymous()`) to call `Appcues.reset()` when the user ID changes (instead of manually resetting values, since this missed the need to call the `.appcuesReset` notification for the debugger).