### PR TITLE
Update text init to avoid inadvertant localization

### DIFF
--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -32,7 +32,7 @@ internal struct AppcuesText: View {
 @available(iOS 13.0, *)
 extension Text {
     init(textModel: ExperienceComponent.TextModel, skipColor: Bool = false, scaled: Bool = false) {
-        self.init("")
+        self.init(verbatim: "")
 
         // Note: a ViewBuilder approach here doesn't work because the requirement that we operate strictly on `Text`
         // and not `some View` for concatenation to work. Therefore we work with the struct directly.


### PR DESCRIPTION
Just in case an app has `""` as a localization key.