### PR TITLE
Add slideout options to dialog modal presentation

### DIFF
--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperienceTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperienceTrait.swift
@@ -122,10 +122,10 @@ internal protocol AppcuesWrapperCreatingTrait: AppcuesExperienceTrait {
     /// ending the attempt to display the experience.
     func createWrapper(around containerController: AppcuesExperienceContainerViewController) throws -> UIViewController
 
-    /// Add the decorated backdrop view to the wrapper.
-    /// - Parameter backdropView: The backdrop.
+    /// Return the backdrop view used by the given wrapper, if any.
     /// - Parameter wrapperController: The wrapper view controller.
-    func addBackdrop(backdropView: UIView, to wrapperController: UIViewController)
+    /// - Returns: The `UIView` being used for the backdrop, or `nil` if no backdrop is used for this wrapper.
+    func getBackdrop(for wrapperController: UIViewController) -> UIView?
 }
 
 /// A trait responsible for providing the ability to show and hide the experience.

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
@@ -53,10 +53,6 @@ internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesContaine
         applyStyle(nil, to: containerController)
     }
 
-    func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {
-        // no backdrop on embeds
-    }
-
     func present(viewController: UIViewController, completion: (() -> Void)?) throws {
         let experienceRenderer = appcues?.container.resolve(ExperienceRendering.self)
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -13,7 +13,7 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
 
     enum Transition {
         case fade
-        case slide(edgeIn: TransitionEdge, edgeOut: TransitionEdge)
+        case slide(edge: TransitionEdge)
     }
 
     enum TransitionEdge: String {
@@ -28,8 +28,6 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
         let presentationStyle: PresentationStyle
         let style: ExperienceComponent.Style?
         let transition: String?
-        let slideInEdge: String? // only used if transition is "slide"
-        let slideOutEdge: String? // only used if transition is "slide"
     }
 
     static let type = "@appcues/modal"
@@ -126,40 +124,30 @@ extension AppcuesModalTrait.Config {
 
         switch self.transition {
         case "slide":
-            // will default to any explicitly specified edge from the config, but
-            // fall back to the expected default based on the horizontal and vertical
+            // determine the slide edge based on the horizontal and vertical
             // position of the modal
-            var edgeIn: AppcuesModalTrait.TransitionEdge
-            var edgeOut: AppcuesModalTrait.TransitionEdge
-
-            let configEdgeIn = self.slideInEdge.flatMap { AppcuesModalTrait.TransitionEdge(rawValue: $0) }
-            let configEdgeOut = self.slideOutEdge.flatMap { AppcuesModalTrait.TransitionEdge(rawValue: $0) }
+            var edge: AppcuesModalTrait.TransitionEdge
 
             let horizontalAlign = style?.horizontalAlignment ?? "center"
             let verticalAlign = style?.verticalAlignment ?? "center"
 
             switch horizontalAlign {
             case "leading":
-                edgeIn = configEdgeIn ?? .leading
-                edgeOut = configEdgeOut ?? edgeIn
+                edge = .leading
             case "trailing":
-                edgeIn = configEdgeIn ?? .trailing
-                edgeOut = configEdgeOut ?? edgeIn
+                edge = .trailing
             default:
                 switch verticalAlign {
                 case "top":
-                    edgeIn = configEdgeIn ?? .top
-                    edgeOut = configEdgeOut ?? edgeIn
+                    edge = .top
                 case "bottom":
-                    edgeIn = configEdgeIn ?? .bottom
-                    edgeOut = configEdgeOut ?? edgeIn
+                    edge = .bottom
                 default:
-                    edgeIn = configEdgeIn ?? .center
-                    edgeOut = configEdgeOut ?? edgeIn
+                    edge = .center
                 }
             }
 
-            return .slide(edgeIn: edgeIn, edgeOut: edgeOut)
+            return .slide(edge: edge)
 
         default:
             return .fade

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -11,12 +11,12 @@ import UIKit
 @available(iOS 13.0, *)
 internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
 
-    enum Transition {
+    enum Transition: Equatable {
         case fade
         case slide(edge: TransitionEdge)
     }
 
-    enum TransitionEdge: String {
+    enum TransitionEdge: String, Equatable {
         case leading
         case trailing
         case top

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -80,6 +80,7 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
         if let dialogController = wrapperController as? ExperienceWrapperViewController {
             dialogController.view.insertSubview(backdropView, at: 0)
             backdropView.pin(to: dialogController.view)
+            dialogController.backdropView = backdropView
         }
     }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -10,9 +10,26 @@ import UIKit
 
 @available(iOS 13.0, *)
 internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
+
+    enum Transition {
+        case fade
+        case slide(edgeIn: TransitionEdge, edgeOut: TransitionEdge)
+    }
+
+    enum TransitionEdge: String {
+        case leading
+        case trailing
+        case top
+        case bottom
+        case center
+    }
+
     struct Config: Decodable {
         let presentationStyle: PresentationStyle
         let style: ExperienceComponent.Style?
+        let transition: String?
+        let slideInEdge: String? // only used if transition is "slide"
+        let slideOutEdge: String? // only used if transition is "slide"
     }
 
     static let type = "@appcues/modal"
@@ -21,11 +38,13 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
 
     private let presentationStyle: PresentationStyle
     private let modalStyle: ExperienceComponent.Style?
+    private let transition: Transition
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         guard let config = configuration.decode(Config.self) else { return nil }
         self.presentationStyle = config.presentationStyle
         self.modalStyle = config.style
+        self.transition = config.toTransition()
     }
 
     func decorate(stepController: UIViewController) throws {
@@ -38,7 +57,8 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
         containerController.modalPresentationStyle = presentationStyle.modalPresentationStyle
 
         if presentationStyle == .dialog {
-            return ExperienceWrapperViewController(wrapping: containerController).configureStyle(modalStyle)
+            return ExperienceWrapperViewController(wrapping: containerController)
+                .configureStyle(modalStyle, transition: transition)
         }
 
         if let backgroundColor = UIColor(dynamicColor: modalStyle?.backgroundColor) {
@@ -95,6 +115,53 @@ extension AppcuesModalTrait {
             case .halfSheet:
                 return .formSheet
             }
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesModalTrait.Config {
+    func toTransition() -> AppcuesModalTrait.Transition {
+
+        switch self.transition {
+        case "slide":
+            // will default to any explicitly specified edge from the config, but
+            // fall back to the expected default based on the horizontal and vertical
+            // position of the modal
+            var edgeIn: AppcuesModalTrait.TransitionEdge
+            var edgeOut: AppcuesModalTrait.TransitionEdge
+
+            let configEdgeIn = self.slideInEdge.flatMap { AppcuesModalTrait.TransitionEdge(rawValue: $0) }
+            let configEdgeOut = self.slideOutEdge.flatMap { AppcuesModalTrait.TransitionEdge(rawValue: $0) }
+
+            let horizontalAlign = style?.horizontalAlignment ?? "center"
+            let verticalAlign = style?.verticalAlignment ?? "center"
+
+            switch horizontalAlign {
+            case "leading":
+                edgeIn = configEdgeIn ?? .leading
+                edgeOut = configEdgeOut ?? edgeIn
+            case "trailing":
+                edgeIn = configEdgeIn ?? .trailing
+                edgeOut = configEdgeOut ?? edgeIn
+            default:
+                switch verticalAlign {
+                case "top":
+                    edgeIn = configEdgeIn ?? .top
+                    edgeOut = configEdgeOut ?? edgeIn
+                case "bottom":
+                    edgeIn = configEdgeIn ?? .bottom
+                    edgeOut = configEdgeOut ?? edgeIn
+                default:
+                    edgeIn = configEdgeIn ?? .center
+                    edgeOut = configEdgeOut ?? edgeIn
+                }
+            }
+
+            return .slide(edgeIn: edgeIn, edgeOut: edgeOut)
+
+        default:
+            return .fade
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -74,12 +74,8 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
         return containerController
     }
 
-    func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {
-        if let dialogController = wrapperController as? ExperienceWrapperViewController {
-            dialogController.view.insertSubview(backdropView, at: 0)
-            backdropView.pin(to: dialogController.view)
-            dialogController.backdropView = backdropView
-        }
+    func getBackdrop(for wrapperController: UIViewController) -> UIView? {
+        return (wrapperController as? ExperienceWrapperViewController)?.bodyView.backdropView
     }
 
     func present(viewController: UIViewController, completion: (() -> Void)?) throws {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -127,20 +127,17 @@ extension AppcuesModalTrait.Config {
             let horizontalAlign = style?.horizontalAlignment ?? "center"
             let verticalAlign = style?.verticalAlignment ?? "center"
 
-            switch horizontalAlign {
-            case "leading":
+            switch (horizontalAlign, verticalAlign) {
+            case ("leading", _):
                 edge = .leading
-            case "trailing":
+            case ("trailing", _):
                 edge = .trailing
+            case (_, "top"):
+                edge = .top
+            case (_, "bottom"):
+                edge = .bottom
             default:
-                switch verticalAlign {
-                case "top":
-                    edge = .top
-                case "bottom":
-                    edge = .bottom
-                default:
-                    edge = .center
-                }
+                edge = .center
             }
 
             return .slide(edge: edge)

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
@@ -75,9 +75,8 @@ internal class AppcuesTooltipTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCr
         }
     }
 
-    func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {
-        wrapperController.view.insertSubview(backdropView, at: 0)
-        backdropView.pin(to: wrapperController.view)
+    func getBackdrop(for wrapperController: UIViewController) -> UIView? {
+        return (wrapperController as? ExperienceWrapperViewController)?.bodyView.backdropView
     }
 
     func present(viewController: UIViewController, completion: (() -> Void)?) throws {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
@@ -76,7 +76,7 @@ internal class AppcuesTooltipTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCr
     }
 
     func getBackdrop(for wrapperController: UIViewController) -> UIView? {
-        return (wrapperController as? ExperienceWrapperViewController)?.bodyView.backdropView
+        return (wrapperController as? ExperienceWrapperViewController<TooltipWrapperView>)?.bodyView.backdropView
     }
 
     func present(viewController: UIViewController, completion: (() -> Void)?) throws {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
@@ -22,6 +22,8 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     private let edgeIn: AppcuesModalTrait.TransitionEdge
     private let edgeOut: AppcuesModalTrait.TransitionEdge
 
+    var backdropView: UIView?
+
     private var transitionDuration: TimeInterval {
         switch transitionType {
         case .presentation:
@@ -85,6 +87,8 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
 
         let edge = transitionType == .presentation ? edgeIn : edgeOut
 
+        backdropView?.alpha = 0.0
+
         switch edge {
         case .top:
             offsetX = 0
@@ -111,5 +115,6 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     private func endTransition() {
         view.contentWrapperView.transform = CGAffineTransform.identity
         view.contentWrapperView.alpha = 1.0
+        backdropView?.alpha = 1.0
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
@@ -21,8 +21,6 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     private let view: ExperienceWrapperView
     private let edge: AppcuesModalTrait.TransitionEdge
 
-    var backdropView: UIView?
-
     private var transitionDuration: TimeInterval {
         switch transitionType {
         case .presentation:
@@ -83,7 +81,7 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
         var offsetX: CGFloat
         var offsetY: CGFloat
 
-        backdropView?.alpha = 0.0
+        view.backdropView.alpha = 0.0
 
         switch edge {
         case .top:
@@ -111,6 +109,6 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     private func endTransition() {
         view.contentWrapperView.transform = CGAffineTransform.identity
         view.contentWrapperView.alpha = 1.0
-        backdropView?.alpha = 1.0
+        view.backdropView.alpha = 1.0
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
@@ -19,8 +19,7 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     var transitionType: ModalTransitionType = .presentation
 
     private let view: ExperienceWrapperView
-    private let edgeIn: AppcuesModalTrait.TransitionEdge
-    private let edgeOut: AppcuesModalTrait.TransitionEdge
+    private let edge: AppcuesModalTrait.TransitionEdge
 
     var backdropView: UIView?
 
@@ -33,10 +32,9 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
         }
     }
 
-    init(view: ExperienceWrapperView, edgeIn: AppcuesModalTrait.TransitionEdge, edgeOut: AppcuesModalTrait.TransitionEdge) {
+    init(view: ExperienceWrapperView, edge: AppcuesModalTrait.TransitionEdge) {
         self.view = view
-        self.edgeIn = edgeIn
-        self.edgeOut = edgeOut
+        self.edge = edge
     }
 
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
@@ -84,8 +82,6 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     private func beginTransition(_ transitionContext: UIViewControllerContextTransitioning) {
         var offsetX: CGFloat
         var offsetY: CGFloat
-
-        let edge = transitionType == .presentation ? edgeIn : edgeOut
 
         backdropView?.alpha = 0.0
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
@@ -1,0 +1,115 @@
+//
+//  ExperienceWrapperSlideAnimator.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 9/7/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+
+    enum ModalTransitionType {
+        case presentation
+        case dismissal
+    }
+
+    var transitionType: ModalTransitionType = .presentation
+
+    private let view: ExperienceWrapperView
+    private let edgeIn: AppcuesModalTrait.TransitionEdge
+    private let edgeOut: AppcuesModalTrait.TransitionEdge
+
+    private var transitionDuration: TimeInterval {
+        switch transitionType {
+        case .presentation:
+            return 1.0
+        case .dismissal:
+            return 0.4
+        }
+    }
+
+    init(view: ExperienceWrapperView, edgeIn: AppcuesModalTrait.TransitionEdge, edgeOut: AppcuesModalTrait.TransitionEdge) {
+        self.view = view
+        self.edgeIn = edgeIn
+        self.edgeOut = edgeOut
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return transitionDuration
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+
+        let animator: UIViewPropertyAnimator
+        switch transitionType {
+        case .presentation:
+            animator = UIViewPropertyAnimator(duration: transitionDuration, dampingRatio: 0.82)
+        case .dismissal:
+            animator = UIViewPropertyAnimator(duration: transitionDuration, curve: UIView.AnimationCurve.easeIn)
+        }
+
+        switch transitionType {
+        case .presentation:
+            // We need to add the modal to the view hierarchy,
+            // and perform the animation.
+            if let toView = transitionContext.view(forKey: .to) {
+                toView.translatesAutoresizingMaskIntoConstraints = false
+                transitionContext.containerView.addSubview(toView)
+                toView.pin(to: transitionContext.containerView)
+                toView.layoutIfNeeded()
+            }
+
+            // move the modal off screen
+            UIView.performWithoutAnimation { beginTransition(transitionContext) }
+            // then slide it in
+            animator.addAnimations { [weak self] in self?.endTransition() }
+        case .dismissal:
+            // The modal is already in the view hierarchy,
+            // so we just perform the animation.
+            animator.addAnimations { [weak self] in self?.beginTransition(transitionContext) }
+        }
+
+        animator.addCompletion { _ in
+            transitionContext.completeTransition(true)
+        }
+
+        animator.startAnimation()
+    }
+
+    private func beginTransition(_ transitionContext: UIViewControllerContextTransitioning) {
+        var offsetX: CGFloat
+        var offsetY: CGFloat
+
+        let edge = transitionType == .presentation ? edgeIn : edgeOut
+
+        switch edge {
+        case .top:
+            offsetX = 0
+            offsetY = -1 * view.shadowWrappingView.frame.maxY
+        case .leading:
+            offsetX = -1 * view.shadowWrappingView.frame.maxX
+            offsetY = 0
+        case .bottom:
+            offsetX = 0
+            offsetY = transitionContext.containerView.bounds.height - view.shadowWrappingView.frame.minY
+        case .trailing:
+            offsetX = transitionContext.containerView.bounds.width - view.shadowWrappingView.frame.minX
+            offsetY = 0
+        case .center:
+            // center+center special case - will be similar to bottom, but not start fully offscreen
+            offsetX = 0
+            offsetY = view.shadowWrappingView.frame.height / 2.0
+            view.contentWrapperView.alpha = 0.0
+        }
+
+        view.contentWrapperView.transform = CGAffineTransform.identity.translatedBy(x: offsetX, y: offsetY)
+    }
+
+    private func endTransition() {
+        view.contentWrapperView.transform = CGAffineTransform.identity
+        view.contentWrapperView.alpha = 1.0
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
@@ -78,37 +78,43 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     }
 
     private func beginTransition(_ transitionContext: UIViewControllerContextTransitioning) {
-        var offsetX: CGFloat
-        var offsetY: CGFloat
-
         view.backdropView.alpha = 0.0
-
-        switch edge {
-        case .top:
-            offsetX = 0
-            offsetY = -1 * view.shadowWrappingView.frame.maxY
-        case .leading:
-            offsetX = -1 * view.shadowWrappingView.frame.maxX
-            offsetY = 0
-        case .bottom:
-            offsetX = 0
-            offsetY = transitionContext.containerView.bounds.height - view.shadowWrappingView.frame.minY
-        case .trailing:
-            offsetX = transitionContext.containerView.bounds.width - view.shadowWrappingView.frame.minX
-            offsetY = 0
-        case .center:
-            // center+center special case - will be similar to bottom, but not start fully offscreen
-            offsetX = 0
-            offsetY = view.shadowWrappingView.frame.height / 2.0
-            view.contentWrapperView.alpha = 0.0
-        }
-
-        view.contentWrapperView.transform = CGAffineTransform.identity.translatedBy(x: offsetX, y: offsetY)
+        view.contentWrapperView.alpha = edge == .center ? 0.0 : 1.0
+        view.slideTransform(edge: edge, containerBounds: transitionContext.containerView.bounds)
     }
 
     private func endTransition() {
         view.contentWrapperView.transform = CGAffineTransform.identity
         view.contentWrapperView.alpha = 1.0
         view.backdropView.alpha = 1.0
+    }
+}
+
+@available(iOS 13.0, *)
+extension ExperienceWrapperView {
+    func slideTransform(edge: AppcuesModalTrait.TransitionEdge, containerBounds: CGRect) {
+        var offsetX: CGFloat
+        var offsetY: CGFloat
+
+        switch edge {
+        case .top:
+            offsetX = 0
+            offsetY = -1 * shadowWrappingView.frame.maxY
+        case .leading:
+            offsetX = -1 * shadowWrappingView.frame.maxX
+            offsetY = 0
+        case .bottom:
+            offsetX = 0
+            offsetY = containerBounds.height - shadowWrappingView.frame.minY
+        case .trailing:
+            offsetX = containerBounds.width - shadowWrappingView.frame.minX
+            offsetY = 0
+        case .center:
+            // center+center special case - will be similar to bottom, but not start fully offscreen
+            offsetX = 0
+            offsetY = shadowWrappingView.frame.height / 2.0
+        }
+
+        contentWrapperView.transform = CGAffineTransform.identity.translatedBy(x: offsetX, y: offsetY)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
@@ -45,8 +45,9 @@ internal class ExperienceWrapperView: UIView {
         contentWrapperView.pin(to: shadowWrappingView)
 
         NSLayoutConstraint.activate([
-            contentWrapperView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
-            contentWrapperView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
+            contentWrapperView.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor),
+            contentWrapperView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
+            contentWrapperView.widthAnchor.constraint(lessThanOrEqualTo: readableContentGuide.widthAnchor),
 
             // ensure the dialog can't exceed the container height (it should scroll instead).
             contentWrapperView.topAnchor.constraint(greaterThanOrEqualTo: safeAreaLayoutGuide.topAnchor),

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
@@ -13,6 +13,8 @@ internal class ExperienceWrapperView: UIView {
 
     var preferredContentSize: CGSize?
 
+    let backdropView = UIView()
+
     let contentWrapperView: UIView = {
         // contentWrapperView can take a tooltip shape mask, so ignore hits outside that shape when it's set.
         let view = HitTestingOverrideUIView(overrideApproach: .applyMask)
@@ -28,6 +30,9 @@ internal class ExperienceWrapperView: UIView {
         super.init(frame: .zero)
 
         backgroundColor = .clear
+
+        addSubview(backdropView)
+        backdropView.pin(to: self)
 
         addSubview(shadowWrappingView)
         shadowWrappingView.addSubview(contentWrapperView)

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
@@ -69,13 +69,35 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
 
         bodyView.setNeedsLayout()
 
+        configureConstraints(style)
+
+        switch transition {
+        case .fade:
+            modalTransitionStyle = .crossDissolve
+            modalPresentationStyle = .overFullScreen
+        case let .slide(edgeIn, edgeOut):
+            modalPresentationStyle = .custom
+            transitioningDelegate = self
+            slideAnimationController = ExperienceWrapperSlideAnimator(view: bodyView, edgeIn: edgeIn, edgeOut: edgeOut)
+        }
+
+        return self
+    }
+
+    private func configureConstraints(_ style: ExperienceComponent.Style?) {
         let contentView = bodyView.contentWrapperView
 
         switch style?.verticalAlignment {
         case "top":
-            contentView.topAnchor.constraint(equalTo: bodyView.safeAreaLayoutGuide.topAnchor).isActive = true
+            contentView.topAnchor.constraint(
+                equalTo: bodyView.safeAreaLayoutGuide.topAnchor,
+                constant: style?.marginTop ?? 0
+            ).isActive = true
         case "bottom":
-            let constraint = contentView.bottomAnchor.constraint(equalTo: bodyView.safeAreaLayoutGuide.bottomAnchor)
+            let constraint = contentView.bottomAnchor.constraint(
+                equalTo: bodyView.safeAreaLayoutGuide.bottomAnchor,
+                constant: -1 * (style?.marginBottom ?? 0)
+            )
             constraint.isActive = true
             bottomConstraint = constraint
         default:
@@ -84,9 +106,15 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
 
         switch style?.horizontalAlignment {
         case "leading":
-            contentView.leadingAnchor.constraint(equalTo: bodyView.layoutMarginsGuide.leadingAnchor).isActive = true
+            contentView.leadingAnchor.constraint(
+                equalTo: bodyView.layoutMarginsGuide.leadingAnchor,
+                constant: style?.marginLeading ?? 0
+            ).isActive = true
         case "trailing":
-            contentView.trailingAnchor.constraint(equalTo: bodyView.layoutMarginsGuide.trailingAnchor).isActive = true
+            contentView.trailingAnchor.constraint(
+                equalTo: bodyView.layoutMarginsGuide.trailingAnchor,
+                constant: -1 * (style?.marginTrailing ?? 0)
+            ).isActive = true
         default:
             contentView.centerXAnchor.constraint(equalTo: bodyView.centerXAnchor).isActive = true
         }
@@ -101,18 +129,6 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
             // if no explicit width set, defaults to the readable content guide width
             contentView.widthAnchor.constraint(equalTo: bodyView.readableContentGuide.widthAnchor).isActive = true
         }
-
-        switch transition {
-        case .fade:
-            modalTransitionStyle = .crossDissolve
-            modalPresentationStyle = .overFullScreen
-        case let .slide(edgeIn, edgeOut):
-            modalPresentationStyle = .custom
-            transitioningDelegate = self
-            slideAnimationController = ExperienceWrapperSlideAnimator(view: bodyView, edgeIn: edgeIn, edgeOut: edgeOut)
-        }
-
-        return self
     }
 
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
@@ -18,12 +18,6 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
     // Only set for bottom-aligned modals. Need access to the constant value for keyboard avoidance.
     var bottomConstraint: NSLayoutConstraint?
 
-    var backdropView: UIView? {
-        didSet {
-            slideAnimationController?.backdropView = backdropView
-        }
-    }
-
     private var slideAnimationController: ExperienceWrapperSlideAnimator?
 
     init(wrapping containerViewController: UIViewController) {
@@ -85,7 +79,6 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
             modalPresentationStyle = .custom
             transitioningDelegate = self
             let animator = ExperienceWrapperSlideAnimator(view: bodyView, edge: edge)
-            animator.backdropView = backdropView
             slideAnimationController = animator
         }
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
@@ -122,7 +122,7 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
 
         if let width = style?.width, width > 0 {
             let widthConstraint = contentView.widthAnchor.constraint(equalToConstant: width)
-            // lower priority here so that the constraint on width being >= the readableContentGuide width
+            // lower priority here so that the constraint on width being <= the readableContentGuide width
             // set in the ExperienceWrapperView by default takes priority, if width is too large
             widthConstraint.priority = .init(999)
             widthConstraint.isActive = true

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
@@ -18,6 +18,12 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
     // Only set for bottom-aligned modals. Need access to the constant value for keyboard avoidance.
     var bottomConstraint: NSLayoutConstraint?
 
+    var backdropView: UIView? {
+        didSet {
+            slideAnimationController?.backdropView = backdropView
+        }
+    }
+
     private var slideAnimationController: ExperienceWrapperSlideAnimator?
 
     init(wrapping containerViewController: UIViewController) {
@@ -78,7 +84,9 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
         case let .slide(edgeIn, edgeOut):
             modalPresentationStyle = .custom
             transitioningDelegate = self
-            slideAnimationController = ExperienceWrapperSlideAnimator(view: bodyView, edgeIn: edgeIn, edgeOut: edgeOut)
+            let animator = ExperienceWrapperSlideAnimator(view: bodyView, edgeIn: edgeIn, edgeOut: edgeOut)
+            animator.backdropView = backdropView
+            slideAnimationController = animator
         }
 
         return self

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
@@ -81,10 +81,10 @@ internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>:
         case .fade:
             modalTransitionStyle = .crossDissolve
             modalPresentationStyle = .overFullScreen
-        case let .slide(edgeIn, edgeOut):
+        case let .slide(edge):
             modalPresentationStyle = .custom
             transitioningDelegate = self
-            let animator = ExperienceWrapperSlideAnimator(view: bodyView, edgeIn: edgeIn, edgeOut: edgeOut)
+            let animator = ExperienceWrapperSlideAnimator(view: bodyView, edge: edge)
             animator.backdropView = backdropView
             slideAnimationController = animator
         }

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -104,9 +104,7 @@ internal class TraitComposer: TraitComposing {
         let containerController = try (decomposedTraits.containerCreating ?? DefaultContainerCreatingTrait())
             .createContainer(for: stepControllers, with: pageMonitor)
         let wrapperController = try decomposedTraits.wrapperCreating?.createWrapper(around: containerController) ?? containerController
-
-        let backdropView = UIView()
-        decomposedTraits.wrapperCreating?.addBackdrop(backdropView: backdropView, to: wrapperController)
+        let backdropView = decomposedTraits.wrapperCreating?.getBackdrop(for: wrapperController)
 
         let stepDecoratingTraitUpdater: (Int, Int?) throws -> Void = { newIndex, previousIndex in
             // Remove old decorations
@@ -115,8 +113,10 @@ internal class TraitComposer: TraitComposing {
                     try $0.undecorate(containerController: containerController)
                 }
 
-                try stepModelsWithTraits[previousIndex].decomposedTraits.backdropDecorating.forEach {
-                    try $0.undecorate(backdropView: backdropView)
+                if let backdropView = backdropView {
+                    try stepModelsWithTraits[previousIndex].decomposedTraits.backdropDecorating.forEach {
+                        try $0.undecorate(backdropView: backdropView)
+                    }
                 }
             }
 
@@ -125,8 +125,10 @@ internal class TraitComposer: TraitComposing {
                 try $0.decorate(containerController: containerController)
             }
 
-            try stepModelsWithTraits[newIndex].decomposedTraits.backdropDecorating.forEach {
-                try $0.decorate(backdropView: backdropView)
+            if let backdropView = backdropView {
+                try stepModelsWithTraits[newIndex].decomposedTraits.backdropDecorating.forEach {
+                    try $0.decorate(backdropView: backdropView)
+                }
             }
 
             metadataDelegate.publish()

--- a/Tests/AppcuesKitTests/Traits/AppcuesModalTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesModalTraitTests.swift
@@ -12,6 +12,33 @@ import XCTest
 @available(iOS 13.0, *)
 class AppcuesModalTraitTests: XCTestCase {
 
+    func testBackdrop() throws {
+        // Arrange
+        let containerController = DefaultContainerViewController(
+            stepControllers: [],
+            pageMonitor: AppcuesExperiencePageMonitor(numberOfPages: 0, currentPage: 0)
+        )
+        let dialogTrait = try XCTUnwrap(AppcuesModalTrait(presentationStyle: .dialog))
+        let dialogWrapper = try dialogTrait.createWrapper(around: containerController)
+        let fullTrait = try XCTUnwrap(AppcuesModalTrait(presentationStyle: .full))
+        let fullWrapper = try fullTrait.createWrapper(around: containerController)
+        let halfSheetTrait = try XCTUnwrap(AppcuesModalTrait(presentationStyle: .halfSheet))
+        let halfSheetWrapper = try halfSheetTrait.createWrapper(around: containerController)
+        let sheetTrait = try XCTUnwrap(AppcuesModalTrait(presentationStyle: .sheet))
+        let sheetWrapper = try sheetTrait.createWrapper(around: containerController)
+
+        // Act
+        let dialogBackdrop = dialogTrait.getBackdrop(for: dialogWrapper)
+        let fullBackdrop = fullTrait.getBackdrop(for: fullWrapper)
+        let halfSheetBackdrop = halfSheetTrait.getBackdrop(for: halfSheetWrapper)
+        let sheetBackdrop = sheetTrait.getBackdrop(for: sheetWrapper)
+
+        // Assert
+        XCTAssertNotNil(dialogBackdrop) // only one that should hav a backdrop
+        XCTAssertNil(fullBackdrop)
+        XCTAssertNil(halfSheetBackdrop)
+        XCTAssertNil(sheetBackdrop)
+    }
 
     func testTransitionConfig() throws {
         // Assert
@@ -87,6 +114,17 @@ class AppcuesModalTraitTests: XCTestCase {
 }
 
 @available(iOS 13.0, *)
+extension AppcuesModalTrait {
+    convenience init?(presentationStyle: PresentationStyle) {
+        self.init(
+            configuration: AppcuesExperiencePluginConfiguration(
+                AppcuesModalTrait.Config(presentationStyle: presentationStyle, style: nil, transition: nil)
+            )
+        )
+    }
+}
+
+@available(iOS 13.0, *)
 extension AppcuesModalTrait.Config {
     init(
         transition: String,
@@ -125,6 +163,4 @@ extension AppcuesModalTrait.Config {
             transition: transition
         )
     }
-
-
 }

--- a/Tests/AppcuesKitTests/Traits/AppcuesModalTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesModalTraitTests.swift
@@ -1,0 +1,130 @@
+//
+//  AppcuesModalTraitTests.swift
+//  AppcuesKitTests
+//
+//  Created by James Ellis on 9/12/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class AppcuesModalTraitTests: XCTestCase {
+
+
+    func testTransitionConfig() throws {
+        // Assert
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "fade").toTransition(),
+            .fade
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide").toTransition(),
+            .slide(edge: .center)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "center").toTransition(),
+            .slide(edge: .center)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", verticalAlignment: "center").toTransition(),
+            .slide(edge: .center)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "center", verticalAlignment: "center").toTransition(),
+            .slide(edge: .center)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "leading").toTransition(),
+            .slide(edge: .leading)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "leading", verticalAlignment: "top").toTransition(),
+            .slide(edge: .leading)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "leading", verticalAlignment: "center").toTransition(),
+            .slide(edge: .leading)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "leading", verticalAlignment: "bottom").toTransition(),
+            .slide(edge: .leading)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "trailing").toTransition(),
+            .slide(edge: .trailing)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "trailing", verticalAlignment: "top").toTransition(),
+            .slide(edge: .trailing)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "trailing", verticalAlignment: "center").toTransition(),
+            .slide(edge: .trailing)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "trailing", verticalAlignment: "bottom").toTransition(),
+            .slide(edge: .trailing)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", verticalAlignment: "top").toTransition(),
+            .slide(edge: .top)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "center", verticalAlignment: "top").toTransition(),
+            .slide(edge: .top)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", verticalAlignment: "bottom").toTransition(),
+            .slide(edge: .bottom)
+        )
+        XCTAssertEqual(
+            AppcuesModalTrait.Config(transition: "slide", horizontalAlignment: "center", verticalAlignment: "bottom").toTransition(),
+            .slide(edge: .bottom)
+        )
+    }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesModalTrait.Config {
+    init(
+        transition: String,
+        horizontalAlignment: String? = nil,
+        verticalAlignment: String? = nil
+    ) {
+        self.init(
+            presentationStyle: .dialog,
+            style: ExperienceComponent.Style(
+                verticalAlignment: verticalAlignment,
+                horizontalAlignment: horizontalAlignment,
+                paddingTop: nil,
+                paddingLeading: nil,
+                paddingBottom: nil,
+                paddingTrailing: nil,
+                marginTop: nil,
+                marginLeading: nil,
+                marginBottom: nil,
+                marginTrailing: nil,
+                height: nil,
+                width: nil,
+                fontName: nil,
+                fontSize: nil,
+                letterSpacing: nil,
+                lineHeight: nil,
+                textAlignment: nil,
+                foregroundColor: nil,
+                backgroundColor: nil,
+                backgroundGradient: nil,
+                backgroundImage: nil,
+                shadow: nil,
+                cornerRadius: nil,
+                borderColor: nil,
+                borderWidth: nil
+            ),
+            transition: transition
+        )
+    }
+
+
+}

--- a/Tests/AppcuesKitTests/Traits/AppcuesTooltipTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTooltipTraitTests.swift
@@ -1,0 +1,41 @@
+//
+//  AppcuesTooltipTraitTests.swift
+//  AppcuesKitTests
+//
+//  Created by James Ellis on 9/13/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class AppcuesTooltipTraitTests: XCTestCase {
+
+    func testBackdrop() throws {
+        // Arrange
+        let containerController = DefaultContainerViewController(
+            stepControllers: [],
+            pageMonitor: AppcuesExperiencePageMonitor(numberOfPages: 0, currentPage: 0)
+        )
+        let trait = try XCTUnwrap(AppcuesTooltipTrait())
+        let wrapper = try trait.createWrapper(around: containerController)
+
+        // Act
+        let backdrop = trait.getBackdrop(for: wrapper)
+
+        // Assert
+        XCTAssertNotNil(backdrop)
+    }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesTooltipTrait {
+    convenience init?() {
+        self.init(
+            configuration: AppcuesExperiencePluginConfiguration(
+                AppcuesTooltipTrait.Config(hidePointer: nil, pointerBase: nil, pointerLength: nil, pointerCornerRadius: nil, style: nil)
+            )
+        )
+    }
+}

--- a/Tests/AppcuesKitTests/Traits/ExperienceWrapperSlideAnimatorTests.swift
+++ b/Tests/AppcuesKitTests/Traits/ExperienceWrapperSlideAnimatorTests.swift
@@ -1,0 +1,96 @@
+//
+//  ExperienceWrapperSlideAnimatorTests.swift
+//  AppcuesKitTests
+//
+//  Created by James Ellis on 9/12/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class ExperienceWrapperSlideAnimatorTests: XCTestCase {
+
+    private static let iPhone14ProPortraitFrame = CGRect(x: 0, y: 0, width: 393, height: 852)
+
+    func testTopTransform() throws {
+        // Arrange
+        let wrapperView = ExperienceWrapperView()
+        wrapperView.shadowWrappingView.frame = CGRect(x: 50, y: 100, width: 200, height: 300)
+
+        // Act
+        wrapperView.slideTransform(edge: .top, containerBounds: Self.iPhone14ProPortraitFrame)
+
+        // Assert
+        XCTAssertEqual(
+            wrapperView.contentWrapperView.transform,
+            CGAffineTransform.identity.translatedBy(x: 0, y: -400)
+        )
+    }
+
+    func testLeadingTransform() throws {
+        // Arrange
+        let wrapperView = ExperienceWrapperView()
+        wrapperView.shadowWrappingView.frame = CGRect(x: 50, y: 100, width: 200, height: 300)
+
+        // Act
+        wrapperView.slideTransform(edge: .leading, containerBounds: Self.iPhone14ProPortraitFrame)
+
+        // Assert
+        XCTAssertEqual(
+            wrapperView.contentWrapperView.transform,
+            CGAffineTransform.identity.translatedBy(x: -250, y: 0
+            )
+        )
+    }
+
+    func testBottomTransform() throws {
+        // Arrange
+        let wrapperView = ExperienceWrapperView()
+        wrapperView.shadowWrappingView.frame = CGRect(x: 50, y: 100, width: 200, height: 300)
+
+        // Act
+        wrapperView.slideTransform(edge: .bottom, containerBounds: Self.iPhone14ProPortraitFrame)
+
+        // Assert
+        XCTAssertEqual(
+            wrapperView.contentWrapperView.transform,
+            CGAffineTransform.identity.translatedBy(x: 0, y: 752)
+        )
+    }
+
+    func testTrailingTransform() throws {
+        // Arrange
+        let wrapperView = ExperienceWrapperView()
+        wrapperView.shadowWrappingView.frame = CGRect(x: 50, y: 100, width: 200, height: 300)
+
+        // Act
+        wrapperView.slideTransform(edge: .trailing, containerBounds: Self.iPhone14ProPortraitFrame)
+
+        // Assert
+        XCTAssertEqual(
+            wrapperView.contentWrapperView.transform,
+            CGAffineTransform.identity.translatedBy(x: 343, y: 0)
+        )
+    }
+
+    func testCenterTransform() throws {
+        // Arrange
+        let wrapperView = ExperienceWrapperView()
+        wrapperView.shadowWrappingView.frame = CGRect(x: 50, y: 100, width: 200, height: 300)
+
+        // Act
+        wrapperView.slideTransform(edge: .center, containerBounds: Self.iPhone14ProPortraitFrame)
+
+        // Assert
+        XCTAssertEqual(
+            wrapperView.contentWrapperView.transform,
+            CGAffineTransform.identity.translatedBy(x: 0, y: 150)
+        )
+    }
+
+}

--- a/Tests/AppcuesKitTests/Traits/ExperienceWrapperSlideAnimatorTests.swift
+++ b/Tests/AppcuesKitTests/Traits/ExperienceWrapperSlideAnimatorTests.swift
@@ -9,9 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-import XCTest
-@testable import AppcuesKit
-
 @available(iOS 13.0, *)
 class ExperienceWrapperSlideAnimatorTests: XCTestCase {
 

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -558,8 +558,8 @@ extension TraitComposerTests {
             return containerController
         }
 
-        func addBackdrop(backdropView: UIView, to wrapperController: UIViewController) {
-            // nothing
+        func getBackdrop(for wrapperController: UIViewController) -> UIView? {
+            return UIView()
         }
 
         // AppcuesBackdropDecoratingTrait


### PR DESCRIPTION
Implements the slideout modal design using the model updates specified in https://github.com/appcues/appcues-mobile-experience-spec/pull/210

There was a little bit of constraint work, to allow for the dialog to have a width specified, and allow it to anchor to an edge of the screen rather than always the readable guide.

The bulk of the work was on the transition, in `ExperienceWrapperSlideAnimator`.  This involved some reading and learning about `UIViewControllerAnimatedTransitioning` on my part, and ended up following an approach adapted from some ideas found [here](https://devsign.co/notes/navigation-transitions-2).

Certainly open to any feedback and improvement on the animation details - I'm no expert. The 1 second entrance for the slide _felt_ about right to me.


https://github.com/appcues/appcues-ios-sdk/assets/19266448/72b0c8a0-51bb-43ed-8e3b-47380c8af8ca

