### PR TITLE
Add experienceInstanceId to experience analytics

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
@@ -38,7 +38,8 @@ internal enum LifecycleEvent: String, CaseIterable {
         var properties: [String: Any] = [
             "experienceId": experience.id.appcuesFormatted,
             "experienceName": experience.name,
-            "experienceType": experience.type
+            "experienceType": experience.type,
+            "experienceInstanceId": experience.instanceID.appcuesFormatted
             // TODO: Add locale values to analytics for localized experiences
 //            "localeName": "",
 //            "localeId": ""
@@ -96,6 +97,7 @@ extension LifecycleEvent {
         let type: LifecycleEvent
         let experienceID: UUID
         let experienceName: String
+        let experienceInstanceID: UUID
         let frameID: String?
         let stepID: UUID?
         let stepIndex: Experience.StepIndex?
@@ -107,13 +109,15 @@ extension LifecycleEvent {
             guard let type = LifecycleEvent(trackingType: update.type) else { return nil }
 
             guard let experienceID = UUID(uuidString: update.properties?["experienceId"] as? String ?? ""),
-                  let experienceName = update.properties?["experienceName"] as? String else {
+                  let experienceName = update.properties?["experienceName"] as? String,
+                  let experienceInstanceID = UUID(uuidString: update.properties?["experienceInstanceId"] as? String ?? "") else {
                 return nil
             }
 
             self.type = type
             self.experienceID = experienceID
             self.experienceName = experienceName
+            self.experienceInstanceID = experienceInstanceID
             self.frameID = update.properties?["frameID"] as? String
 
             self.stepID = UUID(uuidString: update.properties?["stepId"] as? String ?? "")
@@ -127,6 +131,7 @@ extension LifecycleEvent {
             type: LifecycleEvent,
             experienceID: UUID,
             experienceName: String,
+            experienceInstanceID: UUID,
             frameID: String? = nil,
             stepID: UUID? = nil,
             stepIndex: Experience.StepIndex? = nil,
@@ -136,6 +141,7 @@ extension LifecycleEvent {
             self.type = type
             self.experienceID = experienceID
             self.experienceName = experienceName
+            self.experienceInstanceID = experienceInstanceID
             self.frameID = frameID
             self.stepID = stepID
             self.stepIndex = stepIndex

--- a/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
@@ -31,9 +31,10 @@ class AppcuesStepInteractionActionTests: XCTestCase {
     func testNextStep() throws {
         // Arrange
         var mostRecentUpdate: TrackingUpdate?
+        let experience = ExperienceData.mock
 
         appcues.experienceRenderer.onExperienceData = { _ in
-            ExperienceData.mock
+            experience
         }
         appcues.experienceRenderer.onStepIndex = { _ in
             .initial
@@ -69,13 +70,14 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                 "text": "My Button"
             ],
             // Event properties
-            "experienceId": Experience.mock.id.appcuesFormatted,
-            "experienceName": Experience.mock.name,
-            "experienceType": Experience.mock.type,
-            "stepId": Experience.mock.steps[0].items[0].id.appcuesFormatted,
-            "stepType": Experience.mock.steps[0].items[0].type,
+            "experienceId": experience.id.appcuesFormatted,
+            "experienceName": experience.name,
+            "experienceType": experience.type,
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
+            "stepId": experience.steps[0].items[0].id.appcuesFormatted,
+            "stepType": experience.steps[0].items[0].type,
             "stepIndex": "0,0",
-            "version": try XCTUnwrap(Experience.mock.publishedAt)
+            "version": try XCTUnwrap(experience.publishedAt)
         ].verifyPropertiesMatch(lastUpdate.properties)
     }
 

--- a/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
@@ -48,8 +48,9 @@ class AppcuesSubmitFormActionTests: XCTestCase {
         var completionCount = 0
         var updates: [TrackingUpdate] = []
 
+        let experience = ExperienceData.mockWithForm(defaultValue: "default value")
         appcues.experienceRenderer.onExperienceData = { _ in
-            ExperienceData.mockWithForm(defaultValue: "default value")
+            experience
         }
         appcues.experienceRenderer.onStepIndex = { _ in
             .initial
@@ -77,6 +78,7 @@ class AppcuesSubmitFormActionTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Single step with form",
             "experienceId": "ded7b50f-bc24-42de-a0fa-b1f10fc10d00",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "stepType": "modal",

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -63,7 +63,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         XCTAssertNil(appcues.storage.lastContentShownAt)
 
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), isFirst: true)))
+        let experience = ExperienceData.mock
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(experience, .initial, experience.package(), isFirst: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -73,6 +74,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "stepType": "modal",
@@ -87,6 +89,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 type: .stepSeen,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID,
                 stepID: UUID(uuidString: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
                 stepIndex: Experience.StepIndex(group: 0, item: 0)
             ),
@@ -96,7 +99,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateRenderingStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), isFirst: false)))
+        let experience = ExperienceData.mock
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(experience, .initial, experience.package(), isFirst: false)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -106,6 +110,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "stepType": "modal",
@@ -119,6 +124,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 type: .stepSeen,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID,
                 stepID: UUID(uuidString: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
                 stepIndex: Experience.StepIndex(group: 0, item: 0)
             ),
@@ -128,7 +134,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(ExperienceData.mock, .initial, ExperienceData.mock.package(), markComplete: true)))
+        let experience = ExperienceData.mock
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingStep(experience, .initial, experience.package(), markComplete: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -139,6 +146,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "stepType": "modal",
@@ -152,6 +160,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 type: .stepCompleted,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID,
                 stepID: UUID(uuidString: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
                 stepIndex: Experience.StepIndex(group: 0, item: 0)
             ),
@@ -170,7 +179,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingExperienceState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, .initial, markComplete: false)))
+        let experience = ExperienceData.mock
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(experience, .initial, markComplete: false)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -180,6 +190,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "stepType": "modal",
@@ -193,6 +204,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 type: .experienceDismissed,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID,
                 stepID: UUID(uuidString: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
                 stepIndex: Experience.StepIndex(group: 0, item: 0)
             ),
@@ -202,7 +214,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingExperienceStateMarkComplete() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, .initial, markComplete: true)))
+        let experience = ExperienceData.mock
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(experience, .initial, markComplete: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -212,6 +225,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile"
         ].verifyPropertiesMatch(lastUpdate.properties)
@@ -221,7 +235,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             LifecycleEvent.EventProperties(
                 type: .experienceCompleted,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
-                experienceName: "Mock Experience: Group with 3 steps, Single step"
+                experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID
             ),
             "can succesfully remap the property dict"
         )
@@ -229,7 +244,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateEndingExperienceLastStepState() throws {
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(ExperienceData.mock, Experience.StepIndex(group: 1, item: 0), markComplete: true)))
+        let experience = ExperienceData.mock
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.endingExperience(experience, Experience.StepIndex(group: 1, item: 0), markComplete: true)))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -239,6 +255,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile"
         ].verifyPropertiesMatch(lastUpdate.properties)
@@ -248,7 +265,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             LifecycleEvent.EventProperties(
                 type: .experienceCompleted,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
-                experienceName: "Mock Experience: Group with 3 steps, Single step"
+                experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID
             ),
             "can succesfully remap the property dict"
         )
@@ -256,10 +274,11 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateExperienceError() throws {
         // Arrange
+        let experience = ExperienceData.mock
         UUID.generator = { UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181")! }
 
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.experience(ExperienceData.mock, "error")))
+        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.experience(experience, "error")))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -269,6 +288,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "message": "error",
@@ -281,6 +301,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 type: .experienceError,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID,
                 errorID: UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181"),
                 message: "error"
             ),
@@ -290,10 +311,11 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     func testEvaluateStepError() throws {
         // Arrange
+        let experience = ExperienceData.mock
         UUID.generator = { UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181")! }
 
         // Act
-        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.step(ExperienceData.mock, .initial, "error")))
+        let isCompleted = observer.evaluateIfSatisfied(result: .failure(.step(experience, .initial, "error")))
 
         // Assert
         XCTAssertFalse(isCompleted)
@@ -303,6 +325,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "stepType": "modal",
@@ -318,6 +341,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 type: .stepError,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
+                experienceInstanceID: experience.instanceID,
                 stepID: UUID(uuidString: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
                 stepIndex: Experience.StepIndex(group: 0, item: 0),
                 errorID: UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181"),
@@ -355,6 +379,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experienceData.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "errorId": "2e044aa2-130f-4260-80c2-a36092a88aff",
@@ -365,6 +390,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
             "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experienceData.instanceID.appcuesFormatted,
             "version": 1632142800000,
             "experienceType": "mobile",
             "errorId": "2e044aa2-130f-4260-80c2-a36092a88aff"


### PR DESCRIPTION
This is effectively a one line change to add `experienceInstanceId`, using our internal `instanceId` value, on each experience analytic event. This change allows the backend data system to distinctly tie together any events from one particular rendering of an experience, even if the same experience ID is shown multiple times.

Most of the changes here are to ensure that this new value is handled in analytics testing. There is also a change in `LifecycleEvent.EventProperties` to handle the new value in the structure used by the Debugger.

Related analytics UI test change over in https://github.com/appcues/appcues-ios-sdk/pull/414