### PR TITLE
Add session_id to the root of activity/qualify API request body

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Activity.swift
+++ b/Sources/AppcuesKit/Data/Models/Activity.swift
@@ -18,9 +18,11 @@ internal struct Activity {
     let groupID: String?
     let groupUpdate: [String: Any]?
     let userSignature: String?
+    let sessionID: String
 
     internal init(
         accountID: String,
+        sessionID: String,
         userID: String,
         events: [Event]?,
         profileUpdate: [String: Any]? = nil,
@@ -29,6 +31,7 @@ internal struct Activity {
         userSignature: String? = nil
     ) {
         self.accountID = accountID
+        self.sessionID = sessionID
         self.userID = userID
         self.events = events
         self.profileUpdate = profileUpdate
@@ -45,6 +48,7 @@ extension Activity: Encodable {
         case profileUpdate = "profile_update"
         case userID = "user_id"
         case accountID = "account_id"
+        case sessionID = "session_id"
         case groupID = "group_id"
         case groupUpdate = "group_update"
         // note: userSignature is not serialized - used on request Authentication header when present
@@ -53,6 +57,7 @@ extension Activity: Encodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(accountID, forKey: .accountID)
+        try container.encode(sessionID, forKey: .sessionID)
         try container.encode(userID, forKey: .userID)
         try container.encode(groupID, forKey: .groupID)
         try container.encode(requestID.appcuesFormatted, forKey: .requestID)

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -363,7 +363,16 @@ class ActivityProcessorTests: XCTestCase {
     }
 
     private func generateMockActivity(userID: String, event: Event, userSignature: String? = nil) -> Activity {
-        return Activity(accountID: "00000", userID: userID, events: [event], profileUpdate: nil, groupID: nil, groupUpdate: nil, userSignature: userSignature)
+        return Activity(
+            accountID: "00000",
+            sessionID: UUID().appcuesFormatted,
+            userID: userID,
+            events: [event],
+            profileUpdate: nil,
+            groupID: nil,
+            groupUpdate: nil,
+            userSignature: userSignature
+        )
     }
 
     private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, traits: [], steps: [], redirectURL: nil, nextContentID: nil, renderContext: .modal)

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -19,6 +19,7 @@ class AnalyticsTrackerTests: XCTestCase {
             .anonymousIDFactory({ "my-anonymous-id" })
 
         appcues = MockAppcues(config: config)
+        appcues.sessionID = UUID()
         tracker = AnalyticsTracker(container: appcues.container)
 
         // To test the AnalyticsTracker, we verify that the given tracking update is translated into the expected

--- a/Tests/AppcuesKitTests/Networking/NetworkClientTests.swift
+++ b/Tests/AppcuesKitTests/Networking/NetworkClientTests.swift
@@ -75,6 +75,7 @@ class NetworkClientTests: XCTestCase {
         }
         let model = Activity(
             accountID: "00000",
+            sessionID: UUID().appcuesFormatted,
             userID: "test",
             events: [Event(screen: "my screen")])
 
@@ -102,6 +103,7 @@ class NetworkClientTests: XCTestCase {
         }
         let model = Activity(
             accountID: "00000",
+            sessionID: UUID().appcuesFormatted,
             userID: "test",
             events: [Event(screen: "my screen")])
 


### PR DESCRIPTION
This approach has the `AnalyticsTracker` keep a reference to `Appcues` so that it can grab the session ID at the moment it translates a `TrackingUpdate` to `Activity`. There are a few ways we could do this. I think this is the smallest change, so starting here for any feedback.

Other possibilities:
1. Have the `TrackingUpdate` contain the session ID within. This could be done. There are six different classes that can create a `TrackingUpdate` currently, and most of those spots would need updated with handling to check for the session ID and pass through - somewhere along the line still checking for nil.
2. Update the `AnalyticsSubscriber.track(update)` function to also pass the session ID here, as second param - this would allow `AnalyticsPublisher`, which already has the `Appcues` reference and already checks for session, to pass it through to the `AnalyticsTracker` which could then use it to create the `Activity`. It felt a little odd to change this interface for this prop, but its internal and only used in two places I think, so eh. It may be the most appropriate spot to handle the nil check (already doing it)
3. others?

I think these are all pretty much equally viable, so happy to go a different route if there is a preference.