### PR TITLE
Add test for analytics queuing and response handling

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -39,6 +39,9 @@ public extension Appcues {
 
         var activityStorageMaxAge: UInt?
 
+        // Note: this property doesn't have a public setter
+        var flushAfterDuration: TimeInterval = 10
+
         var additionalAutoProperties: [String: Any] = [:]
 
         var enableUniversalLinks = true

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -14,8 +14,6 @@ internal protocol AnalyticsTracking: AnyObject {
 
 internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
 
-    private static let flushAfterSeconds: Double = 10
-
     private weak var appcues: Appcues?
 
     private let storage: DataStoring
@@ -74,7 +72,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                         }
                     }
                     flushWorkItem = workItem
-                    DispatchQueue.main.asyncAfter(deadline: .now() + AnalyticsTracker.flushAfterSeconds, execute: workItem)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + config.flushAfterDuration, execute: workItem)
                 }
             }
         }

--- a/Sources/AppcuesKit/Data/Analytics/TrackingUpdate.swift
+++ b/Sources/AppcuesKit/Data/Analytics/TrackingUpdate.swift
@@ -56,9 +56,3 @@ internal struct TrackingUpdate {
         }
     }
 }
-
-extension TrackingUpdate: CustomStringConvertible {
-    var description: String {
-        return "TODO: translate for logging / debugger"
-    }
-}


### PR DESCRIPTION
To make analytics queue processing testable, I moved the `private static flushAfterSeconds` to the `Config` object so I can modify it in the test. The test still takes 3s which is long for a unit test, but a lot better than waiting 11s.

Also added a couple tests that verify `AnalyticsTracker` calls `ExperienceRenderer` the way we think it does.