### PR TITLE
Add support for registering fonts from a bundle path

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -48,6 +48,8 @@ public extension Appcues {
 
         var enableTextScaling = false
 
+        var bundleFontsPath: String?
+
         /// Create an Appcues SDK configuration
         /// - Parameter accountID: Appcues Account ID - a string containing an integer, copied from the Account settings page in Studio.
         /// - Parameter applicationID: Appcues Application ID - a string containing a UUID,
@@ -192,6 +194,51 @@ public extension Appcues {
         @objc
         public func enableTextScaling(_ enabled: Bool) -> Self {
             self.enableTextScaling = enabled
+            return self
+        }
+
+        /// Set a custom path to font assets in the app bundle.
+        ///
+        /// Any `.ttf` files in the specified subdirectory will be registered for usage across your application.
+        ///
+        /// Usage of this configuration option is unnecessary if your custom fonts are registered in your Info.plist `UIAppFonts` as
+        /// [recommended by Apple](https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app).
+        ///
+        /// - Parameter path: Path to font files. Leading and trailing slashes are optional.
+        /// - Returns: The `Configuration` object.
+        @discardableResult
+        @objc
+        public func bundleFontsPath(_ path: String?) -> Self {
+            self.bundleFontsPath = path
+
+            if let path = path {
+                let fontResources = Bundle.main.urls(forResourcesWithExtension: "ttf", subdirectory: path) ?? []
+
+                if fontResources.isEmpty {
+                    logger.info(
+                        "No fonts found in main bundle in subdirectory %{public}s",
+                        path
+                    )
+                }
+
+                fontResources.forEach { fontURL in
+                    var error: Unmanaged<CFError>?
+
+                    if !CTFontManagerRegisterFontsForURL(fontURL as CFURL, .process, &error) {
+                        logger.info(
+                            "Error registering font %{public}s %{public}s",
+                            fontURL.lastPathComponent,
+                            error?.takeUnretainedValue().localizedDescription ?? ""
+                        )
+                    } else {
+                        logger.info(
+                            "Successfully registered font at %{public}s",
+                            fontURL.lastPathComponent
+                        )
+                    }
+                }
+            }
+
             return self
         }
     }

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -29,7 +29,7 @@ internal enum DebugUI {
                     }
 
                     Section(header: Text("Info")) {
-                        NavigationLink(destination: DebugFontUI.FontListView(), isActive: $viewModel.navigationDestinationIsFonts) {
+                        NavigationLink(destination: DebugFontUI.FontListView(sections: viewModel.fonts()), isActive: $viewModel.navigationDestinationIsFonts) {
                             Text("Available Fonts")
                         }
                     }

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -68,7 +68,8 @@ internal class UIDebugger: UIDebugging {
             accountID: config.accountID,
             applicationID: config.applicationID,
             currentUserID: storage.userID,
-            isAnonymous: storage.isAnonymous
+            isAnonymous: storage.isAnonymous,
+            bundleFontsPath: config.bundleFontsPath
         )
 
         notificationCenter.addObserver(self, selector: #selector(appcuesReset), name: .appcuesReset, object: nil)

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -31,6 +31,7 @@ class PublicAPITests: XCTestCase {
             .additionalAutoProperties(["test": "value"])
             .enableUniversalLinks(true)
             .enableTextScaling(true)
+            .bundleFontsPath("assets/fonts")
 
         let appcuesInstance = Appcues(config: config)
 


### PR DESCRIPTION
The `Appcues.Config` function registers the fonts and saves the path for the debugger to reference.

I refactored the debugger font view a bit since the view shouldn't be responsible for determining the font list. So now the view model does.