### PR TITLE
Debugger refactor

### DIFF
--- a/Sources/AppcuesKit/Data/Networking/Authorization.swift
+++ b/Sources/AppcuesKit/Data/Networking/Authorization.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal enum Authorization {
+internal enum Authorization: Equatable {
     case bearer(String)
 
     init?(bearerToken: String?) {

--- a/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
@@ -1,0 +1,42 @@
+//
+//  APIVerifier.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-10-10.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+@available(iOS 13.0, *)
+internal class APIVerifier {
+    let title = "Connected to Appcues"
+    let networking: Networking
+
+    let subject = PassthroughSubject<StatusItem, Never>()
+
+    init(networking: Networking) {
+        self.networking = networking
+    }
+
+    func verifyAPI() {
+        subject.send(StatusItem(status: .pending, title: title))
+
+        networking.get(from: APIEndpoint.health, authorization: nil) { [weak self] (result: Result<ActivityResponse, Error>) in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self?.subject.send(StatusItem(status: .verified, title: self?.title ?? ""))
+                case .failure(let error):
+                    self?.subject.send(StatusItem(
+                        status: .unverified,
+                        title: self?.title ?? "",
+                        subtitle: error.localizedDescription,
+                        detailText: "\(error)"
+                    ))
+                }
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
@@ -14,7 +14,8 @@ internal class APIVerifier {
     static let title = "Connected to Appcues"
     let networking: Networking
 
-    let subject = PassthroughSubject<StatusItem, Never>()
+    private let subject = PassthroughSubject<StatusItem, Never>()
+    var publisher: AnyPublisher<StatusItem, Never> { subject.eraseToAnyPublisher() }
 
     init(networking: Networking) {
         self.networking = networking

--- a/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
@@ -11,7 +11,7 @@ import Combine
 
 @available(iOS 13.0, *)
 internal class APIVerifier {
-    let title = "Connected to Appcues"
+    static let title = "Connected to Appcues"
     let networking: Networking
 
     let subject = PassthroughSubject<StatusItem, Never>()
@@ -21,17 +21,17 @@ internal class APIVerifier {
     }
 
     func verifyAPI() {
-        subject.send(StatusItem(status: .pending, title: title))
+        subject.send(StatusItem(status: .pending, title: APIVerifier.title))
 
         networking.get(from: APIEndpoint.health, authorization: nil) { [weak self] (result: Result<ActivityResponse, Error>) in
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                    self?.subject.send(StatusItem(status: .verified, title: self?.title ?? ""))
+                    self?.subject.send(StatusItem(status: .verified, title: APIVerifier.title))
                 case .failure(let error):
                     self?.subject.send(StatusItem(
                         status: .unverified,
-                        title: self?.title ?? "",
+                        title: APIVerifier.title,
                         subtitle: error.localizedDescription,
                         detailText: "\(error)"
                     ))

--- a/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
@@ -19,7 +19,8 @@ internal class DeepLinkVerifier {
 
     var urlTypes: [[String: Any]]? { Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] }
 
-    let subject = PassthroughSubject<StatusItem, Never>()
+    private let subject = PassthroughSubject<StatusItem, Never>()
+    var publisher: AnyPublisher<StatusItem, Never> { subject.eraseToAnyPublisher() }
 
     init(applicationID: String) {
         self.applicationID = applicationID

--- a/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
@@ -17,25 +17,27 @@ internal class DeepLinkVerifier {
     /// Unique value to pass through a deep link to verify handling.
     private var deepLinkVerificationToken: String?
 
+    var urlTypes: [[String: Any]]? { Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] }
+
     let subject = PassthroughSubject<StatusItem, Never>()
 
     init(applicationID: String) {
         self.applicationID = applicationID
     }
 
-    func verifyDeepLink() {
+    func verifyDeepLink(token: UUID = UUID()) {
+        subject.send(StatusItem(status: .pending, title: title, subtitle: nil))
+
         guard infoPlistContainsScheme() else {
             subject.send(StatusItem(status: .unverified, title: title, subtitle: "Error 1: CFBundleURLSchemes value missing"))
             return
         }
 
-        subject.send(StatusItem(status: .pending, title: title, subtitle: nil))
-
-        verifyDeepLinkHandling(token: UUID().uuidString)
+        verifyDeepLinkHandling(token: token.uuidString)
     }
 
     private func infoPlistContainsScheme() -> Bool {
-        guard let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else { return false }
+        guard let urlTypes = urlTypes else { return false }
 
         return urlTypes
             .flatMap { $0["CFBundleURLSchemes"] as? [String] ?? [] }

--- a/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
@@ -1,0 +1,72 @@
+//
+//  DeepLinkVerifier.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-10-10.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+@available(iOS 13.0, *)
+internal class DeepLinkVerifier {
+    let title = "Appcues Deep Link"
+    let applicationID: String
+
+    /// Unique value to pass through a deep link to verify handling.
+    private var deepLinkVerificationToken: String?
+
+    let subject = PassthroughSubject<StatusItem, Never>()
+
+    init(applicationID: String) {
+        self.applicationID = applicationID
+    }
+
+    func verifyDeepLink() {
+        guard infoPlistContainsScheme() else {
+            subject.send(StatusItem(status: .unverified, title: title, subtitle: "Error 1: CFBundleURLSchemes value missing"))
+            return
+        }
+
+        subject.send(StatusItem(status: .pending, title: title, subtitle: nil))
+
+        verifyDeepLinkHandling(token: UUID().uuidString)
+    }
+
+    private func infoPlistContainsScheme() -> Bool {
+        guard let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else { return false }
+
+        return urlTypes
+            .flatMap { $0["CFBundleURLSchemes"] as? [String] ?? [] }
+            .contains { $0 == "appcues-\(applicationID)" }
+    }
+
+    private func verifyDeepLinkHandling(token: String) {
+        guard let url = URL(string: "appcues-\(applicationID)://sdk/verify/\(token)") else {
+            subject.send(StatusItem(status: .unverified, title: title, subtitle: "Error 0: Failed to set up verification"))
+            return
+        }
+
+        deepLinkVerificationToken = token
+
+        UIApplication.shared.open(url, options: [:])
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            if self.deepLinkVerificationToken != nil {
+                self.subject.send(StatusItem(status: .unverified, title: self.title, subtitle: "Error 2: Appcues SDK not receiving links"))
+                self.deepLinkVerificationToken = nil
+            }
+        }
+    }
+
+    func receivedVerification(token: String) {
+        if token == deepLinkVerificationToken {
+            subject.send(StatusItem(status: .verified, title: title, subtitle: nil))
+        } else {
+            subject.send(StatusItem(status: .unverified, title: title, subtitle: "Error 3: Unexpected result"))
+        }
+
+        deepLinkVerificationToken = nil
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -20,14 +20,15 @@ internal class DebugViewController: UIViewController {
     private var debugView = DebugView()
 
     let mode: DebugMode
-    private let apiVerifier: APIVerifier
-    private let deepLinkVerifier: DeepLinkVerifier
-    private let viewModel: DebugViewModel
 
-    init(apiVerifier: APIVerifier, deepLinkVerifier: DeepLinkVerifier, viewModel: DebugViewModel, mode: DebugMode) {
+    let viewModel: DebugViewModel
+    let apiVerifier: APIVerifier
+    let deepLinkVerifier: DeepLinkVerifier
+
+    init(viewModel: DebugViewModel, apiVerifier: APIVerifier, deepLinkVerifier: DeepLinkVerifier, mode: DebugMode) {
+        self.viewModel = viewModel
         self.apiVerifier = apiVerifier
         self.deepLinkVerifier = deepLinkVerifier
-        self.viewModel = viewModel
         self.mode = mode
         super.init(nibName: nil, bundle: nil)
     }
@@ -48,7 +49,11 @@ internal class DebugViewController: UIViewController {
         super.viewDidLoad()
 
         if case .debugger = mode {
-            let panelViewController = UIHostingController(rootView: DebugUI.MainPanelView(apiVerifier: apiVerifier, deepLinkVerifier: deepLinkVerifier, viewModel: viewModel))
+            let panelViewController = UIHostingController(rootView: DebugUI.MainPanelView(
+                apiVerifier: apiVerifier,
+                deepLinkVerifier: deepLinkVerifier,
+                viewModel: viewModel
+            ))
             addChild(panelViewController)
             debugView.panelWrapperView.addSubview(panelViewController.view)
             panelViewController.didMove(toParent: self)

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -20,9 +20,13 @@ internal class DebugViewController: UIViewController {
     private var debugView = DebugView()
 
     let mode: DebugMode
+    private let apiVerifier: APIVerifier
+    private let deepLinkVerifier: DeepLinkVerifier
     private let viewModel: DebugViewModel
 
-    init(viewModel: DebugViewModel, mode: DebugMode) {
+    init(apiVerifier: APIVerifier, deepLinkVerifier: DeepLinkVerifier, viewModel: DebugViewModel, mode: DebugMode) {
+        self.apiVerifier = apiVerifier
+        self.deepLinkVerifier = deepLinkVerifier
         self.viewModel = viewModel
         self.mode = mode
         super.init(nibName: nil, bundle: nil)
@@ -44,7 +48,7 @@ internal class DebugViewController: UIViewController {
         super.viewDidLoad()
 
         if case .debugger = mode {
-            let panelViewController = UIHostingController(rootView: DebugUI.MainPanelView(viewModel: viewModel))
+            let panelViewController = UIHostingController(rootView: DebugUI.MainPanelView(apiVerifier: apiVerifier, deepLinkVerifier: deepLinkVerifier, viewModel: viewModel))
             addChild(panelViewController)
             debugView.panelWrapperView.addSubview(panelViewController.view)
             panelViewController.didMove(toParent: self)

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -114,7 +114,7 @@ internal enum DebugUI {
                 }
                 .foregroundColor(.secondary)
             }
-            .onReceive(apiVerifier.subject) {
+            .onReceive(apiVerifier.publisher) {
                 statusItem = $0
             }
         }
@@ -134,7 +134,7 @@ internal enum DebugUI {
                 }
                 .foregroundColor(.secondary)
             }
-            .onReceive(deepLinkVerifier.subject) {
+            .onReceive(deepLinkVerifier.publisher) {
                 statusItem = $0
             }
         }

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
@@ -18,6 +18,8 @@ internal struct LoggedEvent: Identifiable {
     let name: String
     let properties: [String: Any]?
 
+    let structuredLifecycleProperties: StructuredLifecycleProperties?
+
     var eventDetailItems: [Pair] {
         [
             ("Type", type.description),
@@ -104,6 +106,8 @@ internal struct LoggedEvent: Identifiable {
             self.type = .group
             self.name = "\(groupID ?? "-")"
         }
+
+        self.structuredLifecycleProperties = StructuredLifecycleProperties(update: update)
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
@@ -1,0 +1,171 @@
+//
+//  LoggedEvent.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-09-27.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+internal struct LoggedEvent: Identifiable {
+    typealias Pair = (title: String, value: String?)
+
+    let id = UUID()
+    let timestamp: Date
+    let type: EventType
+    let name: String
+    let properties: [String: Any]?
+
+    var eventDetailItems: [Pair] {
+        [
+            ("Type", type.description),
+            ("Name", name),
+            ("Timestamp", "\(timestamp)")
+        ]
+    }
+
+    var eventProperties: [(title: String, items: [Pair])]? {
+        guard var properties = properties else { return nil }
+
+        var groups: [(title: String, items: [Pair])] = []
+
+        // flatten the nested `_identity` auto-properties into individual top level items.
+        let autoProps = (properties["_identity"] as? [String: Any] ?? [:])
+            .sortedWithAutoProperties()
+            .map { ($0.key, String(describing: $0.value)) }
+        properties["_identity"] = nil
+
+        // flatten the nested `_sdkMetrics` properties into individual top level items.
+        let metricProps = (properties["_sdkMetrics"] as? [String: Any] ?? [:])
+            .sortedWithAutoProperties()
+            .map { ($0.key, String(describing: $0.value)) }
+        properties["_sdkMetrics"] = nil
+
+        // flatten the nested `interactionData` properties into individual top level items.
+        var interactionData = (properties["interactionData"] as? [String: Any] ?? [:])
+        let formResponse = (interactionData["formResponse"] as? ExperienceData.StepState)?.formattedAsDebugData()
+        interactionData["formResponse"] = nil
+        properties["interactionData"] = nil
+        let interactionProps = interactionData
+            .sortedWithAutoProperties()
+            .map { ($0.key, String(describing: $0.value)) }
+
+        let userProps = properties
+            .sortedWithAutoProperties()
+            .map { ($0.key, String(describing: $0.value)) }
+
+        if !userProps.isEmpty {
+            groups.append(("Properties", userProps))
+        }
+
+        // Other types of interaction data
+        if !interactionProps.isEmpty {
+            groups.append(("Interaction Data", interactionProps))
+        }
+
+        if let formResponse = formResponse, !formResponse.isEmpty {
+            groups.append(("Interaction Data: Form Response", formResponse))
+        }
+
+        if !autoProps.isEmpty {
+            groups.append(("Identity Auto-properties", autoProps))
+        }
+
+        if !metricProps.isEmpty {
+            groups.append(("SDK Metrics", metricProps))
+        }
+
+        return groups
+    }
+
+    init(from update: TrackingUpdate) {
+        self.timestamp = update.timestamp
+        self.properties = update.properties
+
+        switch update.type {
+        case let .event(name, _) where SessionEvents.allNames.contains(name):
+            self.type = .session
+            self.name = name.prettifiedEventName
+        case let .event(name, _) where name.starts(with: "appcues:v2:"):
+            self.type = .experience
+            self.name = name.prettifiedEventName
+        case let .event(name, _):
+            self.type = .custom
+            self.name = name
+        case let .screen(title):
+            self.type = .screen
+            self.name = title
+        case .profile:
+            self.type = .profile
+            self.name = "\(update.properties?["userId"] ?? "Profile Update")"
+        case let .group(groupID):
+            self.type = .group
+            self.name = "\(groupID ?? "-")"
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension LoggedEvent {
+    enum EventType: CaseIterable, CustomStringConvertible {
+        case screen
+        case custom
+        case profile
+        case group
+        case session
+        case experience
+
+        var description: String {
+            switch self {
+            case .screen: return "Screen"
+            case .custom: return "Custom"
+            case .profile: return "User Profile"
+            case .group: return "Group"
+            case .session: return "Session"
+            case .experience: return "Experience"
+            }
+        }
+
+        var symbolName: String {
+            switch self {
+            case .screen: return "rectangle.portrait.on.rectangle.portrait"
+            case .custom: return "hand.tap"
+            case .profile: return "person"
+            case .group: return "person.3"
+            case .session: return "clock.arrow.2.circlepath"
+            case .experience: return "arrow.right.square"
+            }
+        }
+    }
+}
+
+private extension Dictionary where Key == String, Value == Any {
+    func sortedWithAutoProperties() -> [(key: Key, value: Value)] {
+        self.sorted {
+            switch ($0.key.first, $1.key.first) {
+            case ("_", "_"):
+                return $0.key <= $1.key
+            case ("_", _):
+                return false
+            case (_, "_"):
+                return true
+            default:
+                return $0.key <= $1.key
+            }
+        }
+    }
+}
+
+private extension String {
+    /// Convert something like "appcues:v2:step_seen" to "Step Seen"
+    var prettifiedEventName: String {
+        self
+            .split(separator: ":")
+            .last?
+            .split(separator: "_")
+            .map { $0.capitalized }
+            .joined(separator: " ") ?? self
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/StatusItem.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/StatusItem.swift
@@ -1,0 +1,59 @@
+//
+//  StatusItem.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-09-27.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+internal struct StatusItem: Identifiable {
+    let id: UUID
+    var status: Status
+    let title: String
+    var subtitle: String?
+    var detailText: String?
+
+    init(
+        status: Status,
+        title: String,
+        subtitle: String? = nil,
+        detailText: String? = nil,
+        id: UUID = UUID()
+    ) {
+        self.id = id
+        self.status = status
+        self.title = title
+        self.subtitle = subtitle
+        self.detailText = detailText
+    }
+}
+
+extension StatusItem {
+    enum Status {
+        case verified
+        case pending
+        case unverified
+        case info
+
+        var symbolName: String {
+            switch self {
+            case .verified: return "checkmark"
+            case .pending: return "ellipsis"
+            case .unverified: return "xmark"
+            case .info: return "info.circle"
+            }
+        }
+
+        @available(iOS 13.0, *)
+        var tintColor: Color {
+            switch self {
+            case .verified: return .green
+            case .pending: return .gray
+            case .unverified: return .red
+            case .info: return .blue
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/StructuredLifecycleProperties.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/StructuredLifecycleProperties.swift
@@ -1,0 +1,76 @@
+//
+//  StructuredLifecycleProperties.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-10-16.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal struct StructuredLifecycleProperties: Equatable {
+    let type: LifecycleEvent
+    let experienceID: UUID
+    let experienceName: String
+    let experienceInstanceID: UUID
+    let frameID: String?
+    let stepID: UUID?
+    let stepIndex: Experience.StepIndex?
+
+    let errorID: UUID?
+    let message: String?
+
+    init?(update: TrackingUpdate) {
+        guard let type = LifecycleEvent(trackingType: update.type) else { return nil }
+
+        guard let experienceID = UUID(uuidString: update.properties?["experienceId"] as? String ?? ""),
+              let experienceName = update.properties?["experienceName"] as? String,
+              let experienceInstanceID = UUID(uuidString: update.properties?["experienceInstanceId"] as? String ?? "") else {
+            return nil
+        }
+
+        self.type = type
+        self.experienceID = experienceID
+        self.experienceName = experienceName
+        self.experienceInstanceID = experienceInstanceID
+        self.frameID = update.properties?["frameID"] as? String
+
+        self.stepID = UUID(uuidString: update.properties?["stepId"] as? String ?? "")
+        self.stepIndex = Experience.StepIndex(description: update.properties?["stepIndex"] as? String ?? "")
+
+        self.errorID = UUID(uuidString: update.properties?["errorId"] as? String ?? "")
+        self.message = update.properties?["message"] as? String
+    }
+
+    init(
+        type: LifecycleEvent,
+        experienceID: UUID,
+        experienceName: String,
+        experienceInstanceID: UUID,
+        frameID: String? = nil,
+        stepID: UUID? = nil,
+        stepIndex: Experience.StepIndex? = nil,
+        errorID: UUID? = nil,
+        message: String? = nil
+    ) {
+        self.type = type
+        self.experienceID = experienceID
+        self.experienceName = experienceName
+        self.experienceInstanceID = experienceInstanceID
+        self.frameID = frameID
+        self.stepID = stepID
+        self.stepIndex = stepIndex
+        self.errorID = errorID
+        self.message = message
+    }
+}
+
+private extension LifecycleEvent {
+    init?(trackingType: TrackingUpdate.TrackingType) {
+        if case .event(let name, _) = trackingType, let val = Self(rawValue: name) {
+            self = val
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/Toasts/DebugToast.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Toasts/DebugToast.swift
@@ -14,7 +14,7 @@ internal struct DebugToast {
         case failure
     }
 
-    enum Message {
+    enum Message: Equatable {
         case screenCaptureSuccess(displayName: String)
         case screenCaptureFailure
         case screenUploadFailure

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/LifecycleEvent.swift
@@ -20,14 +20,6 @@ internal enum LifecycleEvent: String, CaseIterable {
     case experienceError = "appcues:v2:experience_error"
     case experienceRecovered = "appcues:v2:experience_recovered"
 
-    private init?(trackingType: TrackingUpdate.TrackingType) {
-        if case .event(let name, _) = trackingType, let val = Self(rawValue: name) {
-            self = val
-        } else {
-            return nil
-        }
-    }
-
     /// Map experience model to a general property dictionary.
     @available(iOS 13.0, *)
     static func properties(
@@ -73,15 +65,9 @@ internal enum LifecycleEvent: String, CaseIterable {
 
         return properties
     }
-
-    /// Map a general property dictionary to a strongly typed struct `EventProperties`.
-    static func restructure(update: TrackingUpdate) -> EventProperties? {
-        EventProperties(update: update)
-    }
 }
 
 extension LifecycleEvent {
-
     struct ErrorBody: ExpressibleByStringInterpolation {
         let message: String?
         let id: UUID
@@ -95,63 +81,6 @@ extension LifecycleEvent {
         init(stringLiteral value: String) {
             message = value
             id = UUID.create()
-        }
-    }
-
-    struct EventProperties: Equatable {
-        let type: LifecycleEvent
-        let experienceID: UUID
-        let experienceName: String
-        let experienceInstanceID: UUID
-        let frameID: String?
-        let stepID: UUID?
-        let stepIndex: Experience.StepIndex?
-
-        let errorID: UUID?
-        let message: String?
-
-        init?(update: TrackingUpdate) {
-            guard let type = LifecycleEvent(trackingType: update.type) else { return nil }
-
-            guard let experienceID = UUID(uuidString: update.properties?["experienceId"] as? String ?? ""),
-                  let experienceName = update.properties?["experienceName"] as? String,
-                  let experienceInstanceID = UUID(uuidString: update.properties?["experienceInstanceId"] as? String ?? "") else {
-                return nil
-            }
-
-            self.type = type
-            self.experienceID = experienceID
-            self.experienceName = experienceName
-            self.experienceInstanceID = experienceInstanceID
-            self.frameID = update.properties?["frameID"] as? String
-
-            self.stepID = UUID(uuidString: update.properties?["stepId"] as? String ?? "")
-            self.stepIndex = Experience.StepIndex(description: update.properties?["stepIndex"] as? String ?? "")
-
-            self.errorID = UUID(uuidString: update.properties?["errorId"] as? String ?? "")
-            self.message = update.properties?["message"] as? String
-        }
-
-        init(
-            type: LifecycleEvent,
-            experienceID: UUID,
-            experienceName: String,
-            experienceInstanceID: UUID,
-            frameID: String? = nil,
-            stepID: UUID? = nil,
-            stepIndex: Experience.StepIndex? = nil,
-            errorID: UUID? = nil,
-            message: String? = nil
-        ) {
-            self.type = type
-            self.experienceID = experienceID
-            self.experienceName = experienceName
-            self.experienceInstanceID = experienceInstanceID
-            self.frameID = frameID
-            self.stepID = stepID
-            self.stepIndex = stepIndex
-            self.errorID = errorID
-            self.message = message
         }
     }
 }

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
@@ -135,7 +135,7 @@ class AnalyticsBroadcasterTests: XCTestCase {
                         "fieldRequired": true,
                         "value": "default value",
                         "label": "Form label"
-                    ]
+                    ] as [String : Any]
                 ]
             ]
         ].verifyPropertiesMatch(delegate.lastProperties)

--- a/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
@@ -28,7 +28,7 @@ class APIVerifierTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Publishes values then finishes")
         var values: [StatusItem] = []
 
-        apiVerifier.subject
+        apiVerifier.publisher
             .sink {
                 values.append($0)
                 if values.count == 2 {
@@ -56,7 +56,7 @@ class APIVerifierTests: XCTestCase {
         let expectation = expectation(description: "Publishes values then finishes")
         var values: [StatusItem] = []
 
-        apiVerifier.subject
+        apiVerifier.publisher
             .sink {
                 values.append($0)
                 if values.count == 2 {
@@ -74,7 +74,7 @@ class APIVerifierTests: XCTestCase {
 
         // Assert
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values.count, 2, "a pending value and an unverified one")
         XCTAssertEqual(values[safe: 0]?.status, .pending)
         XCTAssertEqual(values[safe: 1]?.status, .unverified)
     }

--- a/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
@@ -1,0 +1,81 @@
+//
+//  APIVerifierTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-10-13.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+import Combine
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class APIVerifierTests: XCTestCase {
+
+    var apiVerifier: APIVerifier!
+    var networking: MockNetworking!
+
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUpWithError() throws {
+        networking = MockNetworking()
+        apiVerifier = APIVerifier(networking: networking)
+    }
+
+    func testSuccess() throws {
+        // Arrange
+        let expectation = XCTestExpectation(description: "Publishes values then finishes")
+        var values: [StatusItem] = []
+
+        apiVerifier.subject
+            .sink {
+                values.append($0)
+                if values.count == 2 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        networking.onGet = { endpoint, _ in
+            return .success(ActivityResponse(ok: true))
+        }
+
+        // Act
+        apiVerifier.verifyAPI()
+
+        // Assert
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values[safe: 0]?.status, .pending)
+        XCTAssertEqual(values[safe: 1]?.status, .verified)
+    }
+
+    func testFailure() throws {
+        // Arrange
+        let expectation = expectation(description: "Publishes values then finishes")
+        var values: [StatusItem] = []
+
+        apiVerifier.subject
+            .sink {
+                values.append($0)
+                if values.count == 2 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        networking.onGet = { endpoint, _ in
+            return .failure(NetworkingError.nonSuccessfulStatusCode(500))
+        }
+
+        // Act
+        apiVerifier.verifyAPI()
+
+        // Assert
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values[safe: 0]?.status, .pending)
+        XCTAssertEqual(values[safe: 1]?.status, .unverified)
+    }
+}

--- a/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
@@ -37,8 +37,8 @@ class APIVerifierTests: XCTestCase {
             }
             .store(in: &cancellables)
 
-        networking.onGet = { endpoint, _ in
-            return .success(ActivityResponse(ok: true))
+        networking.onGet = { endpoint, _, completion in
+            completion(.success(ActivityResponse(ok: true)))
         }
 
         // Act
@@ -65,8 +65,8 @@ class APIVerifierTests: XCTestCase {
             }
             .store(in: &cancellables)
 
-        networking.onGet = { endpoint, _ in
-            return .failure(NetworkingError.nonSuccessfulStatusCode(500))
+        networking.onGet = { endpoint, _, completion in
+            completion(.failure(NetworkingError.nonSuccessfulStatusCode(500)))
         }
 
         // Act

--- a/Tests/AppcuesKitTests/Debugger/DebugViewModelTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/DebugViewModelTests.swift
@@ -1,0 +1,257 @@
+//
+//  DebugViewModelTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-10-16.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+import Combine
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class DebugViewModelTests: XCTestCase {
+
+    var debugViewModel: DebugViewModel!
+    var publisher: PassthroughSubject<LoggedEvent, Never>!
+    var storage: MockStorage!
+
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUpWithError() throws {
+        publisher = PassthroughSubject<LoggedEvent, Never>()
+        storage = MockStorage()
+        debugViewModel = DebugViewModel(
+            eventPublisher: publisher.eraseToAnyPublisher(),
+            storage: storage,
+            accountID: "123",
+            applicationID: "app-id"
+        )
+    }
+
+    func testInitialStatus() throws {
+        // Arrange
+
+        // Act
+
+        // Assert
+        XCTAssertEqual(debugViewModel.accountID, "123")
+        XCTAssertEqual(debugViewModel.applicationID, "app-id")
+        XCTAssertEqual(debugViewModel.currentUserID, "user-id")
+        XCTAssertFalse(debugViewModel.isAnonymous)
+        XCTAssertFalse(debugViewModel.trackingPages)
+        XCTAssertNil(debugViewModel.filter)
+        XCTAssertTrue(debugViewModel.filteredEvents.isEmpty)
+        XCTAssertTrue(debugViewModel.experienceStatuses.isEmpty)
+    }
+
+    func testRemoveExperience() throws {
+        // Arrange
+        let id = UUID()
+        debugViewModel.experienceStatuses = [
+            StatusItem(status: .verified, title: "Showing experience name", id: id)
+        ]
+
+        // Act
+        debugViewModel.removeExperienceStatus(id: id)
+
+        // Assert
+        XCTAssertEqual(debugViewModel.experienceStatuses.count, 0)
+    }
+
+    func testProcessScreenView() throws {
+        // Arrange
+        let update = TrackingUpdate(type: .screen("My Screen"), isInternal: true)
+
+        _ = expectToUpdate(debugViewModel.$trackingPages)
+
+        // Act
+        publisher.send(LoggedEvent(from: update))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(debugViewModel.trackingPages)
+        XCTAssertEqual(debugViewModel.filteredEvents.count, 1)
+    }
+
+    func testProcessExperienceStartedEvent() throws {
+        // Arrange
+        let update = TrackingUpdate(
+            type: .event(name: "appcues:v2:experience_started", interactive: false),
+            properties: [
+                "experienceId": UUID().appcuesFormatted,
+                "experienceInstanceId": UUID().appcuesFormatted,
+                "experienceName": "Test Experience",
+            ],
+            isInternal: true
+        )
+
+        _ = expectToUpdate(debugViewModel.$experienceStatuses)
+
+        // Act
+        publisher.send(LoggedEvent(from: update))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(debugViewModel.experienceStatuses.count, 1)
+        try StatusItem(status: .verified, title: "Showing Test Experience")
+            .verifyMatches(debugViewModel.experienceStatuses[safe: 0])
+        XCTAssertEqual(debugViewModel.filteredEvents.count, 1)
+
+        debugViewModel.filter = .screen
+        XCTAssertEqual(debugViewModel.filteredEvents.count, 0)
+    }
+
+    func testProcessExperienceErrorEvent() throws {
+        // Arrange
+        let update = TrackingUpdate(
+            type: .event(name: "appcues:v2:experience_error", interactive: false),
+            properties: [
+                "experienceId": UUID().appcuesFormatted,
+                "experienceInstanceId": UUID().appcuesFormatted,
+                "experienceName": "Test Experience",
+                "errorId": UUID().appcuesFormatted,
+                "message": "Some error message"
+            ],
+            isInternal: true
+        )
+
+        _ = expectToUpdate(debugViewModel.$experienceStatuses)
+
+        // Act
+        publisher.send(LoggedEvent(from: update))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(debugViewModel.experienceStatuses.count, 1)
+        try StatusItem(status: .unverified, title: "Content Omitted: Test Experience", subtitle: "Some error message")
+            .verifyMatches(debugViewModel.experienceStatuses[safe: 0])
+        XCTAssertEqual(debugViewModel.filteredEvents.count, 1)
+    }
+
+    func testProcessExperienceStepSeenEvent() throws {
+        // Arrange
+        let experienceID = UUID().appcuesFormatted
+        let initialUpdate = TrackingUpdate(
+            type: .event(name: "appcues:v2:experience_started", interactive: false),
+            properties: [
+                "experienceId": experienceID,
+                "experienceInstanceId": UUID().appcuesFormatted,
+                "experienceName": "Test Experience",
+                "frameID": "my-frame"
+            ],
+            isInternal: true
+        )
+
+        let update = TrackingUpdate(
+            type: .event(name: "appcues:v2:step_seen", interactive: false),
+            properties: [
+                "experienceId": experienceID,
+                "experienceInstanceId": UUID().appcuesFormatted,
+                "experienceName": "Test Experience",
+                "stepId": UUID().appcuesFormatted,
+                "stepIndex": Experience.StepIndex.initial.description,
+                "frameID": "my-frame"
+            ],
+            isInternal: true
+        )
+
+        _ = expectToUpdate(debugViewModel.$experienceStatuses, count: 2)
+
+        // Act
+        publisher.send(LoggedEvent(from: initialUpdate))
+        publisher.send(LoggedEvent(from: update))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(debugViewModel.experienceStatuses.count, 1)
+        try StatusItem(status: .verified, title: "Showing Test Experience", subtitle: "Group 1 step 1 (my-frame)")
+            .verifyMatches(debugViewModel.experienceStatuses[safe: 0])
+    }
+
+    func testProcessExperienceCompletedEvent() throws {
+        // Arrange
+        let experienceID = UUID().appcuesFormatted
+        let initialUpdate = TrackingUpdate(
+            type: .event(name: "appcues:v2:step_seen", interactive: false),
+            properties: [
+                "experienceId": experienceID,
+                "experienceInstanceId": UUID().appcuesFormatted,
+                "experienceName": "Test Experience",
+                "stepId": UUID().appcuesFormatted,
+                "stepIndex": Experience.StepIndex.initial.description
+            ],
+            isInternal: true
+        )
+
+        let update = TrackingUpdate(
+            type: .event(name: "appcues:v2:experience_completed", interactive: false),
+            properties: [
+                "experienceId": experienceID,
+                "experienceInstanceId": UUID().appcuesFormatted,
+                "experienceName": "Test Experience"
+            ],
+            isInternal: true
+        )
+
+        _ = expectToUpdate(debugViewModel.$experienceStatuses, count: 2)
+
+        // Act
+        publisher.send(LoggedEvent(from: initialUpdate))
+        publisher.send(LoggedEvent(from: update))
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(debugViewModel.experienceStatuses.count, 0)
+    }
+
+    func testReset() throws {
+        // Arrange
+        let update = TrackingUpdate(type: .screen("My Screen"), isInternal: true)
+        _ = expectToUpdate(debugViewModel.$trackingPages, count: 1)
+        publisher.send(LoggedEvent(from: update))
+        waitForExpectations(timeout: 1)
+        cancellables.removeAll() // remove the subscriber from expectToUpdate above
+
+        debugViewModel.filter = .screen
+        XCTAssertEqual(debugViewModel.filteredEvents.count, 1, "Precondition")
+
+        // Act
+        debugViewModel.reset()
+
+
+        // Assert
+        XCTAssertNil(debugViewModel.filter)
+        XCTAssertEqual(debugViewModel.filteredEvents.count, 0)
+        XCTAssertFalse(debugViewModel.trackingPages)
+    }
+
+    // MARK: - Helpers
+
+    /// Fulfill an expectation once a new value is set.
+    func expectToUpdate<T>(_ publisher: Published<T>.Publisher, count: Int = 1) -> XCTestExpectation {
+        var sinkCount = 0
+        let expectation = expectation(description: "Test")
+        publisher
+            .dropFirst()
+            .sink { _ in
+                sinkCount += 1
+                if sinkCount >= count {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+        return expectation
+    }
+}
+
+extension StatusItem {
+    func verifyMatches(_ other: StatusItem?, file: StaticString = #file, line: UInt = #line) throws {
+        let other = try XCTUnwrap(other)
+        XCTAssertEqual(self.status, other.status, file: file, line: line)
+        XCTAssertEqual(self.title, other.title, file: file, line: line)
+        XCTAssertEqual(self.subtitle, other.subtitle, file: file, line: line)
+        XCTAssertEqual(self.detailText, other.detailText, file: file, line: line)
+    }
+}

--- a/Tests/AppcuesKitTests/Debugger/DeepLinkVerifierTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/DeepLinkVerifierTests.swift
@@ -26,7 +26,7 @@ class DeepLinkVerifierTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Publishes values then finishes")
         var values: [StatusItem] = []
 
-        deepLinkVerifier.subject
+        deepLinkVerifier.publisher
             .sink {
                 values.append($0)
                 if values.count == 2 {
@@ -57,7 +57,7 @@ class DeepLinkVerifierTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Publishes values then finishes")
         var values: [StatusItem] = []
 
-        deepLinkVerifier.subject
+        deepLinkVerifier.publisher
             .sink {
                 values.append($0)
                 if values.count == 2 {
@@ -74,7 +74,7 @@ class DeepLinkVerifierTests: XCTestCase {
 
         // Assert
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values.count, 2, "a pending value and an unverified one")
         XCTAssertEqual(values[safe: 0]?.status, .pending)
         XCTAssertEqual(values[safe: 1]?.status, .unverified)
         XCTAssertEqual(values[safe: 1]?.subtitle, "Error 0: Failed to set up verification")
@@ -85,7 +85,7 @@ class DeepLinkVerifierTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Publishes values then finishes")
         var values: [StatusItem] = []
 
-        deepLinkVerifier.subject
+        deepLinkVerifier.publisher
             .sink {
                 values.append($0)
                 if values.count == 2 {
@@ -102,7 +102,7 @@ class DeepLinkVerifierTests: XCTestCase {
 
         // Assert
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values.count, 2, "a pending value and an unverified one")
         XCTAssertEqual(values[safe: 0]?.status, .pending)
         XCTAssertEqual(values[safe: 1]?.status, .unverified)
         XCTAssertEqual(values[safe: 1]?.subtitle, "Error 1: CFBundleURLSchemes value missing")
@@ -113,7 +113,7 @@ class DeepLinkVerifierTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Publishes values then finishes")
         var values: [StatusItem] = []
 
-        deepLinkVerifier.subject
+        deepLinkVerifier.publisher
             .sink {
                 values.append($0)
                 if values.count == 2 {
@@ -132,7 +132,7 @@ class DeepLinkVerifierTests: XCTestCase {
 
         // Assert
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values.count, 2, "a pending value and an unverified one")
         XCTAssertEqual(values[safe: 0]?.status, .pending)
         XCTAssertEqual(values[safe: 1]?.status, .unverified)
         XCTAssertEqual(values[safe: 1]?.subtitle, "Error 2: Appcues SDK not receiving links")
@@ -143,7 +143,7 @@ class DeepLinkVerifierTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Publishes values then finishes")
         var values: [StatusItem] = []
 
-        deepLinkVerifier.subject
+        deepLinkVerifier.publisher
             .sink {
                 values.append($0)
                 if values.count == 2 {
@@ -162,7 +162,7 @@ class DeepLinkVerifierTests: XCTestCase {
 
         // Assert
         wait(for: [expectation], timeout: 1)
-        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values.count, 2, "a pending value and an unverified one")
         XCTAssertEqual(values[safe: 0]?.status, .pending)
         XCTAssertEqual(values[safe: 1]?.status, .unverified)
         XCTAssertEqual(values[safe: 1]?.subtitle, "Error 3: Unexpected result")

--- a/Tests/AppcuesKitTests/Debugger/DeepLinkVerifierTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/DeepLinkVerifierTests.swift
@@ -1,0 +1,180 @@
+//
+//  DeepLinkVerifierTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-10-13.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+import Combine
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class DeepLinkVerifierTests: XCTestCase {
+
+    var deepLinkVerifier: MockDeepLinkVerifier!
+
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUpWithError() throws {
+        deepLinkVerifier = MockDeepLinkVerifier(applicationID: "app-id")
+    }
+
+    func testSuccess() throws {
+        // Arrange
+        let expectation = XCTestExpectation(description: "Publishes values then finishes")
+        var values: [StatusItem] = []
+
+        deepLinkVerifier.subject
+            .sink {
+                values.append($0)
+                if values.count == 2 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        deepLinkVerifier.mockURLTypes = [["CFBundleURLSchemes": ["appcues-app-id"]]]
+        let token = UUID()
+
+        // Act
+        deepLinkVerifier.verifyDeepLink(token: token)
+        // Simulate link returning
+        deepLinkVerifier.receivedVerification(token: token.uuidString)
+
+        // Assert
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values[safe: 0]?.status, .pending)
+        XCTAssertEqual(values[safe: 1]?.status, .verified)
+    }
+
+    func testError0() throws {
+        // Arrange
+        deepLinkVerifier = MockDeepLinkVerifier(applicationID: "<unsafe>")
+
+        let expectation = XCTestExpectation(description: "Publishes values then finishes")
+        var values: [StatusItem] = []
+
+        deepLinkVerifier.subject
+            .sink {
+                values.append($0)
+                if values.count == 2 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+
+        deepLinkVerifier.mockURLTypes = [["CFBundleURLSchemes": ["appcues-<unsafe>"]]]
+
+        // Act
+        deepLinkVerifier.verifyDeepLink()
+
+        // Assert
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values[safe: 0]?.status, .pending)
+        XCTAssertEqual(values[safe: 1]?.status, .unverified)
+        XCTAssertEqual(values[safe: 1]?.subtitle, "Error 0: Failed to set up verification")
+    }
+
+    func testError1() throws {
+        // Arrange
+        let expectation = XCTestExpectation(description: "Publishes values then finishes")
+        var values: [StatusItem] = []
+
+        deepLinkVerifier.subject
+            .sink {
+                values.append($0)
+                if values.count == 2 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+
+        deepLinkVerifier.mockURLTypes = nil
+
+        // Act
+        deepLinkVerifier.verifyDeepLink()
+
+        // Assert
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values[safe: 0]?.status, .pending)
+        XCTAssertEqual(values[safe: 1]?.status, .unverified)
+        XCTAssertEqual(values[safe: 1]?.subtitle, "Error 1: CFBundleURLSchemes value missing")
+    }
+
+    func testError2() throws {
+        // Arrange
+        let expectation = XCTestExpectation(description: "Publishes values then finishes")
+        var values: [StatusItem] = []
+
+        deepLinkVerifier.subject
+            .sink {
+                values.append($0)
+                if values.count == 2 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+
+        deepLinkVerifier.mockURLTypes = [["CFBundleURLSchemes": ["appcues-app-id"]]]
+
+        // Act
+        deepLinkVerifier.verifyDeepLink()
+        // Simulate link NOT returning
+        // deepLinkVerifier.receivedVerification(token: token.uuidString)
+
+        // Assert
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values[safe: 0]?.status, .pending)
+        XCTAssertEqual(values[safe: 1]?.status, .unverified)
+        XCTAssertEqual(values[safe: 1]?.subtitle, "Error 2: Appcues SDK not receiving links")
+    }
+
+    func testError3() throws {
+        // Arrange
+        let expectation = XCTestExpectation(description: "Publishes values then finishes")
+        var values: [StatusItem] = []
+
+        deepLinkVerifier.subject
+            .sink {
+                values.append($0)
+                if values.count == 2 {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+
+        deepLinkVerifier.mockURLTypes = [["CFBundleURLSchemes": ["appcues-app-id"]]]
+
+        // Act
+        deepLinkVerifier.verifyDeepLink()
+        // Simulate link returning an unexpected token value
+        deepLinkVerifier.receivedVerification(token: "some-random-value")
+
+        // Assert
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(values.count, 2, "a pending value and a success one")
+        XCTAssertEqual(values[safe: 0]?.status, .pending)
+        XCTAssertEqual(values[safe: 1]?.status, .unverified)
+        XCTAssertEqual(values[safe: 1]?.subtitle, "Error 3: Unexpected result")
+    }
+}
+
+/// Mock DeepLinkVerifier that allows overriding loading the CFBundleURLSchemes values from the Info.plist
+@available(iOS 13.0, *)
+class MockDeepLinkVerifier: DeepLinkVerifier {
+    var mockURLTypes: [[String : Any]]?
+
+    override var urlTypes: [[String : Any]]? {
+        mockURLTypes
+    }
+}

--- a/Tests/AppcuesKitTests/Debugger/LoggedEventTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/LoggedEventTests.swift
@@ -1,0 +1,93 @@
+//
+//  LoggedEventTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-10-16.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class LoggedEventTests: XCTestCase {
+
+    func testPropertyGrouping() throws {
+        let autoPropertyDecorator = AutoPropertyDecorator(container: MockAppcues().container)
+        let formResponse = ExperienceData.StepState(formItems: [
+            UUID(): ExperienceData.FormItem(model: ExperienceComponent.TextInputModel(
+                id: UUID(),
+                label: ExperienceComponent.TextModel(id: UUID(), text: "label"),
+                errorLabel: nil,
+                placeholder: nil,
+                defaultValue: "value",
+                required: nil,
+                numberOfLines: nil,
+                maxLength: nil,
+                dataType: nil,
+                textFieldStyle: nil,
+                cursorColor: nil,
+                attributeName: nil,
+                style: nil
+            ))
+        ])
+        let rawUpdate = TrackingUpdate(
+            type: .event(name: "My Event", interactive: true),
+            properties: [
+                // Note that not all these properties will exist on the same event, but we can still test them all at once.
+                "my-prop": true,
+                "_sdkMetrics": [
+                    "timeBeforeRequest": 100
+                ],
+                "_identity": [
+                    "my-prop": true,
+                ],
+                "interactionData": [
+                    "category": "internal",
+                    "formResponse": formResponse
+                ] as [String : Any]
+            ],
+            isInternal: false)
+        let decoratedUpdate = autoPropertyDecorator.decorate(rawUpdate)
+
+        // Act
+        let event = LoggedEvent(from: decoratedUpdate)
+
+        // Assert
+        let groupedProperties = try XCTUnwrap(event.eventProperties)
+        XCTAssertEqual(groupedProperties.count, 5)
+        XCTAssertEqual(groupedProperties[safe: 0]?.title, "Properties")
+        XCTAssertEqual(groupedProperties[safe: 1]?.title, "Interaction Data")
+        XCTAssertEqual(groupedProperties[safe: 2]?.title, "Interaction Data: Form Response")
+        XCTAssertEqual(groupedProperties[safe: 3]?.title, "Identity Auto-properties")
+        XCTAssertEqual(groupedProperties[safe: 4]?.title, "SDK Metrics")
+
+        XCTAssertEqual(event.eventDetailItems.count, 3)
+        XCTAssertEqual(event.eventDetailItems[safe: 0]?.title, "Type")
+        XCTAssertEqual(event.eventDetailItems[safe: 1]?.title, "Name")
+        XCTAssertEqual(event.eventDetailItems[safe: 2]?.title, "Timestamp")
+    }
+
+    func testNoAutoProperties() throws {
+        let update = TrackingUpdate(type: .event(name: "My Event", interactive: true), properties: ["my-prop": true], isInternal: false)
+
+        // Act
+        let event = LoggedEvent(from: update)
+
+        // Assert
+        let groupedProperties = try XCTUnwrap(event.eventProperties)
+        XCTAssertEqual(groupedProperties.count, 1)
+        XCTAssertEqual(groupedProperties[safe: 0]?.title, "Properties")
+    }
+
+    func testNoProperties() throws {
+        let update = TrackingUpdate(type: .event(name: "My Event", interactive: true), isInternal: false)
+
+        // Act
+        let event = LoggedEvent(from: update)
+
+        // Assert
+        XCTAssertNil(event.eventProperties)
+    }
+
+}

--- a/Tests/AppcuesKitTests/Debugger/ScreenCapturerTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/ScreenCapturerTests.swift
@@ -1,0 +1,321 @@
+//
+//  ScreenCapturerTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2023-10-16.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+class ScreenCapturerTests: XCTestCase {
+
+    private var screenCapturer: ScreenCapturer!
+    private var networking: MockNetworking!
+    private var experienceRenderer: MockExperienceRenderer!
+    private var screenCaptureUI: MockScreenCaptureUI!
+
+    let authorization = Authorization(bearerToken: "token")!
+    let sdkSettingsSuccess = SdkSettings(services: SdkSettings.Services(customerApi: "https://customerapi.appcues.com"))
+    let preUploadSuccess = ScreenshotUpload(
+        upload: ScreenshotUpload.Upload(presignedUrl: URL(string: "https://appcues.com/presigned-url")!),
+        url: URL(string: "https://appcues.com/image-url")!
+    )
+
+    override func setUpWithError() throws {
+        Appcues.elementTargeting = MockElementTargeting()
+
+        networking = MockNetworking()
+        experienceRenderer = MockExperienceRenderer()
+        screenCaptureUI = MockScreenCaptureUI()
+
+        screenCapturer = ScreenCapturer(
+            config: MockAppcues().config,
+            networking: networking,
+            experienceRenderer: experienceRenderer)
+    }
+
+    func testVisibleExperiencesAreDismissed() throws {
+        // Arrange
+        var experienceDismissed = false
+        experienceRenderer.onExperienceData = { context in
+            XCTAssertEqual(context, .modal)
+            return experienceDismissed ? nil : ExperienceData.mock
+        }
+
+        experienceRenderer.onDismiss = { context, markComplete, completion in
+            XCTAssertEqual(context, .modal)
+            XCTAssertFalse(markComplete)
+
+            experienceDismissed = true
+            completion?(.success(()))
+        }
+
+        // Act
+        screenCapturer.captureScreen(window: nil, authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        XCTAssertTrue(experienceDismissed)
+    }
+
+    func testInitialFailure() throws {
+        // Arrange
+        var toast: DebugToast?
+        screenCaptureUI.onShowToast = { toast = $0 }
+
+        // Act
+        // nil window should cause failure
+        screenCapturer.captureScreen(window: nil, authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        let unwrappedToast = try XCTUnwrap(toast)
+        XCTAssertEqual(unwrappedToast.message, .screenCaptureFailure)
+        XCTAssertEqual(unwrappedToast.style, .failure)
+    }
+
+    func testConfirmationScreenShows() throws {
+        // Arrange
+        let confirmationShownExpectation = expectation(description: "Confirmation screen shows")
+        screenCaptureUI.onShowConfirmation = { capture, completion in
+            confirmationShownExpectation.fulfill()
+        }
+
+        // Act
+        screenCapturer.captureScreen(window: UIWindow(), authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    // Step 1 failure
+    func testSaveSDKSettingsFail() throws {
+        // Arrange
+        // Step 1
+        networking.onGet = { endpoint, authorization, completion in
+            guard case SettingsEndpoint.settings = endpoint else { return XCTFail("Unexpected GET request") }
+            completion(.failure(NetworkingError.nonSuccessfulStatusCode(500)))
+        }
+
+        // Simulate trigger the interaction to submit
+        screenCaptureUI.onShowConfirmation = { _, completion in completion(.success("Screen Name")) }
+
+        let failureToastShownExpectation = expectation(description: "Toast shown")
+        screenCaptureUI.onShowToast = { toast in
+            XCTAssertEqual(toast.message, .screenUploadFailure)
+            XCTAssertEqual(toast.style, .failure)
+            failureToastShownExpectation.fulfill()
+        }
+
+        // Act
+        screenCapturer.captureScreen(window: UIWindow(), authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    // Step 2 failure
+    func testSavePreUploadFail() throws {
+        // Arrange
+        // Step 1
+        networking.onGet = { endpoint, authorization, completion in
+            guard case SettingsEndpoint.settings = endpoint else { return XCTFail("Unexpected GET request") }
+            XCTAssertNil(authorization)
+            completion(.success(self.sdkSettingsSuccess))
+        }
+
+        // Step 2
+        networking.onPost = { endpoint, authorization, data, requestID, completion in
+            guard case CustomerAPIEndpoint.preSignedImageUpload = endpoint else { return XCTFail("Unexpected POST request") }
+            completion(.failure(NetworkingError.nonSuccessfulStatusCode(500)))
+        }
+
+        // Simulate trigger the interaction to submit
+        screenCaptureUI.onShowConfirmation = { _, completion in completion(.success("Screen Name")) }
+
+        let failureToastShownExpectation = expectation(description: "Toast shown")
+        screenCaptureUI.onShowToast = { toast in
+            XCTAssertEqual(toast.message, .screenUploadFailure)
+            XCTAssertEqual(toast.style, .failure)
+            failureToastShownExpectation.fulfill()
+        }
+
+        // Act
+        screenCapturer.captureScreen(window: UIWindow(), authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    // Step 3 failure
+    func testSaveUploadImageFail() throws {
+        // Arrange
+        // Step 1
+        networking.onGet = { endpoint, authorization, completion in
+            guard case SettingsEndpoint.settings = endpoint else { return XCTFail("Unexpected GET request") }
+            XCTAssertNil(authorization)
+            completion(.success(self.sdkSettingsSuccess))
+        }
+
+        // Step 2
+        networking.onPost = { endpoint, authorization, data, requestID, completion in
+            guard case let CustomerAPIEndpoint.preSignedImageUpload(host, _) = endpoint else { return XCTFail("Unexpected POST request") }
+            XCTAssertEqual(self.authorization, authorization)
+            XCTAssertEqual(host.absoluteString, "https://customerapi.appcues.com")
+            completion(.success(self.preUploadSuccess))
+        }
+
+        // Step 3
+        networking.onPutEmptyResponse = { endpoint, authorization, data, contentType, completion in
+            switch endpoint {
+            case is URLEndpoint:
+                completion(.failure(NetworkingError.nonSuccessfulStatusCode(500)))
+            default:
+                XCTFail("Unexpected PUT request")
+            }
+        }
+
+        // Simulate trigger the interaction to submit
+        screenCaptureUI.onShowConfirmation = { _, completion in completion(.success("Screen Name")) }
+
+        let failureToastShownExpectation = expectation(description: "Toast shown")
+        screenCaptureUI.onShowToast = { toast in
+            XCTAssertEqual(toast.message, .screenUploadFailure)
+            XCTAssertEqual(toast.style, .failure)
+            failureToastShownExpectation.fulfill()
+        }
+
+        // Act
+        screenCapturer.captureScreen(window: UIWindow(), authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    // Step 4 failure
+    func testSaveScreenFail() throws {
+        // Arrange
+        // Step 1
+        networking.onGet = { endpoint, authorization, completion in
+            guard case SettingsEndpoint.settings = endpoint else { return XCTFail("Unexpected GET request") }
+            XCTAssertNil(authorization)
+            completion(.success(self.sdkSettingsSuccess))
+        }
+
+        // Step 2
+        networking.onPost = { endpoint, authorization, data, requestID, completion in
+            guard case let CustomerAPIEndpoint.preSignedImageUpload(host, _) = endpoint else { return XCTFail("Unexpected POST request") }
+            XCTAssertEqual(self.authorization, authorization)
+            XCTAssertEqual(host.absoluteString, "https://customerapi.appcues.com")
+            completion(.success(self.preUploadSuccess))
+        }
+
+        // Step 3
+        networking.onPutEmptyResponse = { endpoint, authorization, data, contentType, completion in
+            guard case let urlEndpoint as URLEndpoint = endpoint else { return XCTFail("Unexpected PUT request") }
+            XCTAssertNil(authorization)
+            XCTAssertEqual(urlEndpoint.url.absoluteString, "https://appcues.com/presigned-url")
+            XCTAssertNotNil(data)
+            XCTAssertEqual(contentType, "image/png")
+            completion(.success(()))
+        }
+
+        // Step 4
+        networking.onPostEmptyResponse = { endpoint, authorization, data, completion in
+            guard case CustomerAPIEndpoint.screenCapture = endpoint else { return XCTFail("Unexpected POST request") }
+            completion(.failure(NetworkingError.nonSuccessfulStatusCode(500)))
+        }
+
+        // Simulate trigger the interaction to submit
+        screenCaptureUI.onShowConfirmation = { _, completion in completion(.success("Screen Name")) }
+
+        let failureToastShownExpectation = expectation(description: "Toast shown")
+        screenCaptureUI.onShowToast = { toast in
+            XCTAssertEqual(toast.message, .screenUploadFailure)
+            XCTAssertEqual(toast.style, .failure)
+            failureToastShownExpectation.fulfill()
+        }
+
+        // Act
+        screenCapturer.captureScreen(window: UIWindow(), authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+
+    // Step 4 success
+    func testSaveSuccess() throws {
+        // Arrange
+        // Step 1
+        networking.onGet = { endpoint, authorization, completion in
+            guard case SettingsEndpoint.settings = endpoint else { return XCTFail("Unexpected GET request") }
+            XCTAssertNil(authorization)
+            completion(.success(self.sdkSettingsSuccess))
+        }
+
+        // Step 2
+        networking.onPost = { endpoint, authorization, data, requestID, completion in
+            guard case let CustomerAPIEndpoint.preSignedImageUpload(host, _) = endpoint else { return XCTFail("Unexpected POST request") }
+            XCTAssertEqual(self.authorization, authorization)
+            XCTAssertEqual(host.absoluteString, "https://customerapi.appcues.com")
+            completion(.success(self.preUploadSuccess))
+        }
+
+        // Step 3
+        networking.onPutEmptyResponse = { endpoint, authorization, data, contentType, completion in
+            guard case let urlEndpoint as URLEndpoint = endpoint else { return XCTFail("Unexpected PUT request") }
+            XCTAssertNil(authorization)
+            XCTAssertEqual(urlEndpoint.url.absoluteString, "https://appcues.com/presigned-url")
+            XCTAssertNotNil(data)
+            XCTAssertEqual(contentType, "image/png")
+            completion(.success(()))
+        }
+
+        // Step 4
+        networking.onPostEmptyResponse = { endpoint, authorization, data, completion in
+            guard case let CustomerAPIEndpoint.screenCapture(host) = endpoint else { return XCTFail("Unexpected POST request") }
+            XCTAssertEqual(self.authorization, authorization)
+            XCTAssertEqual(host.absoluteString, "https://customerapi.appcues.com")
+            completion(.success(()))
+        }
+
+        // Simulate trigger the interaction to submit
+        screenCaptureUI.onShowConfirmation = { _, completion in completion(.success("Screen Name")) }
+
+        let successToastShownExpectation = expectation(description: "Toast shown")
+        screenCaptureUI.onShowToast = { toast in
+            XCTAssertEqual(toast.message, .screenCaptureSuccess(displayName: "Screen Name"))
+            XCTAssertEqual(toast.style, .success)
+            successToastShownExpectation.fulfill()
+        }
+
+        // Act
+        screenCapturer.captureScreen(window: UIWindow(), authorization: authorization, captureUI: screenCaptureUI)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+    }
+}
+
+private class MockScreenCaptureUI: ScreenCaptureUI {
+    var onShowConfirmation: ((Capture, (Result<String, Error>) -> Void) -> Void)?
+    func showConfirmation(screen: Capture, completion: @escaping (Result<String, Error>) -> Void) {
+        onShowConfirmation?(screen, completion)
+    }
+
+    var onShowToast: ((DebugToast) -> Void)?
+    func showToast(_ toast: DebugToast) {
+        onShowToast?(toast)
+    }
+}
+
+private class MockElementTargeting: AppcuesElementTargeting {
+    func captureLayout() -> AppcuesViewElement? {
+        AppcuesViewElement(x: 0, y: 0, width: 10, height: 10, type: "mock", selector: nil, children: nil)
+    }
+
+    func inflateSelector(from properties: [String : String]) -> AppcuesKit.AppcuesElementSelector? {
+        nil
+    }
+}

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -22,12 +22,12 @@ class ExperienceLoaderTests: XCTestCase {
 
     func testLoadPublished() throws {
         // Arrange
-        appcues.networking.onGet = { endpoint, authorization in
+        appcues.networking.onGet = { endpoint, authorization, completion in
             XCTAssertEqual(
                 endpoint.url(config: self.appcues.config, storage: self.appcues.storage),
                 APIEndpoint.content(experienceID: "123").url(config: self.appcues.config, storage: self.appcues.storage)
             )
-            return .success(Experience.mock)
+            completion(.success(Experience.mock))
         }
         appcues.experienceRenderer.onProcessAndShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
@@ -51,12 +51,12 @@ class ExperienceLoaderTests: XCTestCase {
 
     func testLoadUnpublished() throws {
         // Arrange
-        appcues.networking.onGet = { endpoint, authorization in
+        appcues.networking.onGet = { endpoint, authorization, completion in
             XCTAssertEqual(
                 endpoint.url(config: self.appcues.config, storage: self.appcues.storage),
                 APIEndpoint.preview(experienceID: "123").url(config: self.appcues.config, storage: self.appcues.storage)
             )
-            return .success(Experience.mock)
+            completion(.success(Experience.mock))
         }
         appcues.experienceRenderer.onProcessAndShowExperience = { experience, completion in
             XCTAssertEqual(experience.priority, .normal)
@@ -80,8 +80,8 @@ class ExperienceLoaderTests: XCTestCase {
 
     func testLoadFail() throws {
         // Arrange
-        appcues.networking.onGet = { endpoint, authorization in
-            return .failure(URLError(.resourceUnavailable))
+        appcues.networking.onGet = { endpoint, authorization, completion in
+            completion(.failure(URLError(.resourceUnavailable)))
         }
 
         let completionExpectation = expectation(description: "Completion called")
@@ -104,14 +104,14 @@ class ExperienceLoaderTests: XCTestCase {
         // Load the initial preview
         experienceLoader.load(experienceID: "123", published: false, trigger: .preview, completion: nil)
 
-        appcues.networking.onGet = { endpoint, authorization in
+        appcues.networking.onGet = { endpoint, authorization, completion in
             XCTAssertEqual(
                 endpoint.url(config: self.appcues.config, storage: self.appcues.storage),
                 APIEndpoint.preview(experienceID: "123").url(config: self.appcues.config, storage: self.appcues.storage)
             )
             reloadExpectation.fulfill()
 
-            return .success(Experience.mock)
+            completion(.success(Experience.mock))
         }
 
         // Act
@@ -131,10 +131,9 @@ class ExperienceLoaderTests: XCTestCase {
         // Load a published experience
         experienceLoader.load(experienceID: "abc", published: true, trigger: .preview, completion: nil)
 
-        appcues.networking.onGet = { endpoint, authorization in
+        appcues.networking.onGet = { endpoint, authorization, completion in
             reloadExpectation.fulfill()
             XCTFail("Experience should not be loaded on notification")
-            return .success(Experience.mock)
         }
 
         // Act

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -86,8 +86,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         XCTAssertNotNil(appcues.storage.lastContentShownAt)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .stepSeen,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
@@ -123,8 +123,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .stepSeen,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
@@ -161,8 +161,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .stepCompleted,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
@@ -207,8 +207,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .experienceDismissed,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
@@ -241,8 +241,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .experienceCompleted,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
@@ -273,8 +273,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .experienceCompleted,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
@@ -310,8 +310,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .experienceError,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
@@ -352,8 +352,8 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
 
         XCTAssertEqual(
-            try XCTUnwrap(LifecycleEvent.restructure(update: lastUpdate)),
-            LifecycleEvent.EventProperties(
+            try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
+            StructuredLifecycleProperties(
                 type: .stepError,
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",


### PR DESCRIPTION
The debugger is undoubtedly (by far!) in the poorest shape of any part of the SDK codebase and is almost entirely untested. It's not a critical piece of the SDK, so that's not a huge problem, but with stuff like screen capture being increasingly important, it'd be worthwhile trying to make it better. This PR does some significant refactoring and adds a bunch of new tests.

## Changes
1. Break up `DebugViewModel`. This >500 line file has a massive amount of stuff in it.
  1. I've moved models like `StatusItem` and `LoggedEvent` to their own files.
  2. I've created standalone classes `APIVerifier` and `DeepLinkVerifier` that encapsulate that functionality.
2. `DebugUI` now has views for each of the Status items. This better separates concerns and will make testing these in the future easier (all the tests in this PR are just related to the logic—nothing about the presentation yet).
3. I've created `ScreenCapturer which encapsulate the screen capture logic instead of it being bolted on to `UIDebugger`. It uses the new `protocol ScreenCaptureUI` to communicate back to `UIDebugger`.
4. Moved `LifecycleEvent.EventProperties` to the debugger directories as `StructuredLifecycleProperties` since the only place it's used is in the debugger.

## Benefits
1. Testability! There's now tests for all this stuff.
2. The DebugViewController and friends are tied the the lifecycle of the debug view and not the UIDebugger class. So when the debugger is dismissed, all that stuff is deinited instead of sticking around forever after it's shown once.
3. Simpler data flow. The events that come in via AnalyticsSubscribing are now piped through a single combine Publisher that gets used to show the fleeting log items, update the event list in the debugger, and calculate the active experiences section of the debugger.

## How to review this PR
Looking at the final diff will make it quite challenging to follow where everything moved to. Reviewing each of the 3 "♻️ Refactor..." commits might be simpler. Note that some of the things in ac6c4f0 were subsequently changed further in 118543b (like where the `APIVerifier` and `DeepLinkVerifier` are inited).

Some of the tests are complicated. For example, the ScreenCapturer still does the 4 changed network requests, so to properly mock/test the last step, we need to mock/test all 3 before it. Also testing the Combine pipeline stuff is a bit awkward since you need to set an expectation to fulfill once you see the values you want coming through the pipeline.