### PR TITLE
Add target overlay and help text to the screen capture confirm screen

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
@@ -21,12 +21,15 @@ internal enum SendCaptureUI {
         let capture: Capture
         let completion: (Result<String, Error>) -> Void
 
+        let helpLinkURL = URL(string: "https://docs.appcues.com/mobile-sdk-screen-capture-help")
+
         @State var screenName = ""
 
         var body: some View {
             VStack(spacing: 16) {
                 header
                 screenshotImage
+                captureInfo
                 nameInput
                 bottomButtons
             }
@@ -48,11 +51,35 @@ internal enum SendCaptureUI {
         }
 
         @ViewBuilder var screenshotImage: some View {
-            Image(uiImage: capture.screenshot)
+            Image(uiImage: capture.annotatedScreenshot)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 375)
                 .overlay(Rectangle().stroke(Color.appcuesImageBorder, lineWidth: 1))
+        }
+
+        @ViewBuilder var captureInfo: some View {
+            // The Link view is iOS 14+
+            if let helpLinkURL = helpLinkURL, #available(iOS 14.0, *) {
+                VStack(alignment: .leading, spacing: 8) {
+                    if capture.targetableElementCount > 0 {
+                        Text("Not seeing the element you want highlighted?")
+                        Link(destination: helpLinkURL) {
+                            Text("Read the documentation for troubleshooting.")
+                        }
+                        .foregroundColor(.blue)
+                    } else {
+                        Text("Warning: this screen capture has 0 target elements for use with anchored tooltips.")
+                            .foregroundColor(Color.orange)
+                        Link(destination: helpLinkURL) {
+                            Text("Need help? Read the documentation.")
+                        }
+                        .foregroundColor(.blue)
+                    }
+                }
+                .font(.system(size: 14))
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
 
         @ViewBuilder var nameInput: some View {

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
@@ -64,18 +64,14 @@ internal enum SendCaptureUI {
                 VStack(alignment: .leading, spacing: 8) {
                     if capture.targetableElementCount > 0 {
                         Text("Not seeing the element you want highlighted?")
-                        Link(destination: helpLinkURL) {
-                            Text("Read the documentation for troubleshooting.")
-                        }
-                        .foregroundColor(.blue)
                     } else {
-                        Text("Warning: this screen capture has 0 target elements for use with anchored tooltips.")
+                        Text("Warning: this screen capture does not have any targetable elements identified.")
                             .foregroundColor(Color.orange)
-                        Link(destination: helpLinkURL) {
-                            Text("Need help? Read the documentation.")
-                        }
-                        .foregroundColor(.blue)
                     }
+                    Link(destination: helpLinkURL) {
+                        Text("Tap to view troubleshooting documentation.")
+                    }
+                    .foregroundColor(.blue)
                 }
                 .font(.system(size: 14))
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Draw highlights (matching the mobile builder style) emphasizing the screenshot regions with selectors and add some help text if people aren't seeing the results they expect. The doc link is to https://docs.appcues.com/mobile-sdk-screen-capture-help which is a configurable redirect (so we can update it if the docs change).

|Some selectors|No selectors|
|-|-|
|![Simulator Screenshot - iPhone 14 Pro - 2023-10-18 at 15 18 51](https://github.com/appcues/appcues-ios-sdk/assets/845681/1aaa4b48-152f-4bfe-a5ec-4470285bb1d6)|![Simulator Screenshot - iPhone 14 Pro - 2023-10-18 at 15 18 46](https://github.com/appcues/appcues-ios-sdk/assets/845681/5fef7b69-6929-47a2-a285-16573efab2ad)|