### PR TITLE
Add identify to example embed options

### DIFF
--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedTestHarnessViewController.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/EmbedTestHarnessViewController.swift
@@ -109,6 +109,9 @@ class EmbedTestHarnessViewController: UIViewController {
                 UIAction(title: "Toggle 'frame2'", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
                     guard let self = self else { return }
                     self.testHarnessView.toggleFrame(id: "frame2", viewController: self)
+                },
+                UIAction(title: "Identify 'user-1'", image: UIImage(systemName: "person")) { _ in
+                    Appcues.shared.identify(userID: "user-1")
                 }
             ])
 

--- a/Examples/DeveloperSPMExample/SPMExample/EmbedTestHarnessViewController.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/EmbedTestHarnessViewController.swift
@@ -109,6 +109,9 @@ class EmbedTestHarnessViewController: UIViewController {
                 UIAction(title: "Toggle 'frame2'", image: UIImage(systemName: "photo.artframe")) { [weak self] _ in
                     guard let self = self else { return }
                     self.testHarnessView.toggleFrame(id: "frame2", viewController: self)
+                },
+                UIAction(title: "Identify 'user-1'", image: UIImage(systemName: "person")) { _ in
+                    Appcues.shared.identify(userID: "user-1")
                 }
             ])
 


### PR DESCRIPTION
Test app update that lets us identify a user from the embed test harness. Merging this before the re-render fix so we can verify the bug and fix in the TestFlight app.