### PR TITLE
🐛 Do not dismiss and re-render an experience with the same instance from cache

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -137,6 +137,12 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
             return
         }
 
+        guard experience.instanceID != stateMachine.state.currentExperienceData?.instanceID else {
+            // This experience is already showing
+            completion?(.success(()))
+            return
+        }
+
         guard experience.experiment?.shouldExecute ?? true else {
             // if we get here, it means we did have an experiment, but it was the control group and
             // we should not continue. So track experiment_entered analytics for it (always)..


### PR DESCRIPTION
Sibling to https://github.com/appcues/appcues-android-sdk/pull/519 (and PR description shameless stolen)

Scenario:

- embed is triggered on session start (event trigger) and placed in cache
- later gets rendered ok
- another analytic occurs (i.e. identify, not a screen)
- no new experiences, and no cache clear, cache is re-processed
- the experience in cache tries to re-render by dismissing the current experience and re-starting --> not desired

We only want to dismiss the current experience if (1) it is a new experience from the server of normal priority (not a screen view) or (2) it is an updated version of the current experience from server (new instance id)
