### PR TITLE
Remove _userAgent auto property

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -116,19 +116,6 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             "_deviceType": UIDevice.current.userInterfaceIdiom.analyticsName,
             "_deviceModel": UIDevice.current.modelName
         ]
-
-        if Thread.isMainThread {
-            updateUserAgent()
-        } else {
-            DispatchQueue.main.sync {
-                self.updateUserAgent()
-            }
-        }
-    }
-
-    private func updateUserAgent() {
-        guard let userAgent = WKWebView().value(forKey: "userAgent") as? String else { return }
-        applicationProperties["_userAgent"] = userAgent
     }
 }
 

--- a/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
@@ -37,7 +37,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
         let expectedPropertyKeys = ["_identity", "CUSTOM"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_userAgent", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.eventAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
     }
 
@@ -53,7 +53,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
         let expectedPropertyKeys = ["_identity", "CUSTOM"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_userAgent", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionRandomizer", "_sessionId"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionRandomizer", "_sessionId"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.eventAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
     }
 
@@ -67,7 +67,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         // Assert
         let expectedContextKeys = ["app_id", "app_version"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
-        let expectedPropertyKeys = ["CUSTOM", "userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_userAgent", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId"]
+        let expectedPropertyKeys = ["CUSTOM", "userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
         XCTAssertNil(decorated.eventAutoProperties)
     }
@@ -100,7 +100,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         let decorated = decorator.decorate(update)
 
         // Assert
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_userAgent", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId", "_myProp"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId", "_myProp"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.eventAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
 
         // new custom prop
@@ -124,7 +124,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
         let expectedPropertyKeys = ["_identity"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_userAgent", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId", "PROFILE_PROPERTY"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId", "PROFILE_PROPERTY"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.eventAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
     }
 }


### PR DESCRIPTION
Removing this auto property on iOS for performance reasons: the user agent value was determined at SDK init and must be on the main thread because it uses a UIKit view.

It is not believed to be a useful property in mobile for most scenarios, and it can be sent as a custom property if still desired for targeting content.

Sibling of https://github.com/appcues/appcues-android-sdk/pull/520