### PR TITLE
Add support for AppcuesUniversalLinkHostAllowList Info.plist allow list

### DIFF
--- a/Sources/AppcuesKit/AppcuesKit.docc/UniversalLinking.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/UniversalLinking.md
@@ -1,10 +1,10 @@
 # Configuring Handling of Universal Links
 
-The Appcues iOS SDK supports universal links as an option deep linking to screens within your app.
+The Appcues iOS SDK supports universal links as an option for deep linking to screens within your app.
 
 ## Overview
 
-You must implement `UIApplicationDelegate.application(_:continue:restorationHandler:)` to handle your universal links. The Appcues iOS SDK will call this method for every `https` link it tries to open to allow your app a chance to handle it internally instead of opening the link in a browser.
+You must implement `UIApplicationDelegate.application(_:continue:restorationHandler:)` to handle your universal links. By default, the Appcues iOS SDK will call this method for every `https` link it tries to open to allow your app a chance to handle it internally instead of opening the link in a browser. Optionally, you may provide an allow list of URL hosts—refer to the Domain Allow List section below.
 
 > If your app has opted into [UIKit Scenes](https://developer.apple.com/documentation/uikit/app_and_environment/scenes), you still must implement the `UIApplicationDelegate` method to handle universal links triggered from the Appcues iOS SDK.
 
@@ -34,4 +34,28 @@ func application(_ application: UIApplication,
 
     // TODO: Parse the `incomingURL` here and return true if the link has been handled, false otherwise.
 }
+```
+
+## Implementing a Domain Allow List 
+
+You may define a custom key, `AppcuesUniversalLinkHostAllowList`, in your _Info.plist_ file with an array of (string) host values to control which URLs are passed to `UIApplicationDelegate.application(_:continue:restorationHandler:)`. A URL whose host matches any of the provided host values will be treated as a potential universal link.
+
+An empty array will prevent all links from be treated as universal links and is functionally the same as calling ``Appcues/Config/enableUniversalLinks(_:)`` with a `false` argument.
+
+If the `AppcuesUniversalLinkHostAllowList` key is absent from `Info.plist`, all `https` links will be treated as potential universal links.
+
+Example _Info.plist_ to only treat links to `appcues.com` as universal links:
+
+```plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    ...
+    <key>AppcuesUniversalLinkHostAllowList</key>
+    <array>
+        <string>appcues.com</string>
+    </array>
+</dict>
+</plist>
 ```

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -61,7 +61,9 @@ internal class AppcuesLinkAction: AppcuesExperienceAction {
         if isWebLink {
             // Check try opening the link as if it's a universal link, and if not,
             // then fall back to the desired in-app or external browser.
-            let successfullyHandledUniversalLink = appcues.config.enableUniversalLinks && urlOpener.open(potentialUniversalLink: url)
+            let successfullyHandledUniversalLink = appcues.config.enableUniversalLinks
+            && isAllowListed(url)
+            && urlOpener.open(potentialUniversalLink: url)
 
             if successfullyHandledUniversalLink {
                 completion()
@@ -76,5 +78,14 @@ internal class AppcuesLinkAction: AppcuesExperienceAction {
             // Scheme link
             urlOpener.open(url, options: [:]) { _ in completion() }
         }
+    }
+
+    private func isAllowListed(_ url: URL) -> Bool {
+        guard let host = url.host, let hostAllowList = urlOpener.universalLinkHostAllowList else {
+            // If no `AppcuesUniversalLinkHostAllowList` value in Info.plist, then all hosts are allowed.
+            return true
+        }
+
+        return hostAllowList.contains(host)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
@@ -13,7 +13,10 @@ internal protocol TopControllerGetting {
 
     func topViewController() -> UIViewController?
 }
+
 internal protocol URLOpening {
+    var universalLinkHostAllowList: [String]? { get }
+
     func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?)
     func open(potentialUniversalLink: URL) -> Bool
 }
@@ -84,6 +87,10 @@ extension UIApplication: TopControllerGetting {
 }
 
 extension UIApplication: URLOpening {
+    var universalLinkHostAllowList: [String]? {
+        Bundle.main.object(forInfoDictionaryKey: "AppcuesUniversalLinkHostAllowList") as? [String]
+    }
+
     func open(potentialUniversalLink url: URL) -> Bool {
         let userActivity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
         userActivity.webpageURL = url


### PR DESCRIPTION
React Native apps that [support universal links](https://reactnative.dev/docs/linking#enabling-deep-links) always [return true](https://github.com/facebook/react-native/blob/4ed3260266bd1bad0403032179ca426aa7016c68/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm#L81) from `UIApplicationDelegate.application(_:continue:restorationHandler:)`. This means that unless these apps specifically support opening arbitrary links in their universal link handling (which is unlikely), experiences using the link action won't actually open the link because the SDK is told that the app handled the link when the app didn't actually.

This PR adds an easy configuration option (setting the Info.plist is simpler than an `Appcues.Config` value which would need corresponding changes to the React Native module) to provide an allow list of URL hosts that actually are intended for use with universal links.

The implementation is pretty straightforward—I added the Info.plist getter to `URLOpening` so it can be mocked easily in tests.

Updated the docs here, but I also intend to add a new universal link doc to the React Native repo.