### PR TITLE
Remove assertionFailures

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -230,20 +230,22 @@ public class Appcues: NSObject {
 
     /// Register a trait that modifies an `Experience`.
     /// - Parameter trait: Trait to register.
+    /// - Returns: Whether the trait was successfully registered.
     @objc
-    internal func register(trait: AppcuesExperienceTrait.Type) {
-        guard #available(iOS 13.0, *) else { return }
+    internal func register(trait: AppcuesExperienceTrait.Type) -> Bool {
+        guard #available(iOS 13.0, *) else { return false }
 
-        traitRegistry.register(trait: trait)
+        return traitRegistry.register(trait: trait)
     }
 
     /// Register an action that can be activated in an `Experience`.
     /// - Parameter action: Action to register.
+    /// - Returns: Whether the action was successfully registered.
     @objc
-    internal func register(action: AppcuesExperienceAction.Type) {
-        guard #available(iOS 13.0, *) else { return }
+    internal func register(action: AppcuesExperienceAction.Type) -> Bool {
+        guard #available(iOS 13.0, *) else { return false }
 
-        actionRegistry.register(action: action)
+        return actionRegistry.register(action: action)
     }
 
     /// Registers the specified frame to be available to host qualified embedded Appcues experience content.

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -231,6 +231,8 @@ public class Appcues: NSObject {
     /// Register a trait that modifies an `Experience`.
     /// - Parameter trait: Trait to register.
     /// - Returns: Whether the trait was successfully registered.
+    ///
+    /// A trait will not be registered if the specified trait type is already registered.
     @objc
     internal func register(trait: AppcuesExperienceTrait.Type) -> Bool {
         guard #available(iOS 13.0, *) else { return false }
@@ -241,6 +243,8 @@ public class Appcues: NSObject {
     /// Register an action that can be activated in an `Experience`.
     /// - Parameter action: Action to register.
     /// - Returns: Whether the action was successfully registered.
+    ///
+    /// An action will not be registered if the specified action type is already registered.
     @objc
     internal func register(action: AppcuesExperienceAction.Type) -> Bool {
         guard #available(iOS 13.0, *) else { return false }

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -150,20 +150,22 @@ extension Activity {
                 accountID: config.accountID,
                 sessionID: sessionID.appcuesFormatted,
                 userID: storage.userID,
-                events: [Event(name: name, attributes: update.properties, context: update.context)],
+                events: [Event(name: name, attributes: update.properties, context: update.context, logger: config.logger)],
                 profileUpdate: update.eventAutoProperties,
                 groupID: storage.groupID,
-                userSignature: storage.userSignature
+                userSignature: storage.userSignature,
+                logger: config.logger
             )
         case let .screen(title):
             self.init(
                 accountID: config.accountID,
                 sessionID: sessionID.appcuesFormatted,
                 userID: storage.userID,
-                events: [Event(screen: title, attributes: update.properties, context: update.context)],
+                events: [Event(screen: title, attributes: update.properties, context: update.context, logger: config.logger)],
                 profileUpdate: update.eventAutoProperties,
                 groupID: storage.groupID,
-                userSignature: storage.userSignature
+                userSignature: storage.userSignature,
+                logger: config.logger
             )
         case .profile:
             self.init(
@@ -173,7 +175,8 @@ extension Activity {
                 events: nil,
                 profileUpdate: update.properties,
                 groupID: storage.groupID,
-                userSignature: storage.userSignature
+                userSignature: storage.userSignature,
+                logger: config.logger
             )
         case .group:
             self.init(
@@ -183,7 +186,8 @@ extension Activity {
                 events: nil,
                 groupID: storage.groupID,
                 groupUpdate: update.properties,
-                userSignature: storage.userSignature
+                userSignature: storage.userSignature,
+                logger: config.logger
             )
         }
     }

--- a/Sources/AppcuesKit/Data/Logging/OSLog+Convenience.swift
+++ b/Sources/AppcuesKit/Data/Logging/OSLog+Convenience.swift
@@ -50,7 +50,7 @@ extension OSLog {
         // Swift doesn't support splatting so unfortunately `args` needs to be manually enumerated.
         // Limiting it to 5 since that seems reasonable.
         guard args.count <= 5 else {
-            assertionFailure("Too many log args. 5 are supported, \(args.count) passed.")
+            error("Too many log args. 5 are supported, %{public}d passed.", args.count)
             return
         }
 

--- a/Sources/AppcuesKit/Data/Models/Activity.swift
+++ b/Sources/AppcuesKit/Data/Models/Activity.swift
@@ -7,9 +7,12 @@
 //
 
 import Foundation
+import os.log
 
 /// API request body for registering user activity.
 internal struct Activity {
+    let logger: OSLog
+
     let requestID = UUID()
     var events: [Event]?
     var profileUpdate: [String: Any]?
@@ -28,7 +31,8 @@ internal struct Activity {
         profileUpdate: [String: Any]? = nil,
         groupID: String? = nil,
         groupUpdate: [String: Any]? = nil,
-        userSignature: String? = nil
+        userSignature: String? = nil,
+        logger: OSLog = .disabled
     ) {
         self.accountID = accountID
         self.sessionID = sessionID
@@ -38,6 +42,7 @@ internal struct Activity {
         self.groupID = groupID
         self.groupUpdate = groupUpdate
         self.userSignature = userSignature
+        self.logger = logger
     }
 }
 
@@ -67,12 +72,12 @@ extension Activity: Encodable {
 
         if let profileUpdate = profileUpdate {
             var profileInfoContainer = container.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: .profileUpdate)
-            try profileInfoContainer.encodeSkippingInvalid(profileUpdate)
+            try profileInfoContainer.encodeSkippingInvalid(profileUpdate, logger: logger)
         }
 
         if let groupUpdate = groupUpdate {
             var groupInfoContainer = container.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: .groupUpdate)
-            try groupInfoContainer.encodeSkippingInvalid(groupUpdate)
+            try groupInfoContainer.encodeSkippingInvalid(groupUpdate, logger: logger)
         }
     }
 }

--- a/Sources/AppcuesKit/Data/Models/Event.swift
+++ b/Sources/AppcuesKit/Data/Models/Event.swift
@@ -7,22 +7,27 @@
 //
 
 import Foundation
+import os.log
 
 /// API request structure for an activity event.
 internal struct Event {
+    let logger: OSLog
+
     let name: String
     let timestamp: Date
     let attributes: [String: Any]?
     let context: [String: Any]?
 
-    init(name: String, timestamp: Date = Date(), attributes: [String: Any]? = nil, context: [String: Any]? = nil) {
+    init(name: String, timestamp: Date = Date(), attributes: [String: Any]? = nil, context: [String: Any]? = nil, logger: OSLog = .disabled) {
         self.name = name
         self.timestamp = timestamp
         self.attributes = attributes
         self.context = context
+        self.logger = logger
+
     }
 
-    init(screen screenTitle: String, attributes: [String: Any]? = nil, context: [String: Any]? = nil) {
+    init(screen screenTitle: String, attributes: [String: Any]? = nil, context: [String: Any]? = nil, logger: OSLog = .disabled) {
         name = "appcues:screen_view"
         timestamp = Date()
 
@@ -30,6 +35,7 @@ internal struct Event {
         extendedAttributes["screenTitle"] = screenTitle
         self.attributes = extendedAttributes
         self.context = context
+        self.logger = logger
     }
 }
 
@@ -48,12 +54,12 @@ extension Event: Encodable {
 
         if let attributes = attributes {
             var attributesContainer = container.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: .attributes)
-            try attributesContainer.encodeSkippingInvalid(attributes)
+            try attributesContainer.encodeSkippingInvalid(attributes, logger: logger)
         }
 
         if let context = context {
             var attributesContainer = container.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: .context)
-            try attributesContainer.encodeSkippingInvalid(context)
+            try attributesContainer.encodeSkippingInvalid(context, logger: logger)
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -35,17 +35,12 @@ internal class ActionRegistry {
         register(action: AppcuesRequestReviewAction.self)
     }
 
-    func register(action: AppcuesExperienceAction.Type) {
-        guard actions[action.type] == nil else {
-            #if DEBUG
-            if ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil {
-                assertionFailure("Action of type \(action.type) is already registered.")
-            }
-            #endif
-            return
-        }
+    @discardableResult
+    func register(action: AppcuesExperienceAction.Type) -> Bool {
+        guard actions[action.type] == nil else { return false }
 
         actions[action.type] = action
+        return true
     }
 
     private func processFirstAction() {

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -37,7 +37,10 @@ internal class ActionRegistry {
 
     @discardableResult
     func register(action: AppcuesExperienceAction.Type) -> Bool {
-        guard actions[action.type] == nil else { return false }
+        guard actions[action.type] == nil else {
+            appcues?.config.logger.error("Action of type %{public}@ is already registered.", action.type)
+            return false
+        }
 
         actions[action.type] = action
         return true

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -34,7 +34,10 @@ internal class TraitRegistry {
 
     @discardableResult
     func register(trait: AppcuesExperienceTrait.Type) -> Bool {
-        guard traits[trait.type] == nil else { return false }
+        guard traits[trait.type] == nil else {
+            appcues?.config.logger.error("Trait of type %{public}@ is already registered.", trait.type)
+            return false
+        }
 
         traits[trait.type] = trait
         return true

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -32,17 +32,12 @@ internal class TraitRegistry {
         register(trait: AppcuesEmbeddedTrait.self)
     }
 
-    func register(trait: AppcuesExperienceTrait.Type) {
-        guard traits[trait.type] == nil else {
-            #if DEBUG
-            if ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil {
-                assertionFailure("Trait of type \(trait.type) is already registered.")
-            }
-            #endif
-            return
-        }
+    @discardableResult
+    func register(trait: AppcuesExperienceTrait.Type) -> Bool {
+        guard traits[trait.type] == nil else { return false }
 
         traits[trait.type] = trait
+        return true
     }
 
     func instances(

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -78,11 +78,12 @@ class ActionRegistryTests: XCTestCase {
         )
 
         // Act
-        actionRegistry.register(action: TestAction.self)
-        // This will trigger an assertionFailure if we're not in a test cycle
-        actionRegistry.register(action: TestAction2.self)
+        let successfullyRegisteredAction1 = actionRegistry.register(action: TestAction.self)
+        let successfullyRegisteredAction2 = actionRegistry.register(action: TestAction2.self)
 
         // Assert
+        XCTAssertTrue(successfullyRegisteredAction1)
+        XCTAssertFalse(successfullyRegisteredAction2)
         actionRegistry.enqueue(
             actionModels: [actionModel],
             level: .step,

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -49,11 +49,12 @@ class TraitRegistryTests: XCTestCase {
         let traitModel = Experience.Trait(type: TestTrait.type, config: nil)
 
         // Act
-        traitRegistry.register(trait: TestTrait.self)
-        // This will trigger an assertionFailure if we're not in a test cycle
-        traitRegistry.register(trait: TestTrait.self)
+        let successfullyRegisteredTrait1 = traitRegistry.register(trait: TestTrait.self)
+        let successfullyRegisteredTrait2 = traitRegistry.register(trait: TestTrait.self)
 
         // Assert
+        XCTAssertTrue(successfullyRegisteredTrait1)
+        XCTAssertFalse(successfullyRegisteredTrait2)
         let traitInstances = traitRegistry.instances(for: [traitModel], level: .group, renderContext: .modal)
         XCTAssertEqual(traitInstances.count, 1)
     }


### PR DESCRIPTION
To be as safe as possible, remove places where `assertionFailure` would cause a crash in `-Onone` debug builds (https://developer.apple.com/documentation/swift/assertionfailure(_:file:line:)).

To not lose the message when encoding properties, I'm passing the logging instance through to the encoder from the `Activity` and `Event` models. I'm not the biggest fan of doing this, but I think it's worthwhile (and the parameter is optional).

I have a subsequent PR lined op that makes a generic `Logging` protocol that will let us intercept the logs to show in the debugger and test the log messages that get generated.