### PR TITLE
Add log viewing to debugger

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -27,7 +27,7 @@ public extension Appcues {
 
         var urlSession: URLSession = NetworkClient.defaultURLSession
 
-        var logger: OSLog = .disabled
+        var logger: Logging = OSLog.disabled
 
         var anonymousIDFactory: () -> String = {
             UIDevice.identifier

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -92,7 +92,7 @@ public class Appcues: NSObject {
 
         initializeContainer()
 
-        config.logger.info("Appcues SDK %{public}s initialized", version())
+        config.logger.info("Appcues SDK %{public}@ initialized", version())
     }
 
     /// Get the current version of the Appcues SDK.

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -117,7 +117,7 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
                     SdkMetrics.remove(activity.requestID)
                 }
             case .failure(let error):
-                self?.config.logger.error("Failed processing qualify response: %{public}s", "\(error)")
+                self?.config.logger.error("Failed processing qualify response: %{public}@", "\(error)")
                 SdkMetrics.remove(activity.requestID)
             }
         }

--- a/Sources/AppcuesKit/Data/Logging/Logging.swift
+++ b/Sources/AppcuesKit/Data/Logging/Logging.swift
@@ -1,5 +1,5 @@
 //
-//  OSLog+Convenience.swift
+//  Logging.swift
 //  AppcuesKit
 //
 //  Created by Matt on 2021-10-08.
@@ -8,13 +8,21 @@
 
 import os.log
 
+internal protocol Logging {
+    func debug(_ message: StaticString, _ args: CVarArg...)
+    func info(_ message: StaticString, _ args: CVarArg...)
+    func log(_ message: StaticString, _ args: CVarArg...)
+    func error(_ message: StaticString, _ args: CVarArg...)
+    func fault(_ message: StaticString, _ args: CVarArg...)
+}
+
 // Convenience methods to make the logging call site a bit tidier:
-// `logger.error("%{private}s", data)`
+// `logger.error("%{private}@", data)`
 // vs
-// `os_log("%{private}s", log: .default, type: .error, data)`
+// `os_log("%{private}@", log: .default, type: .error, data)`
 //
 // This also saves us having to `import os.log` everywhere.
-extension OSLog {
+extension OSLog: Logging {
 
     /// Create an appcues-specific logger.
     convenience init(appcuesCategory category: String) {

--- a/Sources/AppcuesKit/Data/Models/Activity.swift
+++ b/Sources/AppcuesKit/Data/Models/Activity.swift
@@ -11,7 +11,7 @@ import os.log
 
 /// API request body for registering user activity.
 internal struct Activity {
-    let logger: OSLog
+    let logger: Logging
 
     let requestID = UUID()
     var events: [Event]?
@@ -32,7 +32,7 @@ internal struct Activity {
         groupID: String? = nil,
         groupUpdate: [String: Any]? = nil,
         userSignature: String? = nil,
-        logger: OSLog = .disabled
+        logger: Logging = OSLog.disabled
     ) {
         self.accountID = accountID
         self.sessionID = sessionID

--- a/Sources/AppcuesKit/Data/Models/Event.swift
+++ b/Sources/AppcuesKit/Data/Models/Event.swift
@@ -11,23 +11,22 @@ import os.log
 
 /// API request structure for an activity event.
 internal struct Event {
-    let logger: OSLog
+    let logger: Logging
 
     let name: String
     let timestamp: Date
     let attributes: [String: Any]?
     let context: [String: Any]?
 
-    init(name: String, timestamp: Date = Date(), attributes: [String: Any]? = nil, context: [String: Any]? = nil, logger: OSLog = .disabled) {
+    init(name: String, timestamp: Date = Date(), attributes: [String: Any]? = nil, context: [String: Any]? = nil, logger: Logging = OSLog.disabled) {
         self.name = name
         self.timestamp = timestamp
         self.attributes = attributes
         self.context = context
         self.logger = logger
-
     }
 
-    init(screen screenTitle: String, attributes: [String: Any]? = nil, context: [String: Any]? = nil, logger: OSLog = .disabled) {
+    init(screen screenTitle: String, attributes: [String: Any]? = nil, context: [String: Any]? = nil, logger: Logging = OSLog.disabled) {
         name = "appcues:screen_view"
         timestamp = Date()
 

--- a/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
+++ b/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
@@ -72,7 +72,7 @@ extension KeyedEncodingContainer where K == DynamicCodingKeys {
         if !encodingErrorKeys.isEmpty {
             logger.error(
                 """
-                Unsupported value(s) included in %{public}s when encoding key(s): %{public}s.
+                Unsupported value(s) included in %{public}@ when encoding key(s): %{public}@.
                 These keys have been omitted. Only String, Number, Date, URL and Bool types allowed.
                 """,
                 self.codingPath.pretty,

--- a/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
+++ b/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
@@ -31,7 +31,7 @@ internal struct DynamicCodingKeys: CodingKey {
 extension KeyedEncodingContainer where K == DynamicCodingKeys {
 
     /// Encodes the given dictionary to primitive types permitted by the Appcues API, skipping invalid types.
-    mutating func encodeSkippingInvalid(_ dict: [String: Any]?, logger: OSLog = .disabled) throws {
+    mutating func encodeSkippingInvalid(_ dict: [String: Any]?, logger: Logging = OSLog.disabled) throws {
         var encodingErrorKeys: [String] = []
 
         try dict?.forEach { key, value in
@@ -76,7 +76,7 @@ extension KeyedEncodingContainer where K == DynamicCodingKeys {
                 These keys have been omitted. Only String, Number, Date, URL and Bool types allowed.
                 """,
                 self.codingPath.pretty,
-                encodingErrorKeys.description
+                encodingErrorKeys.sorted().description
             )
         }
     }

--- a/Sources/AppcuesKit/Data/Networking/NetworkClient.swift
+++ b/Sources/AppcuesKit/Data/Networking/NetworkClient.swift
@@ -134,7 +134,7 @@ internal class NetworkClient: Networking {
             if let url = response?.url?.absoluteString, let statusCode = (response as? HTTPURLResponse)?.statusCode {
                 let data = String(data: data ?? Data(), encoding: .utf8) ?? ""
 
-                self?.config.logger.debug("RESPONSE: %{public}d %{public}s\n%{private}s", statusCode, url, data)
+                self?.config.logger.debug("RESPONSE: %{public}d %{public}@\n%{private}@", statusCode, url, data)
             }
 
             if let error = error {
@@ -161,7 +161,7 @@ internal class NetworkClient: Networking {
 
         if let method = urlRequest.httpMethod, let url = urlRequest.url?.absoluteString {
             let data = String(data: urlRequest.httpBody ?? Data(), encoding: .utf8) ?? ""
-            config.logger.debug("REQUEST: %{public}s %{public}s\n%{private}s", method, url, data)
+            config.logger.debug("REQUEST: %{public}@ %{public}@\n%{private}@", method, url, data)
         }
 
         dataTask.resume()
@@ -174,7 +174,7 @@ internal class NetworkClient: Networking {
     ) {
         let dataTask = config.urlSession.dataTask(with: urlRequest) { [weak self] _, response, error in
             if let url = response?.url?.absoluteString, let statusCode = (response as? HTTPURLResponse)?.statusCode {
-                self?.config.logger.debug("RESPONSE: %{public}d %{public}s", statusCode, url)
+                self?.config.logger.debug("RESPONSE: %{public}d %{public}@", statusCode, url)
             }
 
             if let error = error {
@@ -192,7 +192,7 @@ internal class NetworkClient: Networking {
 
         if let method = urlRequest.httpMethod, let url = urlRequest.url?.absoluteString {
             let data = String(data: urlRequest.httpBody ?? Data(), encoding: .utf8) ?? ""
-            config.logger.debug("REQUEST: %{public}s %{public}s\n%{private}s", method, url, data)
+            config.logger.debug("REQUEST: %{public}@ %{public}@\n%{private}@", method, url, data)
         }
 
         dataTask.resume()

--- a/Sources/AppcuesKit/Presentation/Debugger/DebugLogger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/DebugLogger.swift
@@ -1,0 +1,95 @@
+//
+//  DebugLogger.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-10-25.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal class DebugLogger: ObservableObject, Logging {
+    let previousLogger: Logging?
+
+    @Published var log: [Log] = []
+
+    init(previousLogger: Logging?) {
+        self.previousLogger = previousLogger
+    }
+
+    func debug(_ message: StaticString, _ args: CVarArg...) {
+        previousLogger?.debug(message, args)
+        log(message, type: .debug, args)
+    }
+
+    func info(_ message: StaticString, _ args: CVarArg...) {
+        previousLogger?.info(message, args)
+        log(message, type: .info, args)
+    }
+
+    func log(_ message: StaticString, _ args: CVarArg...) {
+        previousLogger?.log(message, args)
+        log(message, type: .log, args)
+    }
+
+    func error(_ message: StaticString, _ args: CVarArg...) {
+        previousLogger?.error(message, args)
+        log(message, type: .error, args)
+    }
+
+    func fault(_ message: StaticString, _ args: CVarArg...) {
+        previousLogger?.fault(message, args)
+        log(message, type: .fault, args)
+    }
+
+    private func log(_ message: StaticString, type: Level, _ args: [CVarArg]) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { self.log(message, type: type, args) }
+            return
+        }
+
+        // Convert the os_log StaticString to a normal format String
+        let normalizedMessage = message.description
+            .replacingOccurrences(of: "{public}", with: "")
+            .replacingOccurrences(of: "{private}", with: "")
+        let item = Log(
+            level: type,
+            message: String(format: normalizedMessage, args)
+        )
+
+        log.append(item)
+    }
+}
+
+@available(iOS 13.0, *)
+extension DebugLogger {
+    struct Log: Identifiable {
+        let id = UUID()
+        let timestamp = Date()
+        let level: Level
+        let message: String
+    }
+
+    enum Level: CaseIterable {
+        case debug, info, log, error, fault
+
+        var description: String {
+            switch self {
+            case .debug: return "Debug"
+            case .info: return "Info"
+            case .log: return "Log"
+            case .error: return "Error"
+            case .fault: return "Fault"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .debug, .info: return .secondary
+            case .log: return .primary
+            case .error, .fault: return .red
+            }
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -22,11 +22,13 @@ internal class DebugViewController: UIViewController {
     let mode: DebugMode
 
     let viewModel: DebugViewModel
+    let logger: DebugLogger
     let apiVerifier: APIVerifier
     let deepLinkVerifier: DeepLinkVerifier
 
-    init(viewModel: DebugViewModel, apiVerifier: APIVerifier, deepLinkVerifier: DeepLinkVerifier, mode: DebugMode) {
+    init(viewModel: DebugViewModel, logger: DebugLogger, apiVerifier: APIVerifier, deepLinkVerifier: DeepLinkVerifier, mode: DebugMode) {
         self.viewModel = viewModel
+        self.logger = logger
         self.apiVerifier = apiVerifier
         self.deepLinkVerifier = deepLinkVerifier
         self.mode = mode
@@ -53,7 +55,7 @@ internal class DebugViewController: UIViewController {
                 apiVerifier: apiVerifier,
                 deepLinkVerifier: deepLinkVerifier,
                 viewModel: viewModel
-            ))
+            ).environmentObject(logger))
             addChild(panelViewController)
             debugView.panelWrapperView.addSubview(panelViewController.view)
             panelViewController.didMove(toParent: self)

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
@@ -1,0 +1,58 @@
+//
+//  DebugLogUI.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-10-25.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal enum DebugLogUI {
+    struct LoggerView: View {
+        @EnvironmentObject var logger: DebugLogger
+
+        var body: some View {
+            List {
+                ForEach(logger.log.suffix(20).reversed()) { log in
+                    NavigationLink(destination: DetailView(log: log)) {
+                        VStack(alignment: .leading) {
+                            Text("\(log.level.description): \(log.timestamp.description)")
+                                .fontWeight(.bold)
+                            Text(log.message)
+                                .lineLimit(10)
+                        }
+                        .font(.system(size: 14, design: .monospaced))
+                        .foregroundColor(log.level.color)
+                    }
+                }
+            }
+            .navigationBarTitle("", displayMode: .inline)
+        }
+    }
+
+    private struct DetailView: View {
+        let log: DebugLogger.Log
+
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading) {
+                    Text("Level: \(log.level.description)")
+                        .fontWeight(.bold)
+                    Text("Timestamp: \(log.timestamp.description)")
+                        .fontWeight(.bold)
+                    Divider()
+                    Text(log.message)
+                }
+                .font(.system(size: 14, design: .monospaced))
+                .foregroundColor(log.level.color)
+                .padding()
+            }
+            .navigationBarTitle("", displayMode: .inline)
+            .navigationBarItems(trailing: Button("Copy Log") {
+                UIPasteboard.general.string = log.message
+            })
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -51,6 +51,9 @@ internal enum DebugUI {
                         NavigationLink(destination: DebugFontUI.FontListView(), isActive: $viewModel.navigationDestinationIsFonts) {
                             Text("Available Fonts")
                         }
+                        NavigationLink(destination: DebugLogUI.LoggerView()) {
+                            Text("Detailed Log")
+                        }
                     }
 
                     Section(header: EventsSectionHeader(selection: $viewModel.filter)) {

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -123,9 +123,13 @@ internal class UIDebugger: UIDebugging {
             return
         }
 
+        let debugLogger = DebugLogger(previousLogger: config.logger)
+        config.logger = debugLogger
+
         analyticsPublisher.register(subscriber: self)
         let rootViewController = DebugViewController(
             viewModel: viewModel,
+            logger: debugLogger,
             apiVerifier: APIVerifier(networking: networking),
             deepLinkVerifier: DeepLinkVerifier(applicationID: config.applicationID),
             mode: mode
@@ -147,6 +151,11 @@ internal class UIDebugger: UIDebugging {
         debugWindow?.isHidden = true
         debugWindow = nil
         cancellable.removeAll()
+
+        // Reset the logger back to the way it was
+        if let oldLogger = (config.logger as? DebugLogger)?.previousLogger {
+            config.logger = oldLogger
+        }
     }
 
     func showToast(_ toast: DebugToast) {

--- a/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceLoader.swift
@@ -52,7 +52,7 @@ internal class ExperienceLoader: ExperienceLoading {
                     completion: completion
                 )
             case .failure(let error):
-                self?.config.logger.error("Loading experience %{public}s failed with error %{public}s", experienceID, "\(error)")
+                self?.config.logger.error("Loading experience %{public}@ failed with error %{public}@", experienceID, "\(error)")
                 completion?(.failure(error))
             }
 

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -14,9 +14,12 @@ class ActionRegistryTests: XCTestCase {
 
     var appcues: MockAppcues!
     var actionRegistry: ActionRegistry!
+    var logger: DebugLogger!
 
     override func setUpWithError() throws {
+        logger = DebugLogger(previousLogger: nil)
         appcues = MockAppcues()
+        appcues.config.logger = logger
         actionRegistry = ActionRegistry(container: appcues.container)
     }
 
@@ -91,6 +94,11 @@ class ActionRegistryTests: XCTestCase {
             interactionType: "Button Tapped",
             viewDescription: "My Button")
         waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(logger.log.count, 1)
+        let log = try XCTUnwrap(logger.log.first)
+        XCTAssertEqual(log.level, .error)
+        XCTAssertEqual(log.message, "Action of type @test/action is already registered.")
     }
 
     func testQueueExecution() throws {

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -14,9 +14,12 @@ class TraitRegistryTests: XCTestCase {
 
     var appcues: MockAppcues!
     var traitRegistry: TraitRegistry!
+    var logger: DebugLogger!
 
     override func setUpWithError() throws {
+        logger = DebugLogger(previousLogger: nil)
         appcues = MockAppcues()
+        appcues.config.logger = logger
         traitRegistry = TraitRegistry(container: appcues.container)
     }
 
@@ -57,6 +60,11 @@ class TraitRegistryTests: XCTestCase {
         XCTAssertFalse(successfullyRegisteredTrait2)
         let traitInstances = traitRegistry.instances(for: [traitModel], level: .group, renderContext: .modal)
         XCTAssertEqual(traitInstances.count, 1)
+
+        XCTAssertEqual(logger.log.count, 1)
+        let log = try XCTUnwrap(logger.log.first)
+        XCTAssertEqual(log.level, .error)
+        XCTAssertEqual(log.message, "Trait of type @test/trait is already registered.")
     }
 }
 


### PR DESCRIPTION
I used %s for the original logs without much thought (copied from some blog post IIRC), and it worked, but for mapping to an actual string, %@ is the way to go, so fixed that ([format string reference](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html)). We have to strip out the `{public}` and `{private}` OSLog specifiers, but then we can get the log message as a regular String to show in the debugger.

Then the new `Logging` protocol has conformees in `OSLog` and the new `DebugLog` so we can transparently switch between them. `DebugLog` even optionally takes another `Logging` instance so we can continue to send the `OSLog` messages in addition to capturing them in the debugger.

The debug logger only starts when the debugger does (and turns off when the floating button is dismissed) for performance reasons.

For an added cherry on top, we can uses `DebugLogger` in tests to verify the log messages being generated by some failure conditions.

Potentially in the future we could add log filtering and searching, and fancy stuff like that, but I'm not going to worry about it now.

Note that iOS 14+ has a much nicer logging format that doesn't use StaticString, but we can't use it.

|Menu item|List|Detail|
|-|-|-|
|![Simulator Screenshot - iPhone 14 Pro - 2023-10-26 at 10 35 06](https://github.com/appcues/appcues-ios-sdk/assets/845681/baeaad81-e1f9-4691-afc2-b3678a27587f)|![Simulator Screenshot - iPhone 14 Pro - 2023-10-26 at 10 35 11](https://github.com/appcues/appcues-ios-sdk/assets/845681/9a5665fa-cae4-4953-b1b7-9357cdcb9cce)|![Simulator Screenshot - iPhone 14 Pro - 2023-10-26 at 10 35 13](https://github.com/appcues/appcues-ios-sdk/assets/845681/1437534d-3744-4f98-8555-7c135e57e019)|