### PR TITLE
Add source to activity requests and  _lastSeenAt group auto prop

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -41,6 +41,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
     func decorate(_ tracking: TrackingUpdate) -> TrackingUpdate {
 
         var context = self.contextProperties
+        var decorated = tracking
 
         switch tracking.type {
         case let .screen(title):
@@ -55,13 +56,14 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             currentScreen = nil
             previousScreen = nil
         case .group:
-            // group updates do not have auto props, don't manipulate anything in the properties
-            return tracking
+            // group updates only have this single auto prop, so add that and return early
+            decorated.properties = (decorated.properties ?? [:]).merging([
+                "_lastSeenAt": Date()
+            ])
+            return decorated
         default:
             break
         }
-
-        var decorated = tracking
 
         var sessionProperties: [String: Any?] = [
             "userId": storage.userID,

--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -55,6 +55,9 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             sessionLatestUserProperties = [:]
             currentScreen = nil
             previousScreen = nil
+        case .group(nil):
+            // removing from a group should not have any auto props
+            return tracking
         case .group:
             // group updates only have this single auto prop, so add that and return early
             decorated.properties = (decorated.properties ?? [:]).merging([

--- a/Sources/AppcuesKit/Data/Models/Activity.swift
+++ b/Sources/AppcuesKit/Data/Models/Activity.swift
@@ -48,6 +48,7 @@ internal struct Activity {
 
 extension Activity: Encodable {
     enum CodingKeys: String, CodingKey {
+        case source
         case requestID = "request_id"
         case events
         case profileUpdate = "profile_update"
@@ -61,6 +62,7 @@ extension Activity: Encodable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("mobile", forKey: .source)
         try container.encode(accountID, forKey: .accountID)
         try container.encode(sessionID, forKey: .sessionID)
         try container.encode(userID, forKey: .userID)

--- a/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
@@ -81,7 +81,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
 
         // Assert
         XCTAssertNil(decorated.context)
-        let expectedPropertyKeys = ["CUSTOM"]
+        let expectedPropertyKeys = ["CUSTOM", "_lastSeenAt"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
         XCTAssertNil(decorated.eventAutoProperties)
     }


### PR DESCRIPTION
Also [sc-58902]

```diff
{
+	"source": "mobile",
	"account_id": "<account-id>",
	"group_id": "my-group",
	"request_id": "fc592fd8-9210-463b-a73d-c4b19dcfe454",
	"session_id": "1b554130-1d90-4969-8a1d-56e7a877ef11",
	"user_id": "default-00000",
	"group_update": {
+		"_lastSeenAt": 1699296009124
	}
}
```