### PR TITLE
Batch group updates with user identification when called right after identify

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -60,9 +60,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             return tracking
         case .group:
             // group updates only have this single auto prop, so add that and return early
-            decorated.properties = (decorated.properties ?? [:]).merging([
-                "_lastSeenAt": Date()
-            ])
+            decorated.properties = (decorated.properties ?? [:]).merging(["_lastSeenAt": Date()])
             return decorated
         default:
             break

--- a/Sources/AppcuesKit/Data/Models/Activity.swift
+++ b/Sources/AppcuesKit/Data/Models/Activity.swift
@@ -18,8 +18,8 @@ internal struct Activity {
     var profileUpdate: [String: Any]?
     let userID: String
     let accountID: String
-    let groupID: String?
-    let groupUpdate: [String: Any]?
+    var groupID: String?
+    var groupUpdate: [String: Any]?
     let userSignature: String?
     let sessionID: String
 

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -131,7 +131,7 @@ class AnalyticsTrackerTests: XCTestCase {
         let onRequestExpectation = expectation(description: "Valid request")
         let expectedEvents = [Event(name: "appcues:screen_view", attributes: ["screenTitle":"screen-name"])]
 
-        // In the case of a profile update, immediately followed by a group update, verify that the
+        // In the case of a profile update, immediately followed by a screen view, verify that the
         // updates get merged together in a single Activity that gets sent to the ActivityProcessor
         appcues.activityProcessor.onProcess = { activity, completion in
             ["userProp":1].verifyPropertiesMatch(activity.profileUpdate)


### PR DESCRIPTION
This is the iOS equivalent of the Android update in https://github.com/appcues/appcues-android-sdk/pull/535 (and similar in concept to the web update in https://github.com/appcues/javascript-sdk/pull/613). Stealing that Android PR description:

* on `identify(id, props)` or the `appcues:session_started` event - a 50ms timer is started to allow analytics that occur immediately after, to be batched together into the same activity payload to the API.
* the expected use case would be a `group(id, props)` called immediately after `identify(id, props)` resulting in a combined payload with the new user and the current group - this prevents any chance of state group information being used during the resulting qualification on the server for the new user update or session start qualification
* all other analytics are unaffected, unless they also happen within that 50ms window (in which case they would go in this immediate batch as well)

This is an example of what this result would look like, for a new user landing on a login page, signing in, and then triggering the resulting user profile update, the session_started event, and an immediate group update to identify that user's current group and props.
![Screenshot 2023-11-09 at 3 28 59 PM](https://github.com/appcues/appcues-ios-sdk/assets/19266448/5ef983b1-1eb6-4a37-82c4-623209d9a544)

This is implemented by adding a new priority queue to our `AnalyticsTracker` - the 50ms queue. We still have the 10 sec background batching queue for flow events as well. If a new priority update comes in (identify or session_start) it will flush anything in the queue existing, and start this new 50ms queue to gather up all immediately subsequent updates.

Couple of edge cases:
* There is already a 50ms queue going for another user - could happen if you made multiple `identify(id)` calls for different user ids, in rapid succession. This will result in the existing priority queue being immediately flushed, stopping any existing timer, before processing the new one.
* There is a 50ms queue running while an otherwise immediate event is triggered (a screen or track event) - this will result in the normally immediate event having some delay of < 50ms, as it is merged into this queue (hopefully rare).