### PR TITLE
Fix/imports

### DIFF
--- a/Sources/AppcuesKit/Data/Extensions/UIDevice+Custom.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UIDevice+Custom.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2021 Appcues. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 extension UIDevice {

--- a/Sources/AppcuesKit/Presentation/Extensions/CGPoint+Relative.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/CGPoint+Relative.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Appcues. All rights reserved.
 //
 
-import Foundation
+import CoreGraphics
 
 internal extension CGPoint {
     func relative(in size: CGSize) -> CGPoint {

--- a/Sources/AppcuesKit/Presentation/Extensions/CGRect+Resize.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/CGRect+Resize.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Appcues. All rights reserved.
 //
 
-import Foundation
+import CoreGraphics
 
 internal extension CGRect {
     var zeroed: CGRect {

--- a/Sources/AppcuesKit/Presentation/Public/ElementTargeting/AppcuesViewElement.swift
+++ b/Sources/AppcuesKit/Presentation/Public/ElementTargeting/AppcuesViewElement.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Appcues. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// Represents a view in the layout hierarchy of the application.
 ///


### PR DESCRIPTION
A default `import Foundation` doesn't work for Swift 5.6.