### PR TITLE
Add support for step error handling and recovery

### DIFF
--- a/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
@@ -144,7 +144,7 @@ internal class DeepLinkHandler: DeepLinkHandling {
             message = "Mobile flow not found."
         case is NetworkingError:
             message = "Error loading mobile flow preview."
-        case let ExperienceStateMachine.ExperienceError.step(experience, _, errorMessage),
+        case let ExperienceStateMachine.ExperienceError.step(experience, _, errorMessage, _),
             let ExperienceStateMachine.ExperienceError.experience(experience, errorMessage):
             message = "Preview of \(experience.name) failed: \(errorMessage)"
         default:

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -182,12 +182,10 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         // if an active experiment does exist, it should now track the experiment_entered analytic
         track(experiment: experience.experiment)
 
-        // only track analytics on published experiences (not previews)
         // and only add the observer if the state machine is idling, otherwise there's already another experience in-flight
         if stateMachine.state == .idling {
-            if experience.published {
-                stateMachine.addObserver(analyticsObserver)
-            }
+            // we always add an analytics observer, it will internally filter out unpublished flows (builder previews)
+            stateMachine.addObserver(analyticsObserver)
 
             if experience.renderContext == .modal {
                 // add recovery observer - on recoverable step errors, initiate recovery and retry

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -61,7 +61,7 @@ internal class StepRecoveryObserver: ExperienceStateObserver {
     }
 
     func stopRetryHandler() {
-        AppcuesScrollViewDelegate.shared.observer = nil
+        AppcuesScrollViewDelegate.shared.detach()
     }
 
     func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
@@ -74,7 +74,7 @@ internal class StepRecoveryObserver: ExperienceStateObserver {
     }
 
     private func startRetryHandler() {
-        AppcuesScrollViewDelegate.shared.observer = self
+        AppcuesScrollViewDelegate.shared.attach(using: self)
     }
 }
 
@@ -106,9 +106,6 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         self.stepRecoveryObserver = StepRecoveryObserver(stateMachine: stateMachine)
 
         stateMachines[ownerFor: .modal] = self
-
-        // TODO: guard against multiple
-        UIScrollView.swizzleScrollViewGetDelegate()
     }
 
     func start(owner: StateMachineOwning, forContext context: RenderContext) {
@@ -170,9 +167,7 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
     private func show(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?) {
         guard Thread.isMainThread else {
-            DispatchQueue.main.async {
-                self.show(experience: experience, completion: completion)
-            }
+            DispatchQueue.main.async { self.show(experience: experience, completion: completion) }
             return
         }
 
@@ -376,9 +371,7 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
     func resetAll() {
         guard Thread.isMainThread else {
-            DispatchQueue.main.async {
-                self.resetAll()
-            }
+            DispatchQueue.main.async { self.resetAll() }
             return
         }
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -41,43 +41,6 @@ internal enum ExperienceRendererError: Error {
     case experimentControl
 }
 
-// This class is only used by the Modal RenderContext (modals and tooltips)
-// to detect recoverable step errors and attempt to retry when scroll changes
-// are observed. It hooks into the AppcuesScrollViewDelegate, which receives
-// scroll updates from the UIScrollView implementations in the app via
-// method swizzling.
-@available(iOS 13.0, *)
-internal class StepRecoveryObserver: ExperienceStateObserver {
-
-    private let stateMachine: ExperienceStateMachine
-
-    init(stateMachine: ExperienceStateMachine) {
-        self.stateMachine = stateMachine
-    }
-
-    func scrollEnded() {
-        stopRetryHandler() // stop now, if this next retry fails, it will start over again
-        try? stateMachine.transition(.retry)
-    }
-
-    func stopRetryHandler() {
-        AppcuesScrollViewDelegate.shared.detach()
-    }
-
-    func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
-        if case .failure(.step(_, _, _, recoverable: true)) = result {
-            startRetryHandler()
-        }
-
-        // recovery observer never stops observing
-        return false
-    }
-
-    private func startRetryHandler() {
-        AppcuesScrollViewDelegate.shared.attach(using: self)
-    }
-}
-
 @available(iOS 13.0, *)
 internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -100,7 +100,6 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         if shouldClearCache {
             potentiallyRenderableExperiences = [:]
             stateMachines.cleanup()
-            stepRecoveryObserver.stopRetryHandler()
         }
 
         // Add new experiences, replacing any existing ones

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -45,23 +45,23 @@ internal enum ExperienceRendererError: Error {
 private class StepRecoveryObserver: ExperienceStateObserver {
     private let stateMachine: ExperienceStateMachine
 
-    private var retryWorkItem: DispatchWorkItem?
+    // private var retryWorkItem: DispatchWorkItem?
 
     init(stateMachine: ExperienceStateMachine) {
         self.stateMachine = stateMachine
     }
 
     func stopRetryHandler() {
-        if retryWorkItem != nil {
-            print("stopping existing step recovery attempts due to screen change")
-        }
-        retryWorkItem?.cancel()
-        retryWorkItem = nil
+//        if retryWorkItem != nil {
+//            print("stopping existing step recovery attempts due to screen change")
+//        }
+//        retryWorkItem?.cancel()
+//        retryWorkItem = nil
     }
 
     func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
         if case .failure(.step(_, _, _, recoverable: true)) = result {
-            startRetryHandler()
+            // startRetryHandler()
         }
 
         // recovery observer never stops observing
@@ -75,17 +75,17 @@ private class StepRecoveryObserver: ExperienceStateObserver {
 
         // simulating this with a 3 sec timer to test for now
 
-        if retryWorkItem == nil {
-            print("recoverable step error - will retry in 3 sec")
-            let workItem = DispatchWorkItem { [weak self] in
-                guard let self = self else { return }
-                print("retrying step...")
-                self.retryWorkItem = nil
-                try? self.stateMachine.transition(.retry)
-            }
-            retryWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
-        }
+//        if retryWorkItem == nil {
+//            print("recoverable step error - will retry in 3 sec")
+//            let workItem = DispatchWorkItem { [weak self] in
+//                guard let self = self else { return }
+//                print("retrying step...")
+//                self.retryWorkItem = nil
+//                try? self.stateMachine.transition(.retry)
+//            }
+//            retryWorkItem = workItem
+//            DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
+//        }
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
@@ -10,12 +10,13 @@ import Foundation
 
 @available(iOS 13.0, *)
 extension ExperienceStateMachine {
-    enum Action {
+    indirect enum Action {
         case startExperience(ExperienceData)
         case startStep(StepReference)
         case renderStep
         case endExperience(markComplete: Bool)
         case reset
-        case reportError(ExperienceError, fatal: Bool)
+        case reportError(error: ExperienceError, retryEffect: SideEffect)
+        case retry
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
@@ -16,7 +16,7 @@ extension ExperienceStateMachine {
         case renderStep
         case endExperience(markComplete: Bool)
         case reset
-        case reportError(error: ExperienceError, retryEffect: SideEffect)
+        case reportError(error: ExperienceError, retryEffect: SideEffect?)
         case retry
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
@@ -59,7 +59,8 @@ extension ExperienceStateMachine.ExperienceError: CustomStringConvertible, Custo
         case let .experience(experience, message):
             return ".experience(experienceID: \(experience.id.uuidString), message: \(message))"
         case let .step(experience, stepIndex, message, recoverable):
-            return ".step(experienceID: \(experience.id.uuidString), stepIndex: \(stepIndex), message: \(message), recoverable: \(recoverable)"
+            return ".step(experienceID: \(experience.id.uuidString), stepIndex: \(stepIndex), " +
+                "message: \(message), recoverable: \(recoverable)"
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
@@ -14,7 +14,7 @@ extension ExperienceStateMachine {
         case noTransition(currentState: State)
         case experienceAlreadyActive(ignoredExperience: ExperienceData)
         case experience(ExperienceData, String)
-        case step(ExperienceData, Experience.StepIndex, String)
+        case step(ExperienceData, Experience.StepIndex, String, recoverable: Bool = false)
     }
 }
 
@@ -28,8 +28,8 @@ extension ExperienceStateMachine.ExperienceError: Equatable {
             return experience1.id == experience2.id
         case let (.experience(experience1, message1), .experience(experience2, message2)):
             return experience1.id == experience2.id && message1 == message2
-        case let (.step(experience1, stepIndex1, message1), .step(experience2, stepIndex2, message2)):
-            return experience1.id == experience2.id && stepIndex1 == stepIndex2 && message1 == message2
+        case let (.step(experience1, stepIndex1, message1, recoverable1), .step(experience2, stepIndex2, message2, recoverable2)):
+            return experience1.id == experience2.id && stepIndex1 == stepIndex2 && message1 == message2 && recoverable1 == recoverable2
         default:
             return false
         }
@@ -45,7 +45,7 @@ extension ExperienceStateMachine.ExperienceError: CustomStringConvertible, Custo
             return "no transition in state machine"
         case .experienceAlreadyActive:
             return "experience already active"
-        case let .experience(_, message), let .step(_, _, message):
+        case let .experience(_, message), let .step(_, _, message, _):
             return message
         }
     }
@@ -58,8 +58,8 @@ extension ExperienceStateMachine.ExperienceError: CustomStringConvertible, Custo
             return ".experienceAlreadyActive(ignoredExperienceID: \(experience.id.uuidString))"
         case let .experience(experience, message):
             return ".experience(experienceID: \(experience.id.uuidString), message: \(message))"
-        case let .step(experience, stepIndex, message):
-            return ".step(experienceID: \(experience.id.uuidString), stepIndex: \(stepIndex), message: \(message))"
+        case let .step(experience, stepIndex, message, recoverable):
+            return ".step(experienceID: \(experience.id.uuidString), stepIndex: \(stepIndex), message: \(message), recoverable: \(recoverable)"
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -130,7 +130,11 @@ extension ExperienceStateMachine {
             if recoverable {
                 experience.recoverableErrorID = errorID
             }
-            let errorProperties = LifecycleEvent.properties(experience, stepIndex, error: LifecycleEvent.ErrorBody(message: message, id: errorID))
+            let errorProperties = LifecycleEvent.properties(
+                experience,
+                stepIndex,
+                error: LifecycleEvent.ErrorBody(message: message, id: errorID)
+            )
             trackLifecycleEvent(.stepError, errorProperties)
         }
 
@@ -138,7 +142,11 @@ extension ExperienceStateMachine {
             // only track a recovery if we had previously captured a render error for this experience
             guard let errorID = experience.recoverableErrorID else { return }
 
-            let errorProperties = LifecycleEvent.properties(experience, stepIndex, error: LifecycleEvent.ErrorBody(message: nil, id: errorID))
+            let errorProperties = LifecycleEvent.properties(
+                experience,
+                stepIndex,
+                error: LifecycleEvent.ErrorBody(message: nil, id: errorID)
+            )
             trackLifecycleEvent(.stepRecovered, errorProperties)
             experience.recoverableErrorID = nil
         }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
@@ -32,8 +32,20 @@ internal class StepRecoveryObserver: ExperienceStateObserver {
     }
 
     func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
-        if case .failure(.step(_, _, _, recoverable: true)) = result {
+        switch result {
+        case .failure(.step(_, _, _, recoverable: true)):
+            // a recoverable step error has been observed, so we begin attempting
+            // recovery - this will attach a listener to scroll changes in the app
+            // to see if layout changes make this experience presentable
             startRetryHandler()
+        case .success(.idling):
+            // if the machine goes back to idling, this means that any experience
+            // that was in a retry state was fully dismissed, or potentially a new
+            // experience has been queued up to start in its place - remove any
+            // existing retry handler to stop attempting recovery
+            stopRetryHandler()
+        default:
+            break
         }
 
         // recovery observer never stops observing

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
@@ -1,0 +1,46 @@
+//
+//  StepRecoveryObserver.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 12/6/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+
+// This class is only used by the Modal RenderContext (modals and tooltips)
+// to detect recoverable step errors and attempt to retry when scroll changes
+// are observed. It hooks into the AppcuesScrollViewDelegate, which receives
+// scroll updates from the UIScrollView implementations in the app via
+// method swizzling.
+@available(iOS 13.0, *)
+internal class StepRecoveryObserver: ExperienceStateObserver {
+
+    private let stateMachine: ExperienceStateMachine
+
+    init(stateMachine: ExperienceStateMachine) {
+        self.stateMachine = stateMachine
+    }
+
+    func scrollEnded() {
+        stopRetryHandler() // stop now, if this next retry fails, it will start over again
+        try? stateMachine.transition(.retry)
+    }
+
+    func stopRetryHandler() {
+        AppcuesScrollViewDelegate.shared.detach()
+    }
+
+    func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
+        if case .failure(.step(_, _, _, recoverable: true)) = result {
+            startRetryHandler()
+        }
+
+        // recovery observer never stops observing
+        return false
+    }
+
+    private func startRetryHandler() {
+        AppcuesScrollViewDelegate.shared.attach(using: self)
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
@@ -23,7 +23,20 @@ internal class AppcuesScrollViewDelegate: NSObject, UIScrollViewDelegate {
     // This could have been a more sophisticated list of weak references to some Protocol implementation,
     // but that would seem to add unnecessary complexity and list management, when really only a single
     // RenderContext in the application (the modal context) can be in recovery mode at any given time.
-    weak var observer: StepRecoveryObserver?
+    private weak var observer: StepRecoveryObserver?
+
+    override private init() {
+        super.init()
+        UIScrollView.swizzleScrollViewGetDelegate()
+    }
+
+    func attach(using observer: StepRecoveryObserver) {
+        self.observer = observer
+    }
+
+    func detach() {
+        self.observer = nil
+    }
 
     // if any scroll activity is currently active, cancel any pending scrollEnded notifications
     // and wait for the next scroll completion to attempt any retry

--- a/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
@@ -1,0 +1,224 @@
+//
+//  UIScrollView+ScrollObserver.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 11/27/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+// This class provides a centralized access point for scroll updates, via the static
+// shared instance. The UIScrollView swizzled methods below can then send updates
+// into this class and have them processed and broadcast to a StepRecoverObserver, if
+// any observer is currently in recovery/retry mode (i.e. failed tooltip)
+@available(iOS 13.0, *)
+internal class AppcuesScrollViewDelegate: NSObject, UIScrollViewDelegate {
+    static var shared = AppcuesScrollViewDelegate()
+
+    private var retryWorkItem: DispatchWorkItem?
+
+    // Using a simple approach here where a single StepRecoverObserver can be attached at a time.
+    //
+    // This could have been a more sophisticated list of weak references to some Protocol implementation,
+    // but that would seem to add unnecessary complexity and list management, when really only a single
+    // RenderContext in the application (the modal context) can be in recovery mode at any given time.
+    weak var observer: StepRecoveryObserver?
+
+    // if any scroll activity is currently active, cancel any pending scrollEnded notifications
+    // and wait for the next scroll completion to attempt any retry
+    func didScroll() {
+        // cancel any existing notification
+        retryWorkItem?.cancel()
+        retryWorkItem = nil
+    }
+
+    // Scroll has to have ended via scrollViewDidEndDragging or scrollViewDidEndDecelerating
+    // and come to a rest for 1 second to send the scrollEnded update to our recovery observer.
+    // This delay ensures that any bounce effect will settle, or avoid sending excessive updates
+    // if scrolling is resumed immediately after it stops.
+    func scrollEnded() {
+        // only schedule a notification if we have an observer in retry state listening
+        guard observer != nil else { return }
+
+        // start a 1 sec timer to notify observer unless more scroll occurs
+        if retryWorkItem == nil {
+            let workItem = DispatchWorkItem { [weak self] in
+                // the observer may have been made `nil` in the 1 second delay, so
+                // we use the current state and do not send the notification if it
+                // is no longer listening for retry
+                self?.observer?.scrollEnded()
+            }
+            retryWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: workItem)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension UIScrollView {
+
+    static func swizzleScrollViewGetDelegate() {
+        // this will swap in a new getter for UIScrollView.delegate - giving our code a chance to hook
+        // in and override the scrollViewDidScroll callback and monitor for UI scroll changes that might
+        // impact Appcues experience rendering
+        let originalScrollViewDelegateSelector = #selector(getter: self.delegate)
+        let swizzledScrollViewDelegateSelector = #selector(appcues__getScrollViewDelegate)
+
+        guard let originalScrollViewMethod = class_getInstanceMethod(self, originalScrollViewDelegateSelector),
+              let swizzledScrollViewMethod = class_getInstanceMethod(self, swizzledScrollViewDelegateSelector) else {
+            return
+        }
+
+        method_exchangeImplementations(originalScrollViewMethod, swizzledScrollViewMethod)
+    }
+
+    // this is our custom getter logic for the UIScrollView.delegate
+    @objc
+    private func appcues__getScrollViewDelegate() -> UIScrollViewDelegate? {
+        let delegate: UIScrollViewDelegate
+
+        var shouldSetDelegate = false
+
+        // this call looks recursive, but it is not, it is calling the swapped implementation
+        // to get the actual delegate value that has been assigned, if any - can be nil
+        if let existingDelegate = appcues__getScrollViewDelegate() {
+            delegate = existingDelegate
+        } else {
+            // if it is nil, then we assign our own delegate implementation so there is
+            // something hooked in to listen to scroll
+            delegate = AppcuesScrollViewDelegate.shared
+            shouldSetDelegate = true
+        }
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("scrollViewDidScroll:"),
+            placeholderSelector: #selector(appcues__placeholderScrollViewDidScroll),
+            swizzleSelector: #selector(appcues__scrollViewDidScroll)
+        )
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("scrollViewDidEndDecelerating:"),
+            placeholderSelector: #selector(appcues__placeholderScrollViewDidEndDecelerating),
+            swizzleSelector: #selector(appcues__scrollViewDidEndDecelerating)
+        )
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("scrollViewDidEndDragging:willDecelerate:"),
+            placeholderSelector: #selector(appcues__placeholderScrollViewDidEndDragging),
+            swizzleSelector: #selector(appcues__scrollViewDidEndDragging)
+        )
+
+        // If we need to set a non-nil implementation where there previously was not one,
+        // swap the swizzled getter back first, then assign, then restore the swizzled getter.
+        // This is done to avoid infinite recursion in some cases observed, where a UICollectionView,
+        // for example, may call the getter during the execution of the setter.
+        if shouldSetDelegate {
+            UIScrollView.swizzleScrollViewGetDelegate()
+            self.delegate = delegate
+            UIScrollView.swizzleScrollViewGetDelegate()
+        }
+
+        return delegate
+    }
+
+    private func swizzle(
+        _ delegate: UIScrollViewDelegate,
+        targetSelector: Selector,
+        placeholderSelector: Selector,
+        swizzleSelector: Selector
+    ) {
+        // see if the currently assigned delegate has an implementation for the target selector already.
+        // these are optional methods in the protocol, and if they are not there already, we'll need to add
+        // a placeholder implementation so that we can consistently swap it with our override, which will attempt
+        // to call back into it, in case there was an implementation already - if we don't do this, we'll
+        // get invalid selector errors in these cases.
+        let originalMethod = class_getInstanceMethod(type(of: delegate), targetSelector)
+
+        if originalMethod == nil {
+            // this is the case where the existing delegate does not have an implementation for the target selector
+
+            guard let placeholderMethod = class_getInstanceMethod(UIScrollView.self, placeholderSelector) else {
+                // this really shouldn't ever be nil, as that would mean the function defined a few lines below is no
+                // longer there, but we must nil check this call
+                return
+            }
+
+            // add the placeholder, so it can be swizzled uniformly
+            class_addMethod(
+                type(of: delegate),
+                targetSelector,
+                method_getImplementation(placeholderMethod),
+                method_getTypeEncoding(placeholderMethod)
+            )
+        }
+
+        // swizzle the new implementation to inject our own custom logic
+
+        // this should never be nil, as it would mean the function defined a few lines below is no longer there,
+        // but we must nil check this call.
+        guard let swizzleMethod = class_getInstanceMethod(UIScrollView.self, swizzleSelector) else { return }
+
+        // add the swizzled version - this will only succeed once for this instance, if its already there, we've already
+        // swizzled, and we can exit early in the next guard
+        let addMethodResult = class_addMethod(
+            type(of: delegate),
+            swizzleSelector,
+            method_getImplementation(swizzleMethod),
+            method_getTypeEncoding(swizzleMethod)
+        )
+
+        guard addMethodResult,
+              let originalMethod = originalMethod ?? class_getInstanceMethod(type(of: delegate), targetSelector),
+              let swizzledMethod = class_getInstanceMethod(type(of: delegate), swizzleSelector) else {
+            return
+        }
+
+        // finally, here is where we swizzle in our custom implementation
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    @objc
+    func appcues__placeholderScrollViewDidScroll(_ scrollView: UIScrollView) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__placeholderScrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__placeholderScrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__scrollViewDidScroll(_ scrollView: UIScrollView) {
+        appcues__scrollViewDidScroll(scrollView)
+
+        AppcuesScrollViewDelegate.shared.didScroll()
+    }
+
+    @objc
+    func appcues__scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        appcues__scrollViewDidEndDecelerating(scrollView)
+
+        AppcuesScrollViewDelegate.shared.scrollEnded()
+    }
+
+    @objc
+    func appcues__scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        appcues__scrollViewDidEndDragging(scrollView, willDecelerate: decelerate)
+
+        if !decelerate {
+            AppcuesScrollViewDelegate.shared.scrollEnded()
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesTraitError.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesTraitError.swift
@@ -14,18 +14,21 @@ internal struct AppcuesTraitError: Error, CustomStringConvertible {
     /// A description of the nature of the error.
     ///
     /// This value will be logged to Appcues Studio.
-    internal var description: String
+    internal let description: String
 
     /// When set, this value can indicate a number of milliseconds after which re-application
     /// of traits can be attempted, to try to auto-recover from this error.
-    internal var retryMilliseconds: Int?
+    internal let retryMilliseconds: Int?
+
+    internal let recoverable: Bool
 
     /// Creates an instance of an error.
     /// - Parameters:
     ///   - description: A description of the nature of the error.
     ///   - retryMilliseconds: The number of milliseconds to wait before attempting to re-apply traits after this error.
-    internal init(description: String, retryMilliseconds: Int? = nil) {
+    internal init(description: String, retryMilliseconds: Int? = nil, recoverable: Bool = false) {
         self.description = description
         self.retryMilliseconds = retryMilliseconds.flatMap { max(0, $0) } // coerce zero or positive value
+        self.recoverable = recoverable
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
@@ -108,7 +108,8 @@ internal class AppcuesTargetElementTrait: AppcuesBackdropDecoratingTrait {
         guard !weightedViews.isEmpty else {
             throw AppcuesTraitError(
                 description: "No view matching selector \(config.selector)",
-                retryMilliseconds: retryMilliseconds
+                retryMilliseconds: retryMilliseconds,
+                recoverable: true
             )
         }
 
@@ -139,7 +140,8 @@ internal class AppcuesTargetElementTrait: AppcuesBackdropDecoratingTrait {
             // this selector was not able to find a distinct match in this view
             throw AppcuesTraitError(
                 description: "multiple non-distinct views (\(weightedViews.count)) matched selector \(config.selector)",
-                retryMilliseconds: retryMilliseconds
+                retryMilliseconds: retryMilliseconds,
+                recoverable: true
             )
         }
 


### PR DESCRIPTION
The work here is analogous to what is being worked on the Android side in https://github.com/appcues/appcues-android-sdk/pull/528.

At a high level: an `AppcuesTraitError` can be marked as `recoverable`. A `.step` error resulting from this can then instruct the state machine to go into a new `.failing` state, rather than being considered fatal, as before. When in the `.failing` state, a `.retry` action can trigger another attempt to move to the desired target state (the state of the transition when it failed previously), and retry some `SideEffect` (as of now, always the container presentation).

If the step is able to recover and present successfully, it moves back into the normal state machine flow (.renderingStep) and an `appcues:v2:step_recovery` analytics event is generated, with a matching `errorId` to the original `step_error` that occurred.

This work will enable future anchored tooltip error/retry logic, to handle target elements that are not immediately visible on screen load. Selected `AppcuesTraitError` instances here will be recoverable - selector not found, or multiple matching selectors. Others will not be recoverable and will end the experience as before.

4 commits here
1. Initial implementation of state machine changes
2. Code cleanup from initial review, fixing lints, and getting existing tests passing
3. New tests for new functionality
4. Disabling (commenting out) the test retry logic - the actual retry logic, based on detecting UI changes that should trigger a retry, will be follow on work. This was just some WIP test code to retry after 3 seconds to prove concepts.

The end result will hopefully be support of error handling and recovery to show tooltips on items that later scroll into view, like this example:


https://github.com/appcues/appcues-ios-sdk/assets/19266448/13f8d6b0-d369-4f9f-821d-855bfa536aeb



