### PR TITLE
Ensure resetting embed frames happens on main thread

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -311,6 +311,13 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
     }
 
     func resetAll() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async {
+                self.resetAll()
+            }
+            return
+        }
+
         pendingPreviewExperiences.removeAll()
         potentiallyRenderableExperiences.removeAll()
 


### PR DESCRIPTION
Noticed this bug in the showcase app. Signing out (ie calling `Appcues.reset()`) would crash, because it was trying to do UI operations on a background thread. The operations in question are resetting embed frames. So I've added our standard main thread check to `ExperienceRenderer.resetAll()` and that fixes it.