### PR TITLE
Ensure FrameView margins are added to the content size to avoid unnecessary scrolling

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIViewController+Embed.swift
@@ -12,7 +12,6 @@ extension UIViewController {
     func embedChildViewController(
         _ childVC: UIViewController,
         inSuperview superview: UIView,
-        margins: NSDirectionalEdgeInsets = .zero,
         respectLayoutMargins: Bool = false
     ) {
         addChild(childVC)
@@ -20,7 +19,7 @@ extension UIViewController {
         if respectLayoutMargins {
             childVC.view.pin(to: superview.layoutMarginsGuide)
         } else {
-            childVC.view.pin(to: superview, margins: margins)
+            childVC.view.pin(to: superview)
         }
         childVC.didMove(toParent: self)
     }

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
@@ -42,6 +42,13 @@ extension AppcuesFrame {
             view = frameView
         }
 
+        override func viewDidLoad() {
+            super.viewDidLoad()
+
+            // Only want to render the margins specified by the embed style
+            viewRespectsSystemMinimumLayoutMargins = false
+        }
+
         override func viewWillLayoutSubviews() {
             super.viewWillLayoutSubviews()
 
@@ -59,7 +66,15 @@ extension AppcuesFrame {
                 return
             }
 
-            preferredContentSize = container.preferredContentSize
+
+            // Add frame margins to the calculated size. Need to do this because the margins must be set on the FrameView,
+            // not the UIViewController it contains which manages the preferredContentSize
+            let margins = frameView.directionalLayoutMargins
+
+            preferredContentSize = CGSize(
+                width: container.preferredContentSize.width + margins.leading + margins.trailing,
+                height: container.preferredContentSize.height + margins.top + margins.bottom
+            )
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -77,7 +77,8 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
 
         configureConstraints(isEmpty: false)
 
-        viewController.embedChildViewController(experienceController, inSuperview: self, margins: margins)
+        self.directionalLayoutMargins = margins
+        viewController.embedChildViewController(experienceController, inSuperview: self, respectLayoutMargins: true)
         experienceViewController = experienceController
 
         switch transition {


### PR DESCRIPTION
Margins work properly for the UIKit implementation of embeds, but not SwiftUI, React Native, and Flutter. Why? Each of the broken options wrap the `AppcuesFrameView` in a `UIViewController` and set the content size according to the `preferredContentSize` of that `UIViewController`.

The margins on an embed were being set by way of `constant` values on constraints. The `AppcuesFrameView` had a child view that constrained to be inset by the margins. The issue is that the `preferredContentSize` that gets reported up the view controller chain doesn't include these margin values which are outside the frame of the `UIViewController.view`.

So for example, if the preferredContentSize is 300x150 and there's 10px margins, the total frame size should be 320x170, but instead the margins were getting applied inside the 300x150 box, resulting in 280x130 for content, and thus a scrollbar (note the scrollbar on the broken image below).

The solution is to use the `directionalLayoutMargins` of the `AppcuesFrameView` which is a property that can then be read by the wrapping `UIViewController` and added to `preferredContentSize` to get the final content size.

|Fixed|Broken|
|-|-|
|![Simulator Screenshot - iPhone 14 Pro - 2023-11-28 at 11 53 49](https://github.com/appcues/appcues-ios-sdk/assets/845681/38578024-2c7f-4238-8b36-ae275233fc9d)|![Simulator Screenshot - iPhone 14 Pro - 2023-11-28 at 11 55 08](https://github.com/appcues/appcues-ios-sdk/assets/845681/40f6d845-9474-43d8-a4f2-3feff3a6e6e7)|

## Notes

1. Unfortunately the changes to AppcuesFrame.swift will need to be made to the React Native and Flutter implementations. I looked long and hard for a solution that could be self contained, but that would require wrapping every frame in another `UIViewController` just to do the logic.
2. `viewRespectsSystemMinimumLayoutMargins` is necessary because otherwise I was getting non-zero horizontal margins when none were specified. I initially thought to add this to the `AppcuesFrameView` just before `viewController.embedChildViewController(...)`, but for the UIKit case where `viewController` is actually the VC in the customers app and not an VC created by the SDK, that could potentially cause layout issues.