### PR TITLE
Update slideout constraints to match the standard UIKit approach

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
@@ -54,9 +54,9 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
             // We need to add the modal to the view hierarchy,
             // and perform the animation.
             if let toView = transitionContext.view(forKey: .to) {
-                toView.translatesAutoresizingMaskIntoConstraints = false
                 transitionContext.containerView.addSubview(toView)
-                toView.pin(to: transitionContext.containerView)
+                toView.frame = transitionContext.containerView.bounds
+                toView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
                 toView.layoutIfNeeded()
             }
 


### PR DESCRIPTION
When a view controller is presented with `UIModalPresentationStyle.overFullScreen`, that results in the following constraints:

![Screenshot 2023-11-28 at 4 31 03 PM](https://github.com/appcues/appcues-ios-sdk/assets/845681/57b87ef7-a810-4d18-be43-3d2afa4d6847)

We were using our `.pin(...)` extension which sets top/left/right/bottom constraints, but crucially doesn't say anything about the dimensions of the view. So when the constraints are recalculated, you can end up with something sized to the slideout, not the window:

![Simulator Screenshot - iPhone 14 Pro - 2023-11-28 at 16 50 37](https://github.com/appcues/appcues-ios-sdk/assets/845681/c90b0f4b-8130-4fa5-85f0-e189e513ee89)

I expected that setting height and width constraints would do the trick, but for some reason it doesn't.

```swift
NSLayoutConstraint.activate([
    toView.heightAnchor.constraint(equalTo: transitionContext.containerView.heightAnchor),
    toView.widthAnchor.constraint(equalTo: transitionContext.containerView.widthAnchor)
])
```

I guess it doesn't work because the `UITransitionView` doesn't have a fixed fullscreen frame, which is how something like a half sheet would work.

So I ditched constraints for the classic autoresizing mask that will match exactly the constraints set by `UIModalPresentationStyle.overFullScreen`.

And now we're all set 😎 

https://github.com/appcues/appcues-ios-sdk/assets/845681/268b03c7-a094-4d44-846a-3b6291ba1919