### PR TITLE
Add capability to listen for scroll changes and attempt to recover a tooltip from step error

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -61,7 +61,7 @@ internal class StepRecoveryObserver: ExperienceStateObserver {
     }
 
     func stopRetryHandler() {
-        AppcuesScrollViewDelegate.shared.observer = nil
+        AppcuesScrollViewDelegate.shared.detach()
     }
 
     func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
@@ -74,7 +74,7 @@ internal class StepRecoveryObserver: ExperienceStateObserver {
     }
 
     private func startRetryHandler() {
-        AppcuesScrollViewDelegate.shared.observer = self
+        AppcuesScrollViewDelegate.shared.attach(using: self)
     }
 }
 
@@ -106,9 +106,6 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         self.stepRecoveryObserver = StepRecoveryObserver(stateMachine: stateMachine)
 
         stateMachines[ownerFor: .modal] = self
-
-        // TODO: guard against multiple
-        UIScrollView.swizzleScrollViewGetDelegate()
     }
 
     func start(owner: StateMachineOwning, forContext context: RenderContext) {
@@ -170,9 +167,7 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
     private func show(experience: ExperienceData, completion: ((Result<Void, Error>) -> Void)?) {
         guard Thread.isMainThread else {
-            DispatchQueue.main.async {
-                self.show(experience: experience, completion: completion)
-            }
+            DispatchQueue.main.async { self.show(experience: experience, completion: completion) }
             return
         }
 
@@ -376,9 +371,7 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
     func resetAll() {
         guard Thread.isMainThread else {
-            DispatchQueue.main.async {
-                self.resetAll()
-            }
+            DispatchQueue.main.async { self.resetAll() }
             return
         }
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -41,43 +41,6 @@ internal enum ExperienceRendererError: Error {
     case experimentControl
 }
 
-// This class is only used by the Modal RenderContext (modals and tooltips)
-// to detect recoverable step errors and attempt to retry when scroll changes
-// are observed. It hooks into the AppcuesScrollViewDelegate, which receives
-// scroll updates from the UIScrollView implementations in the app via
-// method swizzling.
-@available(iOS 13.0, *)
-internal class StepRecoveryObserver: ExperienceStateObserver {
-
-    private let stateMachine: ExperienceStateMachine
-
-    init(stateMachine: ExperienceStateMachine) {
-        self.stateMachine = stateMachine
-    }
-
-    func scrollEnded() {
-        stopRetryHandler() // stop now, if this next retry fails, it will start over again
-        try? stateMachine.transition(.retry)
-    }
-
-    func stopRetryHandler() {
-        AppcuesScrollViewDelegate.shared.detach()
-    }
-
-    func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
-        if case .failure(.step(_, _, _, recoverable: true)) = result {
-            startRetryHandler()
-        }
-
-        // recovery observer never stops observing
-        return false
-    }
-
-    private func startRetryHandler() {
-        AppcuesScrollViewDelegate.shared.attach(using: self)
-    }
-}
-
 @available(iOS 13.0, *)
 internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -100,7 +100,6 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         if shouldClearCache {
             potentiallyRenderableExperiences = [:]
             stateMachines.cleanup()
-            stepRecoveryObserver.stopRetryHandler()
         }
 
         // Add new experiences, replacing any existing ones

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
@@ -32,8 +32,20 @@ internal class StepRecoveryObserver: ExperienceStateObserver {
     }
 
     func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
-        if case .failure(.step(_, _, _, recoverable: true)) = result {
+        switch result {
+        case .failure(.step(_, _, _, recoverable: true)):
+            // a recoverable step error has been observed, so we begin attempting
+            // recovery - this will attach a listener to scroll changes in the app
+            // to see if layout changes make this experience presentable
             startRetryHandler()
+        case .success(.idling):
+            // if the machine goes back to idling, this means that any experience
+            // that was in a retry state was fully dismissed, or potentially a new
+            // experience has been queued up to start in its place - remove any
+            // existing retry handler to stop attempting recovery
+            stopRetryHandler()
+        default:
+            break
         }
 
         // recovery observer never stops observing

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
@@ -1,0 +1,46 @@
+//
+//  StepRecoveryObserver.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 12/6/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import Foundation
+
+// This class is only used by the Modal RenderContext (modals and tooltips)
+// to detect recoverable step errors and attempt to retry when scroll changes
+// are observed. It hooks into the AppcuesScrollViewDelegate, which receives
+// scroll updates from the UIScrollView implementations in the app via
+// method swizzling.
+@available(iOS 13.0, *)
+internal class StepRecoveryObserver: ExperienceStateObserver {
+
+    private let stateMachine: ExperienceStateMachine
+
+    init(stateMachine: ExperienceStateMachine) {
+        self.stateMachine = stateMachine
+    }
+
+    func scrollEnded() {
+        stopRetryHandler() // stop now, if this next retry fails, it will start over again
+        try? stateMachine.transition(.retry)
+    }
+
+    func stopRetryHandler() {
+        AppcuesScrollViewDelegate.shared.detach()
+    }
+
+    func evaluateIfSatisfied(result: ExperienceStateObserver.StateResult) -> Bool {
+        if case .failure(.step(_, _, _, recoverable: true)) = result {
+            startRetryHandler()
+        }
+
+        // recovery observer never stops observing
+        return false
+    }
+
+    private func startRetryHandler() {
+        AppcuesScrollViewDelegate.shared.attach(using: self)
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
@@ -23,7 +23,20 @@ internal class AppcuesScrollViewDelegate: NSObject, UIScrollViewDelegate {
     // This could have been a more sophisticated list of weak references to some Protocol implementation,
     // but that would seem to add unnecessary complexity and list management, when really only a single
     // RenderContext in the application (the modal context) can be in recovery mode at any given time.
-    weak var observer: StepRecoveryObserver?
+    private weak var observer: StepRecoveryObserver?
+
+    override private init() {
+        super.init()
+        UIScrollView.swizzleScrollViewGetDelegate()
+    }
+
+    func attach(using observer: StepRecoveryObserver) {
+        self.observer = observer
+    }
+
+    func detach() {
+        self.observer = nil
+    }
 
     // if any scroll activity is currently active, cancel any pending scrollEnded notifications
     // and wait for the next scroll completion to attempt any retry

--- a/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
@@ -1,0 +1,224 @@
+//
+//  UIScrollView+ScrollObserver.swift
+//  AppcuesKit
+//
+//  Created by James Ellis on 11/27/23.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+// This class provides a centralized access point for scroll updates, via the static
+// shared instance. The UIScrollView swizzled methods below can then send updates
+// into this class and have them processed and broadcast to a StepRecoverObserver, if
+// any observer is currently in recovery/retry mode (i.e. failed tooltip)
+@available(iOS 13.0, *)
+internal class AppcuesScrollViewDelegate: NSObject, UIScrollViewDelegate {
+    static var shared = AppcuesScrollViewDelegate()
+
+    private var retryWorkItem: DispatchWorkItem?
+
+    // Using a simple approach here where a single StepRecoverObserver can be attached at a time.
+    //
+    // This could have been a more sophisticated list of weak references to some Protocol implementation,
+    // but that would seem to add unnecessary complexity and list management, when really only a single
+    // RenderContext in the application (the modal context) can be in recovery mode at any given time.
+    weak var observer: StepRecoveryObserver?
+
+    // if any scroll activity is currently active, cancel any pending scrollEnded notifications
+    // and wait for the next scroll completion to attempt any retry
+    func didScroll() {
+        // cancel any existing notification
+        retryWorkItem?.cancel()
+        retryWorkItem = nil
+    }
+
+    // Scroll has to have ended via scrollViewDidEndDragging or scrollViewDidEndDecelerating
+    // and come to a rest for 1 second to send the scrollEnded update to our recovery observer.
+    // This delay ensures that any bounce effect will settle, or avoid sending excessive updates
+    // if scrolling is resumed immediately after it stops.
+    func scrollEnded() {
+        // only schedule a notification if we have an observer in retry state listening
+        guard observer != nil else { return }
+
+        // start a 1 sec timer to notify observer unless more scroll occurs
+        if retryWorkItem == nil {
+            let workItem = DispatchWorkItem { [weak self] in
+                // the observer may have been made `nil` in the 1 second delay, so
+                // we use the current state and do not send the notification if it
+                // is no longer listening for retry
+                self?.observer?.scrollEnded()
+            }
+            retryWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: workItem)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension UIScrollView {
+
+    static func swizzleScrollViewGetDelegate() {
+        // this will swap in a new getter for UIScrollView.delegate - giving our code a chance to hook
+        // in and override the scrollViewDidScroll callback and monitor for UI scroll changes that might
+        // impact Appcues experience rendering
+        let originalScrollViewDelegateSelector = #selector(getter: self.delegate)
+        let swizzledScrollViewDelegateSelector = #selector(appcues__getScrollViewDelegate)
+
+        guard let originalScrollViewMethod = class_getInstanceMethod(self, originalScrollViewDelegateSelector),
+              let swizzledScrollViewMethod = class_getInstanceMethod(self, swizzledScrollViewDelegateSelector) else {
+            return
+        }
+
+        method_exchangeImplementations(originalScrollViewMethod, swizzledScrollViewMethod)
+    }
+
+    // this is our custom getter logic for the UIScrollView.delegate
+    @objc
+    private func appcues__getScrollViewDelegate() -> UIScrollViewDelegate? {
+        let delegate: UIScrollViewDelegate
+
+        var shouldSetDelegate = false
+
+        // this call looks recursive, but it is not, it is calling the swapped implementation
+        // to get the actual delegate value that has been assigned, if any - can be nil
+        if let existingDelegate = appcues__getScrollViewDelegate() {
+            delegate = existingDelegate
+        } else {
+            // if it is nil, then we assign our own delegate implementation so there is
+            // something hooked in to listen to scroll
+            delegate = AppcuesScrollViewDelegate.shared
+            shouldSetDelegate = true
+        }
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("scrollViewDidScroll:"),
+            placeholderSelector: #selector(appcues__placeholderScrollViewDidScroll),
+            swizzleSelector: #selector(appcues__scrollViewDidScroll)
+        )
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("scrollViewDidEndDecelerating:"),
+            placeholderSelector: #selector(appcues__placeholderScrollViewDidEndDecelerating),
+            swizzleSelector: #selector(appcues__scrollViewDidEndDecelerating)
+        )
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("scrollViewDidEndDragging:willDecelerate:"),
+            placeholderSelector: #selector(appcues__placeholderScrollViewDidEndDragging),
+            swizzleSelector: #selector(appcues__scrollViewDidEndDragging)
+        )
+
+        // If we need to set a non-nil implementation where there previously was not one,
+        // swap the swizzled getter back first, then assign, then restore the swizzled getter.
+        // This is done to avoid infinite recursion in some cases observed, where a UICollectionView,
+        // for example, may call the getter during the execution of the setter.
+        if shouldSetDelegate {
+            UIScrollView.swizzleScrollViewGetDelegate()
+            self.delegate = delegate
+            UIScrollView.swizzleScrollViewGetDelegate()
+        }
+
+        return delegate
+    }
+
+    private func swizzle(
+        _ delegate: UIScrollViewDelegate,
+        targetSelector: Selector,
+        placeholderSelector: Selector,
+        swizzleSelector: Selector
+    ) {
+        // see if the currently assigned delegate has an implementation for the target selector already.
+        // these are optional methods in the protocol, and if they are not there already, we'll need to add
+        // a placeholder implementation so that we can consistently swap it with our override, which will attempt
+        // to call back into it, in case there was an implementation already - if we don't do this, we'll
+        // get invalid selector errors in these cases.
+        let originalMethod = class_getInstanceMethod(type(of: delegate), targetSelector)
+
+        if originalMethod == nil {
+            // this is the case where the existing delegate does not have an implementation for the target selector
+
+            guard let placeholderMethod = class_getInstanceMethod(UIScrollView.self, placeholderSelector) else {
+                // this really shouldn't ever be nil, as that would mean the function defined a few lines below is no
+                // longer there, but we must nil check this call
+                return
+            }
+
+            // add the placeholder, so it can be swizzled uniformly
+            class_addMethod(
+                type(of: delegate),
+                targetSelector,
+                method_getImplementation(placeholderMethod),
+                method_getTypeEncoding(placeholderMethod)
+            )
+        }
+
+        // swizzle the new implementation to inject our own custom logic
+
+        // this should never be nil, as it would mean the function defined a few lines below is no longer there,
+        // but we must nil check this call.
+        guard let swizzleMethod = class_getInstanceMethod(UIScrollView.self, swizzleSelector) else { return }
+
+        // add the swizzled version - this will only succeed once for this instance, if its already there, we've already
+        // swizzled, and we can exit early in the next guard
+        let addMethodResult = class_addMethod(
+            type(of: delegate),
+            swizzleSelector,
+            method_getImplementation(swizzleMethod),
+            method_getTypeEncoding(swizzleMethod)
+        )
+
+        guard addMethodResult,
+              let originalMethod = originalMethod ?? class_getInstanceMethod(type(of: delegate), targetSelector),
+              let swizzledMethod = class_getInstanceMethod(type(of: delegate), swizzleSelector) else {
+            return
+        }
+
+        // finally, here is where we swizzle in our custom implementation
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    @objc
+    func appcues__placeholderScrollViewDidScroll(_ scrollView: UIScrollView) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__placeholderScrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__placeholderScrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__scrollViewDidScroll(_ scrollView: UIScrollView) {
+        appcues__scrollViewDidScroll(scrollView)
+
+        AppcuesScrollViewDelegate.shared.didScroll()
+    }
+
+    @objc
+    func appcues__scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        appcues__scrollViewDidEndDecelerating(scrollView)
+
+        AppcuesScrollViewDelegate.shared.scrollEnded()
+    }
+
+    @objc
+    func appcues__scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        appcues__scrollViewDidEndDragging(scrollView, willDecelerate: decelerate)
+
+        if !decelerate {
+            AppcuesScrollViewDelegate.shared.scrollEnded()
+        }
+    }
+}


### PR DESCRIPTION
These are the updates that stack on top of state machine updates in #474 to address the specific use case of anchored tooltips that scroll into view.

Most of the code here is the swizzling details for UIScrollView. Those updates effectively watch for `scrollViewDidEndDecelerating` and `scrollViewDidEndDragging` calls to determine when a scroll view in the host application may have come to "rest". This "rest" is defined as 1 sec elapsing after those updates without any additional `scrollViewDidScroll` occurring. This logic _should_ also protect against typical scroll "bounce" at top/bottom that can occur - we do not want to identify a target rect during the bounce, as it will be offset from the eventual resting place of that view.

There are multiple scenarios to handle in swizzling related to the UIScrollView `.delegate` getter.
1. The host application has not set any delegate previously, current value is `nil`
2. The host application has set a delegate, but it did not implement the optional methods that we are concerned with here
3. The host application has set a delegate, and it already has implementations of the optional methods we are concerned with here

All of these scenarios are handled by (1) adding a default `AppcuesScrollViewDelegate` if none exists (2) adding placeholder empty functions if the default optionals didn't exist and (3) swizzling in our new function implementations but calling the old ones as well to ensure no noticeable change in host app behavior.

Our `AppcuesScrollViewDelegate.shared` singleton is the point that all updates are funneled through now, and observed by a single `StepRecoveryObserver` (the thing watching for errors in the StateMachine for the modal render context). Only when the first recovery attempt is needed, is this instance created and the UIScrollView functions swizzled. They will then remain swizzled for the duration of that app session. Hopefully, in the vast majority of sessions, there will be no recoverable step errors, and thus there will be zero overhead incurred by the host application. It would only add our listeners when we need to execute recovery.

This also adds a related update in the element capture logic to only create selectors for items once their center point has scrolled into view - and only capture the target rect for the visible portion of the element, the portion that is inside of the safe area (not hidden behind bottom tabs, for instance).

These updates are generally analogous to the implementation approach on the Android side in https://github.com/appcues/appcues-android-sdk/pull/531