### PR TITLE
Fix crash from lack of thread safety in DIContainer

### DIFF
--- a/Sources/AppcuesKit/Utilities/DIContainer.swift
+++ b/Sources/AppcuesKit/Utilities/DIContainer.swift
@@ -15,6 +15,8 @@ internal class DIContainer {
     // reference:
     // https://github.com/Swinject/SwinjectAutoregistration/blob/master/Sources/AutoRegistration.swift
 
+    private let componentQueue = DispatchQueue(label: "appcues-dicontainer", qos: .userInitiated, attributes: .concurrent)
+
     private var initializers: [String: (DIContainer) -> Any] = [:]
     private var components: [String: Any] = [:]
 
@@ -29,20 +31,28 @@ internal class DIContainer {
     }
 
     func register<Component>(_ type: Component.Type, value: Component) {
-        components[String(describing: Component.self)] = value
+        // If we're writing, need to lock, but no return, so this can be async
+        componentQueue.async(flags: .barrier) {
+            self.components[String(describing: Component.self)] = value
+        }
     }
 
     @discardableResult
     func resolve<Component>(_ type: Component.Type) -> Component {
         let key = String(describing: Component.self)
-        if let component = components[key] as? Component {
+
+        // Concurrent reads are ok
+        if let component = componentQueue.sync(execute: { components[key] as? Component }) {
             return component
         }
 
         if let initializer = initializers[key] {
             // swiftlint:disable:next force_cast
             let component = initializer(self) as! Component
-            components[key] = component
+            // If we're writing, need to lock
+            componentQueue.sync(flags: .barrier) {
+                components[key] = component
+            }
             return component
         }
 


### PR DESCRIPTION
As reported on our RN SDK (https://github.com/appcues/appcues-react-native-module/issues/128), we can get crashes in `DIContainer` from a lack of thread safety:

```
EXC_BAD_ACCESS: Attempted to dereference garbage pointer 0x8000000000000008.

0  libswiftCore.dylib +0x400034    _swift_isUniquelyReferenced_nonNull_native
1  Redacted +0xc77b0               specialized Dictionary._Variant.isUniquelyReferenced() (<compiler-generated>)
2  Redacted +0x25298               specialized Dictionary.subscript.setter (<compiler-generated>)
3  Redacted +0x24580               specialized DIContainer.resolve<A>(_:) (<compiler-generated>)
4  Redacted +0x25814               specialized DIContainer.resolve<A>(_:)
5  Redacted +0x158e7c              specialized DIContainer.resolve<A>(_:) (<compiler-generated>)
6  Redacted +0x24430               specialized thunk for @escaping @callee_guaranteed (@guaranteed DIContainer) -> (@out Any)
7  Redacted +0x25814               specialized DIContainer.resolve<A>(_:)
8  Redacted +0x1db5c               specialized DIContainer.resolve<A>(_:) (<compiler-generated>)
9  Redacted +0x135a8               closure #1 in ActivityProcessor.handleQualify(activity:completion:) (ActivityProcessor.swift:167:13)
10 Redacted +0x19d8fc              specialized closure #1 in NetworkClient.handleRequest<A>(_:requestId:completion:) (NetworkClient.swift:156:17)
11 Redacted +0x1a2398              partial apply for specialized closure #1 in NetworkClient.handleRequest<A>(_:requestId:completion:)
12 Redacted +0x19eee8              thunk for @escaping @callee_guaranteed @Sendable (@guaranteed Data?, @guaranteed NSURLResponse?, @guaranteed Error?) -> () (<compiler-generated>)
13 CFNetwork +0xf7b0               0x188de27b0 (0x188de25d0 + 480)
14 CFNetwork +0x2d6cc              0x188e006cc (0x188e00630 + 156)
15 libdispatch.dylib +0x26a4       __dispatch_call_block_and_release
16 libdispatch.dylib +0x42fc       __dispatch_client_callout
17 libdispatch.dylib +0xb890       __dispatch_lane_serial_drain
18 libdispatch.dylib +0xc3f4       __dispatch_lane_invoke
19 libdispatch.dylib +0x17000      __dispatch_root_queue_drain_deferred_wlh
20 libdispatch.dylib +0x16874      __dispatch_workloop_worker_thread
21 libsystem_pthread.dylib +0x1960 __pthread_wqthread
```

I was able to reproduce a crash with a unit test that registers and resolves dependencies across many threads.

The issue is that the `resolve()` method reads from `components` for dependencies that are already initialized, and then also writes to `components` when initializing a lazy dependency.

In the worst case, `resolve()` uses the queue twice, once to concurrently check if there's an initialized dependency instance, and if not, once with a barrier work item to store the value of a newly initialized dependency instance. We have to be careful, since initializing a dependency almost always means resolving (and sometimes also initializing) other dependencies, so we can't be locking access to `components` when initializing a new dependency instance. Thus the call to `initializer(self)` **must** be done outside a queue work item. Using the queue twice is also optimized for the more common case of returning an already initialized component, since this is the majority of cases (i.e. a lazy dependency is only ever inited once, but can be read multiple times).

Note that I didn't add a queue for reads/writes to the `initializers` dictionary since it's only read from, never written to after the `Appcues.init()` and doing so would add extra complexity and queue usage to `resolve()`. If there were other places in the codebase that were calling `registerLazy` while dependencies are also being resolved, then it could be problematic.