### PR TITLE
✨ Adding config.attributes to action @appcues/track

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
@@ -10,8 +10,9 @@ import Foundation
 
 @available(iOS 13.0, *)
 internal class AppcuesTrackAction: AppcuesExperienceAction {
-    struct Config: Decodable {
+    struct Config {
         let eventName: String
+        let attributes: [String: Any]?
     }
 
     static let type = "@appcues/track"
@@ -19,18 +20,58 @@ internal class AppcuesTrackAction: AppcuesExperienceAction {
     private weak var appcues: Appcues?
 
     let eventName: String
+    let attributes: [String: Any]?
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         self.appcues = configuration.appcues
 
         guard let config = configuration.decode(Config.self) else { return nil }
         self.eventName = config.eventName
+        self.attributes = config.attributes
     }
 
     func execute(completion: ActionRegistry.Completion) {
         guard let appcues = appcues else { return completion() }
 
-        appcues.track(name: eventName)
+        appcues.track(name: eventName, properties: attributes)
         completion()
+    }
+}
+
+@available(iOS 13.0, *)
+extension AppcuesTrackAction.Config: Decodable {
+
+    private enum CodingKeys: String, CodingKey {
+           case eventName
+           case attributes
+    }
+
+    // Custom decoding for this one - we want to extract the eventName and then for the attributes
+    // we handle it as a nestedContainer then we trim the set to only those of supported data types
+    // then store in the resulting attributes dictionary
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        eventName = try container.decode(String.self, forKey: .eventName)
+
+        if let attributesContainer = try? container.nestedContainer(keyedBy: CodingKeys.self, forKey: .attributes) {
+            var dict: [String: Any] = [:]
+
+            attributesContainer.allKeys.forEach { key in
+                if let boolValue = try? container.decode(Bool.self, forKey: key) {
+                    dict[key.stringValue] = boolValue
+                } else if let stringValue = try? container.decode(String.self, forKey: key) {
+                    dict[key.stringValue] = stringValue
+                } else if let intValue = try? container.decode(Int.self, forKey: key) {
+                    dict[key.stringValue] = intValue
+                } else if let doubleValue = try? container.decode(Double.self, forKey: key) {
+                    dict[key.stringValue] = doubleValue
+                } else {
+                    // not a supported type
+                }
+            }
+            self.attributes = dict
+        } else {
+            attributes = nil
+        }
     }
 }

--- a/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
@@ -52,7 +52,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/track",
-                    config: AppcuesTrackAction.Config(eventName: "Some event"))
+                    config: AppcuesTrackAction.Config(eventName: "Some event", attributes: nil))
             ],
             level: .step,
             renderContext: .modal,
@@ -98,7 +98,7 @@ class AppcuesStepInteractionActionTests: XCTestCase {
                 Experience.Action(
                     trigger: "tap",
                     type: "@appcues/track",
-                    config: AppcuesTrackAction.Config(eventName: "Some event"))
+                    config: AppcuesTrackAction.Config(eventName: "Some event", attributes: nil))
             ],
             level: .step,
             renderContext: .modal,

--- a/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
@@ -48,6 +48,39 @@ class AppcuesTrackActionTests: XCTestCase {
         XCTAssertEqual(completionCount, 1)
         XCTAssertEqual(trackCount, 1)
     }
+    
+    func testExecuteWithAttributes() throws {
+        // Arrange
+        var completionCount = 0
+        var trackCount = 0
+        appcues.analyticsPublisher.onPublish = { trackingUpdate in
+            XCTAssertEqual(trackingUpdate.type, .event(name: "My Custom Event", interactive: true))
+            
+            [
+                "boolean": true,
+                "string": "string",
+                "int": 10,
+                "double": 10.5
+            ].verifyPropertiesMatch(trackingUpdate.properties)
+            
+            trackCount += 1
+        }
+        let action = AppcuesTrackAction(appcues: appcues, 
+                                        eventName: "My Custom Event",
+                                        attributes: [
+                                            "boolean": true,
+                                            "string": "string",
+                                            "int": 10,
+                                            "double": 10.5
+                                        ])
+
+        // Act
+        action?.execute(completion: { completionCount += 1 })
+
+        // Assert
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(trackCount, 1)
+    }
 
     func testExecuteCompletesWithoutAppcuesInstance() throws {
         // Arrange
@@ -67,7 +100,7 @@ extension AppcuesTrackAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))
     }
-    convenience init?(appcues: Appcues?, eventName: String) {
-        self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesTrackAction.Config(eventName: eventName), appcues: appcues))
+    convenience init?(appcues: Appcues?, eventName: String, attributes: [String: Any]? = nil) {
+        self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesTrackAction.Config(eventName: eventName, attributes: attributes), appcues: appcues))
     }
 }


### PR DESCRIPTION
This is part of a larger initiative for integrations related to button clicks, on our end for now we need to add an attribute property that can receive generic information from builder, and pass it as properties when calling appcues.track internally.