### PR TITLE
Support additional query parameters on deep links to preview or show experiences

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -218,7 +218,7 @@ public class Appcues: NSObject {
             return
         }
 
-        experienceLoader.load(experienceID: experienceID, published: true, trigger: .showCall) { result in
+        experienceLoader.load(experienceID: experienceID, published: true, queryItems: [], trigger: .showCall) { result in
             switch result {
             case .success:
                 completion?(true, nil)

--- a/Sources/AppcuesKit/Data/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Data/Networking/Endpoint.swift
@@ -12,8 +12,8 @@ import Foundation
 internal enum APIEndpoint: Endpoint {
     case activity(userID: String)
     case qualify(userID: String)
-    case content(experienceID: String, queryItems: [URLQueryItem])
-    case preview(experienceID: String, queryItems: [URLQueryItem])
+    case content(experienceID: String, queryItems: [URLQueryItem] = [])
+    case preview(experienceID: String, queryItems: [URLQueryItem] = [])
     case health
 
     /// URL fragments that that are appended to the `Config.apiHost` to make the URL for a network request.

--- a/Sources/AppcuesKit/Data/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Data/Networking/Endpoint.swift
@@ -12,8 +12,8 @@ import Foundation
 internal enum APIEndpoint: Endpoint {
     case activity(userID: String)
     case qualify(userID: String)
-    case content(experienceID: String)
-    case preview(experienceID: String)
+    case content(experienceID: String, queryItems: [URLQueryItem])
+    case preview(experienceID: String, queryItems: [URLQueryItem])
     case health
 
     /// URL fragments that that are appended to the `Config.apiHost` to make the URL for a network request.
@@ -25,15 +25,17 @@ internal enum APIEndpoint: Endpoint {
             components.path = "/v1/accounts/\(config.accountID)/users/\(userID)/activity"
         case let .qualify(userID):
             components.path = "/v1/accounts/\(config.accountID)/users/\(userID)/qualify"
-        case let .content(experienceID):
+        case let .content(experienceID, queryItems):
             components.path = "/v1/accounts/\(config.accountID)/users/\(storage.userID)/experience_content/\(experienceID)"
-        case let .preview(experienceID):
+            components.queryItems = queryItems
+        case let .preview(experienceID, queryItems):
             // optionally include the userID, if one exists, to allow for a personalized preview capability
             if storage.userID.isEmpty {
                 components.path = "/v1/accounts/\(config.accountID)/experience_preview/\(experienceID)"
             } else {
                 components.path = "/v1/accounts/\(config.accountID)/users/\(storage.userID)/experience_preview/\(experienceID)"
             }
+            components.queryItems = queryItems
         case .health:
             components.path = "/healthz"
         }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -53,7 +53,7 @@ internal class AppcuesLaunchExperienceAction: AppcuesExperienceAction {
         // that launches another flow from a button, for example.
         let trigger = self.trigger ?? launchExperienceTrigger(appcues)
 
-        experienceLoading.load(experienceID: experienceID, published: true, trigger: trigger) { _  in
+        experienceLoading.load(experienceID: experienceID, published: true, queryItems: [], trigger: trigger) { _  in
             completion()
         }
     }

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -39,7 +39,7 @@ class ExperienceLoaderTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: true, trigger: .showCall) { result in
+        experienceLoader.load(experienceID: "123", published: true, queryItems: [], trigger: .showCall) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -68,7 +68,7 @@ class ExperienceLoaderTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: false, trigger: .preview) { result in
+        experienceLoader.load(experienceID: "123", published: false, queryItems: [], trigger: .preview) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }
@@ -87,7 +87,7 @@ class ExperienceLoaderTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: true, trigger: .showCall) { result in
+        experienceLoader.load(experienceID: "123", published: true, queryItems: [], trigger: .showCall) { result in
             if case .failure = result {
                 completionExpectation.fulfill()
             }
@@ -102,7 +102,7 @@ class ExperienceLoaderTests: XCTestCase {
         let reloadExpectation = expectation(description: "Data loaded called")
 
         // Load the initial preview
-        experienceLoader.load(experienceID: "123", published: false, trigger: .preview, completion: nil)
+        experienceLoader.load(experienceID: "123", published: false, queryItems: [], trigger: .preview, completion: nil)
 
         appcues.networking.onGet = { endpoint, authorization, completion in
             XCTAssertEqual(
@@ -127,9 +127,9 @@ class ExperienceLoaderTests: XCTestCase {
         reloadExpectation.isInverted = true
 
         // Load the initial preview
-        experienceLoader.load(experienceID: "123", published: false, trigger: .preview, completion: nil)
+        experienceLoader.load(experienceID: "123", published: false, queryItems: [], trigger: .preview, completion: nil)
         // Load a published experience
-        experienceLoader.load(experienceID: "abc", published: true, trigger: .preview, completion: nil)
+        experienceLoader.load(experienceID: "abc", published: true, queryItems: [], trigger: .preview, completion: nil)
 
         appcues.networking.onGet = { endpoint, authorization, completion in
             reloadExpectation.fulfill()

--- a/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceLoaderTests.swift
@@ -54,7 +54,7 @@ class ExperienceLoaderTests: XCTestCase {
         appcues.networking.onGet = { endpoint, authorization, completion in
             XCTAssertEqual(
                 endpoint.url(config: self.appcues.config, storage: self.appcues.storage),
-                APIEndpoint.preview(experienceID: "123").url(config: self.appcues.config, storage: self.appcues.storage)
+                APIEndpoint.preview(experienceID: "123", queryItems: [URLQueryItem(name: "query", value: "xyz")]).url(config: self.appcues.config, storage: self.appcues.storage)
             )
             completion(.success(Experience.mock))
         }
@@ -68,7 +68,7 @@ class ExperienceLoaderTests: XCTestCase {
         let completionExpectation = expectation(description: "Completion called")
 
         // Act
-        experienceLoader.load(experienceID: "123", published: false, queryItems: [], trigger: .preview) { result in
+        experienceLoader.load(experienceID: "123", published: false, queryItems: [URLQueryItem(name: "query", value: "xyz")], trigger: .preview) { result in
             if case .success = result {
                 completionExpectation.fulfill()
             }

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -118,7 +118,13 @@ class MockStorage: DataStoring {
 class MockExperienceLoader: ExperienceLoading {
 
     var onLoad: ((String, Bool, ExperienceTrigger, ((Result<Void, Error>) -> Void)?) -> Void)?
-    func load(experienceID: String, published: Bool, trigger: ExperienceTrigger, completion: ((Result<Void, Error>) -> Void)?) {
+    func load(
+        experienceID: String,
+        published: Bool,
+        queryItems: [URLQueryItem], 
+        trigger: ExperienceTrigger,
+        completion: ((Result<Void, Error>) -> Void)?
+    ){
         onLoad?(experienceID, published, trigger, completion)
     }
 }


### PR DESCRIPTION
Proposing an idea here, not sold on it - but this one would allow us to take any set of additional query parameters on the `/experience_preview` or `/experience_content` SDK deep links. This would be used to support a new `?locale_id={id}` parameter during the QR code preview flow from the builder. This approach is more generic, where it would just take any set of params given and pass them through, verbatim, to the api request that gets made.

The more specific approach would be to simply read the one `locale_id` param on the preview call directly, and use that in only the preview call. I thought perhaps a more general approach here would let us possibly add other things in the future without SDK changes. The more I think about it, it seems like YAGNI and I'm not happy with the change amplification here really. Interested in thoughts. Easy to update to a more targeted approach.