### PR TITLE
Add long press to copy to debugger values

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -309,6 +309,18 @@ internal enum DebugUI {
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.trailing)
                 }
+            }.ifLet(value) { view, value in
+                view.contextMenu {
+                    Button {
+                        UIPasteboard.general.string = value
+                    } label: {
+                        HStack {
+                            Text("Copy")
+                            Spacer()
+                            Image(systemName: "doc.on.doc")
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Went with a long press context menu to
1) avoid accidental copies
2) match the `ListItemRowView` in the debugger