### PR TITLE
Add app_id to activity requests

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -224,6 +224,7 @@ extension Activity {
         case let .event(name, _):
             self.init(
                 accountID: config.accountID,
+                appID: config.applicationID,
                 sessionID: sessionID.appcuesFormatted,
                 userID: storage.userID,
                 events: [Event(name: name, attributes: update.properties, context: update.context, logger: config.logger)],
@@ -235,6 +236,7 @@ extension Activity {
         case let .screen(title):
             self.init(
                 accountID: config.accountID,
+                appID: config.applicationID,
                 sessionID: sessionID.appcuesFormatted,
                 userID: storage.userID,
                 events: [Event(screen: title, attributes: update.properties, context: update.context, logger: config.logger)],
@@ -246,6 +248,7 @@ extension Activity {
         case .profile:
             self.init(
                 accountID: config.accountID,
+                appID: config.applicationID,
                 sessionID: sessionID.appcuesFormatted,
                 userID: storage.userID,
                 events: nil,
@@ -257,6 +260,7 @@ extension Activity {
         case .group:
             self.init(
                 accountID: config.accountID,
+                appID: config.applicationID,
                 sessionID: sessionID.appcuesFormatted,
                 userID: storage.userID,
                 events: nil,

--- a/Sources/AppcuesKit/Data/Models/Activity.swift
+++ b/Sources/AppcuesKit/Data/Models/Activity.swift
@@ -18,6 +18,7 @@ internal struct Activity {
     var profileUpdate: [String: Any]?
     let userID: String
     let accountID: String
+    let appID: String
     var groupID: String?
     var groupUpdate: [String: Any]?
     let userSignature: String?
@@ -25,6 +26,7 @@ internal struct Activity {
 
     internal init(
         accountID: String,
+        appID: String,
         sessionID: String,
         userID: String,
         events: [Event]?,
@@ -35,6 +37,7 @@ internal struct Activity {
         logger: Logging = OSLog.disabled
     ) {
         self.accountID = accountID
+        self.appID = appID
         self.sessionID = sessionID
         self.userID = userID
         self.events = events
@@ -54,6 +57,7 @@ extension Activity: Encodable {
         case profileUpdate = "profile_update"
         case userID = "user_id"
         case accountID = "account_id"
+        case appID = "app_id"
         case sessionID = "session_id"
         case groupID = "group_id"
         case groupUpdate = "group_update"
@@ -64,6 +68,7 @@ extension Activity: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode("mobile", forKey: .source)
         try container.encode(accountID, forKey: .accountID)
+        try container.encode(appID, forKey: .appID)
         try container.encode(sessionID, forKey: .sessionID)
         try container.encode(userID, forKey: .userID)
         try container.encode(groupID, forKey: .groupID)

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -360,6 +360,7 @@ class ActivityProcessorTests: XCTestCase {
     private func generateMockActivity(userID: String, event: Event, userSignature: String? = nil) -> Activity {
         return Activity(
             accountID: "00000",
+            appID: "abc",
             sessionID: UUID().appcuesFormatted,
             userID: userID,
             events: [event],

--- a/Tests/AppcuesKitTests/Networking/NetworkClientTests.swift
+++ b/Tests/AppcuesKitTests/Networking/NetworkClientTests.swift
@@ -75,6 +75,7 @@ class NetworkClientTests: XCTestCase {
         }
         let model = Activity(
             accountID: "00000",
+            appID: "abc",
             sessionID: UUID().appcuesFormatted,
             userID: "test",
             events: [Event(screen: "my screen")])
@@ -103,6 +104,7 @@ class NetworkClientTests: XCTestCase {
         }
         let model = Activity(
             accountID: "00000",
+            appID: "abc",
             sessionID: UUID().appcuesFormatted,
             userID: "test",
             events: [Event(screen: "my screen")])


### PR DESCRIPTION
Generates something like

```diff
{
	"source": "mobile",
	"account_id": "103523",
+	"app_id": "8bc9bdb8-6546-4781-95f8-75abee12fa7a",
	"user_id": "default-00000",
	"group_id": null,
	"session_id": "d1b0bec5-fb59-4d1c-a12a-da63c387d9fd",
	"request_id": "b182bb45-549d-4b61-b778-e4731fac0f96",
	"events": [...],
	"profile_update": {
		"_sdkName": "appcues-ios",
		"_localId": "40229635-9635-45ca-9604-94a136712f44",
		"_deviceType": "phone",
		"_sessionPageviews": 0,
		"_appVersion": "1.0",
		"_bundlePackageId": "com.appcues.sdk-example-spm",
		"_operatingSystem": "iOS",
		"_lastSeenAt": 1707411305343,
		"_appBuild": "1",
		"_appName": "Appcues Example",
		"_deviceModel": "arm64",
		"_updatedAt": 1707411305343,
		"_lastBrowserLanguage": "en",
		"_sdkVersion": "3.1.6",
		"_isAnonymous": false,
		"_osVersion": "15.5",
		"_sessionId": "d1b0bec5-fb59-4d1c-a12a-da63c387d9fd",
		"_sessionRandomizer": 34,
		"_appId": "8bc9bdb8-6546-4781-95f8-75abee12fa7a",
		"userId": "default-00000"
	}
}
```