### PR TITLE
Add Appcues.setPushToken and _pushToken device property

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -228,6 +228,17 @@ public class Appcues: NSObject {
         }
     }
 
+    /// Provide the APNs device token to Appcues.
+    ///
+    /// - Parameter deviceToken: A globally unique token that identifies this device to APNs.
+    ///
+    /// This function is intended to be called from  your `UIApplicationDelegate`'s
+    /// `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` function:
+    @objc
+    public func setPushToken(_ deviceToken: Data?) {
+        storage.pushToken = deviceToken?.map { String(format: "%02x", $0) }.joined()
+    }
+
     /// Register a trait that modifies an `Experience`.
     /// - Parameter trait: Trait to register.
     /// - Returns: Whether the trait was successfully registered.

--- a/Sources/AppcuesKit/AppcuesKit.docc/Extensions/Appcues.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/Extensions/Appcues.md
@@ -26,6 +26,14 @@
 
 - ``Appcues/show(experienceID:completion:)``
 
+### Embeds
+
+- ``Appcues/register(frameID:for:on:)``
+
+### Push Notifications
+
+- ``Appcues/setPushToken(_:)``
+
 ### Debugging
 
 - <doc:Debugging>
@@ -39,6 +47,7 @@
 - ``Appcues/experienceDelegate``
 - ``Appcues/analyticsDelegate``
 - ``Appcues/navigationDelegate``
+- ``Appcues/elementTargeting``
 
 ### Checking Versions
 

--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -133,16 +133,23 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
     }
 
     private func deviceAutoProperties() -> [String: Any] {
-        [
+        // Explicitly encode null value
+        let pushToken: Any = storage.pushToken ?? NSNull()
+
+        var properties = [
             "_deviceId": storage.deviceID,
-            "_language": deviceLanguage,
+            "_pushToken": pushToken,
             // TODO: more properties
-            // _pushToken
             // _pushSubscriptionStatus
             // _pushEnabled
             // _pushEnabledBackground
         ]
-            .compactMapValues { $0 }
+
+        if let language = deviceLanguage {
+            properties["_language"] = language
+        }
+
+        return properties
     }
 }
 

--- a/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
+++ b/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
@@ -63,6 +63,8 @@ extension KeyedEncodingContainer where K == DynamicCodingKeys {
                     try self.encode(bool, forKey: codingKey)
                 case let date as Date:
                     try self.encode(date, forKey: codingKey)
+                case is NSNull:
+                    try self.encodeNil(forKey: codingKey)
                 default:
                     encodingErrorKeys.append(codingKey.stringValue)
                 }

--- a/Sources/AppcuesKit/Data/Storage.swift
+++ b/Sources/AppcuesKit/Data/Storage.swift
@@ -26,6 +26,9 @@ internal protocol DataStoring: AnyObject {
 
     /// Optional, base 64 encoded signature to use as bearer token on API requests from the current user
     var userSignature: String? { get set }
+
+    /// Push token for APNs
+    var pushToken: String? { get set }
 }
 
 internal class Storage: DataStoring {
@@ -37,6 +40,7 @@ internal class Storage: DataStoring {
         case lastContentShownAt
         case groupID
         case userSignature
+        case pushToken
     }
 
     private let config: Appcues.Config
@@ -96,6 +100,15 @@ internal class Storage: DataStoring {
         }
         set {
             write(.userSignature, newValue: newValue)
+        }
+    }
+
+    internal var pushToken: String? {
+        get {
+            return read(.pushToken, defaultValue: nil)
+        }
+        set {
+            write(.pushToken, newValue: newValue)
         }
     }
 

--- a/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
@@ -56,7 +56,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
         let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionRandomizer", "_sessionId"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.identityAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
-        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
+        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_pushToken", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.deviceAutoProperties).keys).symmetricDifference(expectedEventDeviceAutoPropertyKeys))
     }
 

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -244,6 +244,17 @@ class AppcuesTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    func testSetPushToken() throws {
+        // Arrange
+        let token = "some-token".data(using: .utf8)
+
+        // Act
+        appcues.setPushToken(token)
+
+        // Assert
+        XCTAssertEqual(appcues.storage.pushToken, "736f6d652d746f6b656e")
+    }
+
     func testDidHandleURL() throws {
         // Arrange
         appcues.deepLinkHandler.onDidHandleURL = { url -> Bool in

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -113,6 +113,7 @@ class MockStorage: DataStoring {
     var isAnonymous: Bool = false
     var lastContentShownAt: Date?
     var userSignature: String?
+    var pushToken: String?
 }
 
 class MockExperienceLoader: ExperienceLoading {

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -68,6 +68,8 @@ class PublicAPITests: XCTestCase {
             print(success, error)
         }
 
+        appcuesInstance.setPushToken(nil)
+
         appcuesInstance.debug()
 
         appcuesInstance.trackScreens()


### PR DESCRIPTION
Used the format `%02x` (vs [`%02.2hhx`](https://github.com/appcues/appcues-ios-sdk/blob/ca6ffb8894d425557ad1be9ca03cd126d5a50e0c/Sources/AppcuesKit/Appcues.swift#L314C56-L314C64)) according to https://nshipster.com/apns-device-tokens/

We haven't had a case where we explicitly want to pass a null value through the properties, so I needed to add encoding support for `NSNull`.

Also [sc-60904]