### PR TITLE
Improve network logging

### DIFF
--- a/Sources/AppcuesKit/Data/Networking/NetworkingError.swift
+++ b/Sources/AppcuesKit/Data/Networking/NetworkingError.swift
@@ -10,5 +10,6 @@ import Foundation
 
 internal enum NetworkingError: Error {
     case invalidURL
+    case noData
     case nonSuccessfulStatusCode(Int)
 }


### PR DESCRIPTION
Ensure that a helpful response is always logged. Previously if there was no HTTP status code, we'd not get a log which makes debugging extra tricky. Now we always log _something_, and add the `error` body and empty message if those conditions would cause the response decode to fail.

Also, in the case where `data == nil`, we were returning without calling the completion handler, which, while unlikely, is bad, so I added an error completion block there too.

Now we can get something like this, instead of nothing, which is a big improvement.

![Simulator Screenshot - iPhone 13 Pro - 2024-02-20 at 16 39 16](https://github.com/appcues/appcues-ios-sdk/assets/845681/61de619c-4e36-4276-86cb-01477cf74d4d)
