### PR TITLE
Centralize analytic event names

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsPublisher.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsPublisher.swift
@@ -56,7 +56,7 @@ internal class AnalyticsPublisher: AnalyticsPublishing {
                 // immediately track session started before any subsequent analytics
                 decorateAndPublish(
                     TrackingUpdate(
-                        type: .event(name: SessionEvents.sessionStarted.rawValue, interactive: true),
+                        type: .event(name: Events.Session.sessionStarted.rawValue, interactive: true),
                         properties: nil,
                         isInternal: true
                     )

--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -49,7 +49,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             currentScreen = title
             sessionPageviews += 1
             context["screen_title"] = title
-        case .event(SessionEvents.sessionStarted.rawValue, _):
+        case .event(Events.Session.sessionStarted.rawValue, _):
             sessionPageviews = 0
             sessionRandomizer = Int.random(in: 1...100)
             sessionLatestUserProperties = [:]

--- a/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
+++ b/Sources/AppcuesKit/Data/Analytics/SessionMonitor.swift
@@ -17,12 +17,6 @@ internal protocol SessionMonitoring: AnyObject {
     func reset()
 }
 
-internal enum SessionEvents: String, CaseIterable {
-    case sessionStarted = "appcues:session_started"
-
-    static var allNames: [String] { allCases.map { $0.rawValue } }
-}
-
 internal class SessionMonitor: SessionMonitoring {
 
     private weak var appcues: Appcues?

--- a/Sources/AppcuesKit/Data/Analytics/TrackingUpdate.swift
+++ b/Sources/AppcuesKit/Data/Analytics/TrackingUpdate.swift
@@ -40,7 +40,7 @@ internal struct TrackingUpdate {
     var policy: Policy {
         switch type {
         case let .event(name, interactive):
-            if name == SessionEvents.sessionStarted.rawValue {
+            if name == Events.Session.sessionStarted.rawValue {
                 // session_started is a special case, which is allowed to batch with the identify()
                 // that often is directly associated with it, and potentially a group()
                 return .flushThenSend(waitForBatch: true)

--- a/Sources/AppcuesKit/Data/Events.swift
+++ b/Sources/AppcuesKit/Data/Events.swift
@@ -1,0 +1,28 @@
+//
+//  Events.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-02-21.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal enum Events {
+    enum Session: String {
+        case sessionStarted = "appcues:session_started"
+    }
+
+    enum Experience: String {
+        case stepSeen = "appcues:v2:step_seen"
+        case stepInteraction = "appcues:v2:step_interaction"
+        case stepCompleted = "appcues:v2:step_completed"
+        case stepError = "appcues:v2:step_error"
+        case stepRecovered = "appcues:v2:step_recovered"
+        case experienceStarted = "appcues:v2:experience_started"
+        case experienceCompleted = "appcues:v2:experience_completed"
+        case experienceDismissed = "appcues:v2:experience_dismissed"
+        case experienceError = "appcues:v2:experience_error"
+        case experienceRecovered = "appcues:v2:experience_recovered"
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
@@ -53,11 +53,11 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
 
         if let experienceData = experienceRenderer.experienceData(forContext: renderContext),
            let stepIndex = experienceRenderer.stepIndex(forContext: renderContext) {
-            interactionProperties = LifecycleEvent.properties(experienceData, stepIndex).merging(interactionProperties)
+            interactionProperties = Dictionary(propertiesFrom: experienceData, stepIndex: stepIndex).merging(interactionProperties)
         }
 
         analyticsPublisher.publish(TrackingUpdate(
-            type: .event(name: LifecycleEvent.stepInteraction.rawValue, interactive: false),
+            type: .event(name: Events.Experience.stepInteraction.rawValue, interactive: false),
             properties: interactionProperties,
             isInternal: true
         ))

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -43,11 +43,12 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
               let stepIndex = experienceRenderer.stepIndex(forContext: renderContext),
               let stepState = experienceData.state(for: stepIndex) else { return }
 
-        let interactionProperties = LifecycleEvent.properties(experienceData, stepIndex).merging([
-            "interactionType": "Form Submitted",
-            // Passing the actual StepState model is safe because of specific handling in `encodeSkippingInvalid`.
-            "interactionData": [ "formResponse": stepState ]
-        ])
+        let interactionProperties = Dictionary(propertiesFrom: experienceData, stepIndex: stepIndex)
+            .merging([
+                "interactionType": "Form Submitted",
+                // Passing the actual StepState model is safe because of specific handling in `encodeSkippingInvalid`.
+                "interactionData": [ "formResponse": stepState ]
+            ])
 
         analyticsPublisher.publish(TrackingUpdate(
             type: .profile(interactive: false),
@@ -56,7 +57,7 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
         ))
 
         analyticsPublisher.publish(TrackingUpdate(
-            type: .event(name: LifecycleEvent.stepInteraction.rawValue, interactive: false),
+            type: .event(name: Events.Experience.stepInteraction.rawValue, interactive: false),
             properties: interactionProperties,
             isInternal: true
         ))

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
@@ -87,10 +87,10 @@ internal struct LoggedEvent: Identifiable {
         self.properties = update.properties
 
         switch update.type {
-        case let .event(name, _) where SessionEvents.allNames.contains(name):
+        case let .event(name, _) where Events.Session(rawValue: name) != nil:
             self.type = .session
             self.name = name.prettifiedEventName
-        case let .event(name, _) where name.starts(with: "appcues:v2:"):
+        case let .event(name, _) where Events.Experience(rawValue: name) != nil:
             self.type = .experience
             self.name = name.prettifiedEventName
         case let .event(name, _):

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/StructuredLifecycleProperties.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/StructuredLifecycleProperties.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal struct StructuredLifecycleProperties: Equatable {
-    let type: LifecycleEvent
+    let type: Events.Experience
     let experienceID: UUID
     let experienceName: String
     let experienceInstanceID: UUID
@@ -21,7 +21,7 @@ internal struct StructuredLifecycleProperties: Equatable {
     let message: String?
 
     init?(update: TrackingUpdate) {
-        guard let type = LifecycleEvent(trackingType: update.type) else { return nil }
+        guard let type = Events.Experience(trackingType: update.type) else { return nil }
 
         guard let experienceID = UUID(uuidString: update.properties?["experienceId"] as? String ?? ""),
               let experienceName = update.properties?["experienceName"] as? String,
@@ -43,7 +43,7 @@ internal struct StructuredLifecycleProperties: Equatable {
     }
 
     init(
-        type: LifecycleEvent,
+        type: Events.Experience,
         experienceID: UUID,
         experienceName: String,
         experienceInstanceID: UUID,
@@ -65,7 +65,7 @@ internal struct StructuredLifecycleProperties: Equatable {
     }
 }
 
-private extension LifecycleEvent {
+private extension Events.Experience {
     init?(trackingType: TrackingUpdate.TrackingType) {
         if case .event(let name, _) = trackingType, let val = Self(rawValue: name) {
             self = val

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
@@ -1,5 +1,5 @@
 //
-//  LifecycleEvent.swift
+//  Dictionary+ExperienceProperties.swift
 //  AppcuesKit
 //
 //  Created by Matt on 2021-11-19.
@@ -8,25 +8,14 @@
 
 import Foundation
 
-internal enum LifecycleEvent: String, CaseIterable {
-    case stepSeen = "appcues:v2:step_seen"
-    case stepInteraction = "appcues:v2:step_interaction"
-    case stepCompleted = "appcues:v2:step_completed"
-    case stepError = "appcues:v2:step_error"
-    case stepRecovered = "appcues:v2:step_recovered"
-    case experienceStarted = "appcues:v2:experience_started"
-    case experienceCompleted = "appcues:v2:experience_completed"
-    case experienceDismissed = "appcues:v2:experience_dismissed"
-    case experienceError = "appcues:v2:experience_error"
-    case experienceRecovered = "appcues:v2:experience_recovered"
-
+extension Dictionary where Key == String, Value == Any {
     /// Map experience model to a general property dictionary.
     @available(iOS 13.0, *)
-    static func properties(
-        _ experience: ExperienceData,
-        _ stepIndex: Experience.StepIndex? = nil,
-        error: ErrorBody? = nil
-    ) -> [String: Any] {
+    init(
+        propertiesFrom experience: ExperienceData,
+        stepIndex: Experience.StepIndex? = nil,
+        error: Events.Experience.ErrorBody? = nil
+    ) {
         var properties: [String: Any] = [
             "experienceId": experience.id.appcuesFormatted,
             "experienceName": experience.name,
@@ -63,11 +52,11 @@ internal enum LifecycleEvent: String, CaseIterable {
             properties["errorId"] = error.id.appcuesFormatted
         }
 
-        return properties
+        self = properties
     }
 }
 
-extension LifecycleEvent {
+extension Events.Experience {
     struct ErrorBody: ExpressibleByStringInterpolation {
         let message: String?
         let id: UUID
@@ -77,7 +66,7 @@ extension LifecycleEvent {
             self.id = id
         }
 
-        // Conveniently init with `"message"` or `"\(messageVar)"` instead of `ExperienceLifecycleEvent.Error(message: messageVar)`.
+        // Conveniently init with `"message"` or `"\(messageVar)"` instead of `Events.Experience.ErrorBody(message: messageVar)`.
         init(stringLiteral value: String) {
             message = value
             id = UUID.create()


### PR DESCRIPTION
This is some refactoring targeting `main` before adding the new device events in the `sdk4` branch. Basically, I don't like that currently,
1) event names are scattered in different places (manifests the question, "where do I put the new device event names"), and
2) the name `LifecycleEvent` always confused me when I was looking for them.

Now there's `enum Events` which namespaces `Session` and `Experience` (and soon `Device`). This seems substantially more friendly to anyone new to the codebase.

Also in the name of clarity, I replaced the strange static extension `LifecycleEvent.properties()` with a `Dictionary` initializer.

Last little change was renaming `func trackLifecycleEvent(_ name: LifecycleEvent, _ properties: [String: Any])` to `func track(experienceEvent name: Events.Experience, properties: [String: Any])` in `ExperienceStateObserver`.