### PR TITLE
Ensure actions with analytics log instead of publish for experience previews

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
@@ -51,16 +51,19 @@ internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
             ]
         ]
 
+        var shouldPublish = true
+
         if let experienceData = experienceRenderer.experienceData(forContext: renderContext),
            let stepIndex = experienceRenderer.stepIndex(forContext: renderContext) {
             interactionProperties = Dictionary(propertiesFrom: experienceData, stepIndex: stepIndex).merging(interactionProperties)
+            shouldPublish = experienceData.published
         }
 
-        analyticsPublisher.publish(TrackingUpdate(
+        analyticsPublisher.conditionallyPublish(TrackingUpdate(
             type: .event(name: Events.Experience.stepInteraction.rawValue, interactive: false),
             properties: interactionProperties,
             isInternal: true
-        ))
+        ), shouldPublish: shouldPublish)
 
         completion()
     }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -50,17 +50,17 @@ internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActio
                 "interactionData": [ "formResponse": stepState ]
             ])
 
-        analyticsPublisher.publish(TrackingUpdate(
+        analyticsPublisher.conditionallyPublish(TrackingUpdate(
             type: .profile(interactive: false),
             properties: stepState.formattedAsProfileUpdate(),
             isInternal: true
-        ))
+        ), shouldPublish: experienceData.published)
 
-        analyticsPublisher.publish(TrackingUpdate(
+        analyticsPublisher.conditionallyPublish(TrackingUpdate(
             type: .event(name: Events.Experience.stepInteraction.rawValue, interactive: false),
             properties: interactionProperties,
             isInternal: true
-        ))
+        ), shouldPublish: experienceData.published)
     }
 
     // If the form state is invalid, remove this action and all subsequent.

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
@@ -29,6 +29,7 @@ internal enum DebugLogUI {
                 }
             }
             .navigationBarTitle("", displayMode: .inline)
+            .navigationBarItems(trailing: ShareButton(text: logger.stringEncoded()))
         }
     }
 
@@ -50,9 +51,21 @@ internal enum DebugLogUI {
                 .padding()
             }
             .navigationBarTitle("", displayMode: .inline)
-            .navigationBarItems(trailing: Button("Copy Log") {
-                UIPasteboard.general.string = log.message
-            })
+            .navigationBarItems(trailing: ShareButton(text: log.message))
+        }
+    }
+
+    private struct ShareButton: View {
+        let text: String
+
+        var body: some View {
+            if #available(iOS 16.0, *) {
+                ShareLink(item: text)
+            } else {
+                Button("Copy Log") {
+                    UIPasteboard.general.string = text
+                }
+            }
         }
     }
 }

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsPublisherTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsPublisherTests.swift
@@ -22,6 +22,7 @@ class AnalyticsPublisherTests: XCTestCase {
         appcues.sessionID = UUID()
         analyticsPublisher = AnalyticsPublisher(container: appcues.container)
     }
+
     func testRegisterDecorator() throws {
         // Arrange
         let decorator = Mocks.TestDecorator()
@@ -98,6 +99,30 @@ class AnalyticsPublisherTests: XCTestCase {
 
         // Assert
         XCTAssertNil(weakSubscriber)
+    }
+
+    func testConditionalPublishFalse() throws {
+        // Arrange
+        let subscriber = Mocks.TestSubscriber()
+
+        // Act
+        analyticsPublisher.register(subscriber: subscriber)
+        analyticsPublisher.conditionallyPublish(TrackingUpdate(type: .event(name: "custom event", interactive: true), isInternal: false), shouldPublish: false)
+
+        // Assert
+        XCTAssertEqual(0, subscriber.trackedUpdates)
+    }
+
+    func testConditionalPublishTrue() throws {
+        // Arrange
+        let subscriber = Mocks.TestSubscriber()
+
+        // Act
+        analyticsPublisher.register(subscriber: subscriber)
+        analyticsPublisher.conditionallyPublish(TrackingUpdate(type: .event(name: "custom event", interactive: true), isInternal: false), shouldPublish: true)
+
+        // Assert
+        XCTAssertEqual(1, subscriber.trackedUpdates)
     }
 
 }

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -85,6 +85,11 @@ class MockAnalyticsPublisher: AnalyticsPublishing {
         onPublish?(update)
     }
 
+    var onLog: ((TrackingUpdate) -> Void)?
+    func log(_ update: TrackingUpdate) {
+        onLog?(update)
+    }
+
     var onRegisterSubscriber: ((AnalyticsSubscribing) -> Void)?
     func register(subscriber: AnalyticsSubscribing) {
         onRegisterSubscriber?(subscriber)

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -201,8 +201,8 @@ extension Experience.Step.Child {
 extension ExperienceData {
     static var mock: ExperienceData { ExperienceData(.mock, trigger: .showCall) }
     static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock, trigger: .showCall) }
-    static func mockWithForm(defaultValue: String?, attributeName: String? = nil) -> ExperienceData {
-        ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ), trigger: .showCall)
+    static func mockWithForm(defaultValue: String?, attributeName: String? = nil, published: Bool = true) -> ExperienceData {
+        ExperienceData(.mockWithForm(defaultValue: defaultValue, attributeName: attributeName ), trigger: .showCall, published: published)
     }
     static func mockWithStepActions(actions: [Experience.Action], trigger: ExperienceTrigger) -> ExperienceData {
         ExperienceData(.mockWithStepActions(actions: actions), trigger: trigger)


### PR DESCRIPTION
1. Update `AnalyticsPublisher` to be able to conditionally publish or debug log analytics
    - `decorateAndPublish()` got split into `decorate()` and `notifySubscribers()` so that the logging path can also decorate
2. Log experience analytics for flow previews instead of doing nothing
3. Log action analytics with `@appcues/step_interaction` and `@appcues/submit-form` for flow previews instead of publishing
4. Add a share sheet link to the debugger to allow easy sharing (or copying) the entire debug log
5. New tests

![Simulator Screenshot - iPhone 15 Pro - 2024-02-23 at 09 52 59](https://github.com/appcues/appcues-ios-sdk/assets/845681/e602ee82-03c3-444e-86c4-26653ffaf663)
