### PR TITLE
Add push status device properties

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -346,6 +346,7 @@ public class Appcues: NSObject {
         container.registerLazy(ActivityProcessing.self, initializer: ActivityProcessor.init)
         container.registerLazy(ActivityStoring.self, initializer: ActivityFileStorage.init)
         container.registerLazy(AnalyticsBroadcaster.self, initializer: AnalyticsBroadcaster.init)
+        container.registerLazy(PushMonitoring.self, initializer: PushMonitor.init)
 
         if #available(iOS 13.0, *) {
             container.registerLazy(DeepLinkHandling.self, initializer: DeepLinkHandler.init)

--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -19,6 +19,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
 
     private weak var appcues: Appcues?
     private let storage: DataStoring
+    private let pushMonitor: PushMonitoring
     private let config: Appcues.Config
 
     // these are the fixed values for the duration of the app runtime
@@ -50,6 +51,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
     init(container: DIContainer) {
         self.appcues = container.owner
         self.storage = container.resolve(DataStoring.self)
+        self.pushMonitor = container.resolve(PushMonitoring.self)
         self.config = container.resolve(Appcues.Config.self)
     }
 
@@ -123,7 +125,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
         }
 
         switch tracking.type {
-            case .event(Events.Session.sessionStarted.rawValue, _),
+        case .event(Events.Session.sessionStarted.rawValue, _),
                 .event(Events.Device.deviceUpdated.rawValue, _),
                 .event(Events.Device.deviceUnregistered.rawValue, _):
             decorated.deviceAutoProperties = deviceAutoProperties().merging(applicationProperties)
@@ -143,10 +145,10 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
         var properties = [
             "_deviceId": storage.deviceID,
             "_pushToken": pushToken,
+            "_pushEnabled": pushMonitor.pushEnabled,
+            "_pushEnabledBackground": pushMonitor.pushBackgroundEnabled,
             // TODO: more properties
             // _pushSubscriptionStatus
-            // _pushEnabled
-            // _pushEnabledBackground
         ]
 
         if let language = deviceLanguage {

--- a/Sources/AppcuesKit/Data/PushMonitor.swift
+++ b/Sources/AppcuesKit/Data/PushMonitor.swift
@@ -1,0 +1,64 @@
+//
+//  PushMonitor.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-02-22.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal protocol PushMonitoring: AnyObject {
+    var pushEnabled: Bool { get }
+    var pushBackgroundEnabled: Bool { get }
+}
+
+internal class PushMonitor: PushMonitoring {
+
+    private let storage: DataStoring
+
+    private var pushAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    var pushEnabled: Bool {
+        pushAuthorizationStatus == .authorized && storage.pushToken != nil
+    }
+
+    var pushBackgroundEnabled: Bool {
+        storage.pushToken != nil
+    }
+
+    init(container: DIContainer) {
+        self.storage = container.resolve(DataStoring.self)
+
+        refreshPushStatus()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    @objc
+    private func applicationWillEnterForeground(notification: Notification) {
+        refreshPushStatus()
+    }
+
+    private func refreshPushStatus() {
+        // Skip call to UNUserNotificationCenter.current() in tests to avoid crashing in package tests
+        #if DEBUG
+        guard ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil else { return }
+        #endif
+
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            self?.pushAuthorizationStatus = settings.authorizationStatus
+        }
+    }
+
+    #if DEBUG
+    func mockPushStatus(_ status: UNAuthorizationStatus) {
+        pushAuthorizationStatus = status
+    }
+    #endif
+}

--- a/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
@@ -56,7 +56,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
         let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionRandomizer", "_sessionId"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.identityAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
-        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_pushToken", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
+        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_pushToken", "_pushEnabledBackground", "_pushEnabled", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.deviceAutoProperties).keys).symmetricDifference(expectedEventDeviceAutoPropertyKeys))
     }
 

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -28,6 +28,7 @@ class MockAppcues: Appcues {
         container.register(ActivityProcessing.self, value: activityProcessor)
         container.register(ActivityStoring.self, value: activityStorage)
         container.register(AnalyticsTracking.self, value: analyticsTracker)
+        container.register(PushMonitoring.self, value: pushMonitor)
 
         if #available(iOS 13.0, *) {
             container.register(DeepLinkHandling.self, value: deepLinkHandler)
@@ -62,6 +63,7 @@ class MockAppcues: Appcues {
     var activityStorage = MockActivityStorage()
     var networking = MockNetworking()
     var analyticsTracker = MockAnalyticsTracker()
+    var pushMonitor = MockPushMonitor()
 
     // must wrap in @available since MockExperienceRenderer has a stored property with
     // type ExperienceData in it, which is 13+
@@ -359,4 +361,9 @@ class MockAnalyticsTracker: AnalyticsTracking {
     func flush() {
         onFlush?()
     }
+}
+
+class MockPushMonitor: PushMonitoring {
+    var pushEnabled: Bool = false
+    var pushBackgroundEnabled: Bool = false
 }

--- a/Tests/AppcuesKitTests/PushMonitorTests.swift
+++ b/Tests/AppcuesKitTests/PushMonitorTests.swift
@@ -1,0 +1,63 @@
+//
+//  PushMonitorTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2024-02-26.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+class PushMonitorTests: XCTestCase {
+
+    var pushMonitor: PushMonitor!
+    var appcues: MockAppcues!
+
+    override func setUp() {
+        let config = Appcues.Config(accountID: "00000", applicationID: "abc")
+        appcues = MockAppcues(config: config)
+        pushMonitor = PushMonitor(container: appcues.container)
+    }
+
+    func testNoTokenNotAuthorized() throws {
+        // Arrange
+        appcues.storage.pushToken = nil
+        pushMonitor.mockPushStatus(.denied)
+
+        // Assert
+        XCTAssertFalse(pushMonitor.pushEnabled)
+        XCTAssertFalse(pushMonitor.pushBackgroundEnabled)
+    }
+
+    func testNoTokenAuthorized() throws {
+        // Arrange
+        appcues.storage.pushToken = nil
+        pushMonitor.mockPushStatus(.authorized)
+
+        // Assert
+        XCTAssertFalse(pushMonitor.pushEnabled)
+        XCTAssertFalse(pushMonitor.pushBackgroundEnabled)
+    }
+
+    func testTokenNotAuthorized() throws {
+        // Arrange
+        appcues.storage.pushToken = "<some-token>"
+        pushMonitor.mockPushStatus(.denied)
+
+        // Assert
+        XCTAssertFalse(pushMonitor.pushEnabled)
+        XCTAssertTrue(pushMonitor.pushBackgroundEnabled)
+    }
+
+    func testTokenAuthorized() throws {
+        // Arrange
+        appcues.storage.pushToken = "<some-token>"
+        pushMonitor.mockPushStatus(.authorized)
+
+        // Assert
+        XCTAssertTrue(pushMonitor.pushEnabled)
+        XCTAssertTrue(pushMonitor.pushBackgroundEnabled)
+    }
+
+}


### PR DESCRIPTION
I created a new `PushMonitor` dependency, mostly because of the requirement to watch for new foreground events—it felt weird to have that happening in the `AutoPropertyDecorator`, or anywhere else non-specific. Push handlers and other stuff might end up in `PushMonitor` (and necessitate a rename) in the future, but I haven't really planned that out yet.

The non-straightforward part of this is that calls to `UNUserNotificationCenter` crash in tests for non-app targets ([Stack Overflow](https://stackoverflow.com/questions/77448766/app-crashes-when-im-getting-unusernotificationcenter-current-from-into-a-swif)). Because there are tests that use `Appcues` in addition to `MockAppcues`, we can't use `UNUserNotificationCenter` without doing something different in the SDK code when tests are running.

I started off by creating a protocol to be able to mock the notification center, but I didn't like that the mock class had to be in the core SDK code (even if I could `#if DEBUG` wrap it). I've settled (for now) on an approach that has the least test-specific code in the SDK (1 line guard, and a 1 line testing function). Note that I could remove `mockPushStatus()` and just make `var pushAuthorizationStatus` non-private to be able to set it directly in tests, but that could introduce confusion in the future. Other options would be optional dependencies that we know are resolved in non-debug builds, but I prefer the compile-time guarantee of my current approach.

Also [sc-60921]