### PR TITLE
Simplify launch experience action implementation

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -210,7 +210,6 @@ extension Experience {
             if let nextContentID = nextContentID {
                 actions.append(AppcuesLaunchExperienceAction(
                     appcues: appcues,
-                    renderContext: self.renderContext,
                     experienceID: nextContentID,
                     trigger: .experienceCompletionAction(fromExperienceID: self.id)
                 ))


### PR DESCRIPTION
This is a little side quest as I'm implementing push handlers, but I want to keep refactoring on the `main` branch.

The previous `init(appcues: Appcues?, renderContext: RenderContext, experienceID: String, trigger: ExperienceTrigger)` required a `renderContext` value for which there's no proper value when initing from the push handler. That code smell made me look closer and it turns out storing `renderContext` was unnecessary because there’s never a case where it would be used when `trigger` is specified, and `renderContext` was only used to compute a fallback trigger value.

The required change is simply computing the proper `trigger` of `.launchExperienceAction` in the `init` using the `renderContext` of `AppcuesExperiencePluginConfiguration`, instead of storing `renderContext` to use later.

The result is a much simpler action implementation and more logical call sites 😎 