### PR TITLE
Fix AppcuesExperienceDelegate for embeds

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -96,7 +96,7 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
 
     func containerWillAppear() {
         switch state {
-        case let .beginningStep(_, _, package, isFirst) where isFirst && package.wrapperController.isBeingPresented:
+        case let .beginningStep(_, _, package, isFirst) where isFirst && package.wrapperController.isAppearing:
             experienceWillAppear()
         default:
             break
@@ -105,7 +105,7 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
 
     func containerDidAppear() {
         switch state {
-        case let .beginningStep(_, _, package, isFirst) where isFirst && package.wrapperController.isBeingPresented:
+        case let .beginningStep(_, _, package, isFirst) where isFirst && package.wrapperController.isAppearing:
             experienceDidAppear()
         default:
             break
@@ -116,8 +116,7 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
         switch state {
         case .endingExperience:
             experienceWillDisappear()
-        case let .renderingStep(_, _, package, _)
-            where package.wrapperController.isBeingDismissed || package.wrapperController.isMovingFromParent:
+        case let .renderingStep(_, _, package, _) where package.wrapperController.isDisappearing:
             experienceWillDisappear()
         default:
             break
@@ -128,8 +127,7 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
         switch state {
         case .endingExperience:
             experienceDidDisappear()
-        case let .renderingStep(_, _, package, _)
-            where package.wrapperController.isBeingDismissed || package.wrapperController.isMovingFromParent:
+        case let .renderingStep(_, _, package, _) where package.wrapperController.isDisappearing:
             experienceDidDisappear()
             // Update state in response to UI changes that have happened already (a call to UIViewController.dismiss).
             try? transition(.endExperience(markComplete: false))
@@ -194,6 +192,11 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
         clientControllerDelegate?.experienceDidDisappear()
         clientAppcuesDelegate?.experienceDidDisappear()
     }
+}
+
+private extension UIViewController {
+    var isAppearing: Bool { isBeingPresented || isMovingToParent }
+    var isDisappearing: Bool { isBeingDismissed || isMovingFromParent }
 }
 
 // MARK: - State Machine Types

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -106,7 +106,8 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
             isHidden = true
             parentViewController?.unembedChildViewController(experienceController)
             configureConstraints(isEmpty: true)
-            completion?()
+            // Complete async so that experienceController.viewDidDisappear gets called before the state machine moves to .idling
+            DispatchQueue.main.async { completion?() }
         case .fade:
             UIView.animate(
                 withDuration: 0.3,
@@ -117,7 +118,8 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
                     self.isHidden = true
                     self.parentViewController?.unembedChildViewController(experienceController)
                     self.configureConstraints(isEmpty: true)
-                    completion?()
+                    // Complete async so that experienceController.viewDidDisappear gets called before the state machine moves to .idling
+                    DispatchQueue.main.async { completion?() }
                 }
             )
         }


### PR DESCRIPTION
Only `experienceWillDisappear()` was working properly.

`experienceWillAppear()` and `experienceDidAppear()` weren't being called because we were only checking `isBeingPresented` (which works for modals/tooltips) and not also `isMovingToParent`. I cleaned all the checks up with a simpler extension.

`experienceDidDisappear()` wasn't working because the state machine reaches the `.idling` state before `containerDidDisappear` gets called. This is essentially because the `completion()` for the dismisser of the embed gets called too early. There's nothing logically wrong with where it's called, but `DispatchQueue.main.async` fixes it. Alternatively, I could've added a case for `.idling` in `containerDidDisappear` but that could have wider ranging side effects an would be specific to embeds, which is the sort of code we've tried to avoid in the state machine.