### PR TITLE
Add AppcuesPresentationDelegate with experience metadata

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -71,7 +71,11 @@ public class Appcues: NSObject {
     private lazy var notificationCenter = container.resolve(NotificationCenter.self)
 
     /// The delegate object that manages and observes experience presentations.
+    /// Using ``presentationDelegate`` is preferred because it provides additional context about the experience being  presented.
     @objc public weak var experienceDelegate: AppcuesExperienceDelegate?
+
+    /// The delegate object that manages and observes experience presentations.
+    @objc public weak var presentationDelegate: AppcuesPresentationDelegate?
 
     /// The delegate object that observes published analytics events.
     @objc public weak var analyticsDelegate: AppcuesAnalyticsDelegate?

--- a/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
@@ -33,6 +33,8 @@ A Swift library for sending user properties and events to the Appcues API and re
 
 ### Managing Experiences
 
+- ``AppcuesPresentationDelegate``
+- ``AppcuesPresentationMetadata``
 - ``AppcuesExperienceDelegate``
 
 ### Observing Analytics

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -25,6 +25,15 @@ internal enum RenderContext: Hashable, CustomStringConvertible {
     case modal
     case embed(frameID: String)
 
+    var id: String {
+        switch self {
+        case .modal:
+            return "modal"
+        case .embed(let frameID):
+            return frameID
+        }
+    }
+
     var description: String {
         switch self {
         case .modal:
@@ -194,6 +203,7 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         }
 
         analyticsObserver.trackErrorRecovery(ifErrorOn: experience)
+        stateMachine.clientAppcuesPresentationDelegate = appcues?.presentationDelegate
         stateMachine.clientAppcuesDelegate = appcues?.experienceDelegate
         stateMachine.transitionAndObserve(.startExperience(experience), filter: experience.instanceID) { result in
             switch result {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -25,6 +25,7 @@ internal class ExperienceStateMachine {
     }
 
     weak var clientAppcuesPresentationDelegate: AppcuesPresentationDelegate?
+    weak var clientControllerPresentationDelegate: AppcuesPresentationDelegate?
 
     weak var clientAppcuesDelegate: AppcuesExperienceDelegate?
     weak var clientControllerDelegate: AppcuesExperienceDelegate?
@@ -172,6 +173,10 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
             return false
         }
 
+        if let delegate = clientControllerPresentationDelegate, !delegate.canDisplayExperience(metadata: experience.delegateMetadata()) {
+            return false
+        }
+
         if let delegate = clientAppcuesPresentationDelegate, !delegate.canDisplayExperience(metadata: experience.delegateMetadata()) {
             return false
         }
@@ -182,24 +187,28 @@ extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
     private func experienceWillAppear(experience: ExperienceData) {
         clientControllerDelegate?.experienceWillAppear()
         clientAppcuesDelegate?.experienceWillAppear()
+        clientControllerPresentationDelegate?.experienceWillAppear(metadata: experience.delegateMetadata())
         clientAppcuesPresentationDelegate?.experienceWillAppear(metadata: experience.delegateMetadata())
     }
 
     private func experienceDidAppear(experience: ExperienceData) {
         clientControllerDelegate?.experienceDidAppear()
         clientAppcuesDelegate?.experienceDidAppear()
+        clientControllerPresentationDelegate?.experienceDidAppear(metadata: experience.delegateMetadata())
         clientAppcuesPresentationDelegate?.experienceDidAppear(metadata: experience.delegateMetadata())
     }
 
     private func experienceWillDisappear(experience: ExperienceData) {
         clientControllerDelegate?.experienceWillDisappear()
         clientAppcuesDelegate?.experienceWillDisappear()
+        clientControllerPresentationDelegate?.experienceWillDisappear(metadata: experience.delegateMetadata())
         clientAppcuesPresentationDelegate?.experienceWillDisappear(metadata: experience.delegateMetadata())
     }
 
     private func experienceDidDisappear(experience: ExperienceData) {
         clientControllerDelegate?.experienceDidDisappear()
         clientAppcuesDelegate?.experienceDidDisappear()
+        clientControllerPresentationDelegate?.experienceDidDisappear(metadata: experience.delegateMetadata())
         clientAppcuesPresentationDelegate?.experienceDidDisappear(metadata: experience.delegateMetadata())
     }
 }

--- a/Sources/AppcuesKit/Presentation/Public/AppcuesExperienceDelegate.swift
+++ b/Sources/AppcuesKit/Presentation/Public/AppcuesExperienceDelegate.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// A set of methods that allow you to control and respond to Appcues experiences being displayed changes in your app.
+/// Using ``AppcuesPresentationDelegate`` is preferred because it provides additional context about the experience being  presented.
 @objc
 public protocol AppcuesExperienceDelegate: AnyObject {
     /// Asks the delegate for permission to display the Appcues experience.

--- a/Sources/AppcuesKit/Presentation/Public/AppcuesPresentationDelegate.swift
+++ b/Sources/AppcuesKit/Presentation/Public/AppcuesPresentationDelegate.swift
@@ -1,0 +1,54 @@
+//
+//  AppcuesPresentationDelegate.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-03-04.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import Foundation
+
+/// Metadata information for experiences in ``AppcuesPresentationDelegate``.
+@objc
+public class AppcuesPresentationMetadata: NSObject {
+    /// Appcues ID of the experience.
+    public let id: String
+
+    /// Name of the experience.
+    public let name: String
+
+    /// Context of the experience.
+    ///
+    /// Either `"modal"` or the `frameID` of an ``AppcuesFrame``.
+    public let renderContext: String
+
+    internal init(id: String, name: String, renderContext: String) {
+        self.id = id
+        self.name = name
+        self.renderContext = renderContext
+    }
+}
+
+/// A set of methods that allow you to control and respond to Appcues experiences being displayed changes in your app.
+@objc
+public protocol AppcuesPresentationDelegate: AnyObject {
+    /// Asks the delegate for permission to display the Appcues experience.
+    /// - Returns: `true` to allow the SDK to display the experience, `false` to refuse the presentation.
+    func canDisplayExperience(metadata: AppcuesPresentationMetadata) -> Bool
+
+    /// Notifies the delegate before an Appcues experience is presented.
+    /// - Parameter metadata: Dictionary containing metadata about the experience.
+    func experienceWillAppear(metadata: AppcuesPresentationMetadata)
+
+    /// Notifies the delegate after an Appcues experience is presented.
+    /// - Parameter metadata: Dictionary containing metadata about the experience.
+    func experienceDidAppear(metadata: AppcuesPresentationMetadata)
+
+    /// Notifies the delegate before an Appcues experience is dismissed.
+    /// - Parameter metadata: Dictionary containing metadata about the experience.
+    func experienceWillDisappear(metadata: AppcuesPresentationMetadata)
+
+    /// Notifies the delegate after an Appcues experience is dismissed.
+    /// - Parameter metadata: Dictionary containing metadata about the experience.
+    func experienceDidDisappear(metadata: AppcuesPresentationMetadata)
+}

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -16,6 +16,24 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
         case fade
     }
 
+    /// The delegate object that manages and observes presentations in this embed frame.
+    public weak var presentationDelegate: AppcuesPresentationDelegate? {
+        get {
+            if #available(iOS 13.0, *) {
+                return stateMachine?.clientControllerPresentationDelegate
+            } else {
+                return nil
+            }
+        }
+        set {
+            if #available(iOS 13.0, *) {
+                stateMachine?.clientControllerPresentationDelegate = newValue
+            } else {
+                // no-op
+            }
+        }
+    }
+
     // Managed by the StateMachineDirectory
     internal var renderContext: RenderContext?
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -57,6 +57,14 @@ internal class ExperienceData {
         return state(for: stepID)
     }
 
+    func delegateMetadata() -> AppcuesPresentationMetadata {
+        AppcuesPresentationMetadata(
+            id: model.id.appcuesFormatted,
+            name: model.name,
+            renderContext: model.renderContext.id
+        )
+    }
+
     subscript<T>(dynamicMember keyPath: KeyPath<Experience, T>) -> T {
         return model[keyPath: keyPath]
     }

--- a/Tests/AppcuesKitTests/AppcuesPresentationDelegateTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesPresentationDelegateTests.swift
@@ -1,0 +1,126 @@
+//
+//  AppcuesPresentationDelegateTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2024-03-04.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+@available(iOS 13.0, *)
+final class AppcuesPresentationDelegateTests: XCTestCase {
+
+    var appcues: MockAppcues!
+
+    override func setUpWithError() throws {
+        appcues = MockAppcues()
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testDelegateAppear() throws {
+        // Arrange
+        let delegate = MockAppcuesPresentationDelegate()
+        let experience = ExperienceData.mockEmbed(frameID: "some-frame", trigger: .qualification(reason: .screenView))
+        let package = experience.package(onPresent: {}, onDismiss: {})
+        let stateMachine = ExperienceStateMachine(
+            container: appcues.container,
+            initialState: .beginningStep(experience, .initial, package, isFirst: true)
+        )
+        let view = AppcuesFrameView()
+        view.stateMachine = stateMachine
+        package.containerController.eventHandler = stateMachine
+
+        let willAppearExpectation = expectation(description: "experienceWillAppear called")
+        delegate.experienceWillAppear = { metadata in
+            XCTAssertEqual(metadata.id, "54b7ec71-cdaf-4697-affa-f3abd672b3cf")
+            XCTAssertEqual(metadata.name, "Mock embedded experience")
+            XCTAssertEqual(metadata.renderContext, "some-frame")
+            willAppearExpectation.fulfill()
+        }
+
+        let didAppearExpectation = expectation(description: "experienceDidAppear called")
+        delegate.experienceDidAppear = { metadata in
+            XCTAssertEqual(metadata.id, "54b7ec71-cdaf-4697-affa-f3abd672b3cf")
+            XCTAssertEqual(metadata.name, "Mock embedded experience")
+            XCTAssertEqual(metadata.renderContext, "some-frame")
+            didAppearExpectation.fulfill()
+        }
+
+        view.presentationDelegate = delegate
+
+        // Act
+        try package.presenter({})
+
+        // Assert
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testDelegateDisappear() throws {
+        // Arrange
+        let delegate = MockAppcuesPresentationDelegate()
+        let experience = ExperienceData.mockEmbed(frameID: "some-frame", trigger: .qualification(reason: .screenView))
+        let package = experience.package(onPresent: {}, onDismiss: {})
+        let stateMachine = ExperienceStateMachine(
+            container: appcues.container,
+            initialState: .endingExperience(experience, .initial, markComplete: true)
+        )
+        let view = AppcuesFrameView()
+        view.stateMachine = stateMachine
+        package.containerController.eventHandler = stateMachine
+
+        let willDisappearExpectation = expectation(description: "experienceWillDisappear called")
+        delegate.experienceWillDisappear = { metadata in
+            XCTAssertEqual(metadata.id, "54b7ec71-cdaf-4697-affa-f3abd672b3cf")
+            XCTAssertEqual(metadata.name, "Mock embedded experience")
+            XCTAssertEqual(metadata.renderContext, "some-frame")
+            willDisappearExpectation.fulfill()
+        }
+
+        let didDisappearExpectation = expectation(description: "experienceDidDisappear called")
+        delegate.experienceDidDisappear = { metadata in
+            XCTAssertEqual(metadata.id, "54b7ec71-cdaf-4697-affa-f3abd672b3cf")
+            XCTAssertEqual(metadata.name, "Mock embedded experience")
+            XCTAssertEqual(metadata.renderContext, "some-frame")
+            didDisappearExpectation.fulfill()
+        }
+
+        view.presentationDelegate = delegate
+
+        // Act
+        package.dismisser({})
+
+        // Assert
+        waitForExpectations(timeout: 1.0)
+    }
+}
+
+private class MockAppcuesPresentationDelegate: AppcuesPresentationDelegate {
+    func canDisplayExperience(metadata: AppcuesPresentationMetadata) -> Bool {
+        true
+    }
+
+    var experienceWillAppear: ((AppcuesPresentationMetadata) -> Void)?
+    func experienceWillAppear(metadata: AppcuesPresentationMetadata) {
+        experienceWillAppear?(metadata)
+    }
+
+    var experienceDidAppear: ((AppcuesPresentationMetadata) -> Void)?
+    func experienceDidAppear(metadata: AppcuesPresentationMetadata) {
+        experienceDidAppear?(metadata)
+    }
+
+    var experienceWillDisappear: ((AppcuesPresentationMetadata) -> Void)?
+    func experienceWillDisappear(metadata: AppcuesPresentationMetadata) {
+        experienceWillDisappear?(metadata)
+    }
+
+    var experienceDidDisappear: ((AppcuesPresentationMetadata) -> Void)?
+    func experienceDidDisappear(metadata: AppcuesPresentationMetadata) {
+        experienceDidDisappear?(metadata)
+    }
+}

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -35,6 +35,9 @@ class PublicAPITests: XCTestCase {
 
         let appcuesInstance = Appcues(config: config)
 
+        let presentationDelegate = SamplePresentationDelegate()
+        appcuesInstance.presentationDelegate = presentationDelegate
+
         let experienceDelegate = SampleExperienceDelegate()
         appcuesInstance.experienceDelegate = experienceDelegate
 
@@ -80,6 +83,7 @@ class PublicAPITests: XCTestCase {
 
         let frameView = AppcuesFrameView(frame: .zero)
         appcuesInstance.register(frameID: "frame1", for: frameView, on: UIViewController())
+        frameView.presentationDelegate = presentationDelegate
 
         if #available(iOS 13.0, *) {
             let frame = AppcuesFrame(appcues: appcuesInstance, frameID: "frame1")
@@ -111,6 +115,30 @@ class SampleElementTargeting: AppcuesElementTargeting {
 
     func inflateSelector(from properties: [String : String]) -> AppcuesElementSelector? {
         return AppcuesElementSelector()
+    }
+}
+
+class SamplePresentationDelegate: AppcuesPresentationDelegate {
+    func canDisplayExperience(metadata: AppcuesPresentationMetadata) -> Bool {
+        true
+    }
+    
+    func experienceWillAppear(metadata: AppcuesPresentationMetadata) {
+        let id = metadata.id
+        let name = metadata.name
+        let renderContext = metadata.renderContext
+    }
+    
+    func experienceDidAppear(metadata: AppcuesPresentationMetadata) {
+        // no-op
+    }
+    
+    func experienceWillDisappear(metadata: AppcuesPresentationMetadata) {
+        // no-op
+    }
+    
+    func experienceDidDisappear(metadata: AppcuesPresentationMetadata) {
+        // no-op
     }
 }
 


### PR DESCRIPTION
## Background

We provide `AppcuesExperienceDelegate` to allow apps visibility into when the presentation lifecycle of Appcues experiences. This protocol was designed before embeds (and therefore multiple render contexts) and so is no longer particularly useful for an app with multiple embed frames in addition to modals/tooltips.

## Change

I've created `AppcuesPresentationDelegate` that contains the same functions, but with a `metadata` value that provides a dictionary with `id`, `name`, and `renderContext` (`"modal" or $frameName`) to provide more clarity into what experience is triggering the presentation lifecycle methods.

## Frame delegate

I've also added `presentationDelegate` as a property on `AppcuesFrameView`. It functions exactly the same way, but is scoped to only experiences rendering in the specific frame. This doesn't really provide any new functionality since the `metadata["renderContext"]` from the global `Appcues.presentationDelegate` would allow you to filter, but it creates a better developer experience because each frame view can have its own delegate logic that can be implemented close to the UI code for the frame itself instead of once globally.

## Notes

1. For the sake of backwards compatibility, `AppcuesExperienceDelegate` remains untouched, so `AppcuesPresentationDelegate` is solely additive. We can remove `AppcuesExperienceDelegate` in SDK v4 if we so choose. I've updated the docs to indicate using `presentationDelegate` is to be preferred over `experienceDelegate`.
2. Having `AppcuesPresentationDelegate` be objc compatible creates some limitations, so `AppcuesPresentationMetadata` has to be a class instead of the struct which would be preferred.
3. `AppcuesPresentationMetadata` can be enhanced in the future with additional values if we see a need. Note that removing/renaming a value would be a breaking change. 