### PR TITLE
Configure cocoapods example app for push

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.entitlements
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:appcues-mobile-links.netlify.app</string>

--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -9,8 +9,8 @@
 /* Begin PBXBuildFile section */
 		0384A2A89074FC193A107EE5 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663BEDD1883CC408AA4A302 /* SignInViewController.swift */; };
 		04F09F9C75FB66578541D199 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */; };
+		0CE027441C6FE1868C572FAA /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 130EC7251F0D51E83084248A /* Pods_AppcuesCocoapodsExample.framework */; };
 		160BF92965F22C6957DEB27C /* Mulish-Italic-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */; };
-		2087585EFEA8F091F6D2309A /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E4AF7320FDDF83D37C2E76 /* Pods_AppcuesCocoapodsExample.framework */; };
 		3EADA9762D050C3E2ED69514 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */; };
 		40A181AE1ED5DE1982FA05CC /* Mulish-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */; };
 		622C6559F57A6A19F18D46C4 /* EmbedTestHarnessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */; };
@@ -22,6 +22,7 @@
 		A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C713E67205D9507CE2DC80 /* AppDelegate.swift */; };
 		A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */; };
 		B62E50722A74862AEBD2DE44 /* ScrollingTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F518475589397A213D89DA /* ScrollingTableViewController.swift */; };
+		C97A0E802B98D9CA006CDB92 /* AppDelegate+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97A0E7F2B98D9CA006CDB92 /* AppDelegate+Push.swift */; };
 		CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384497BA35A275E793B475C1 /* ProfileViewController.swift */; };
 		CD156254F042866368E77CC3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 024025AF9E2E0D38C368A6AC /* Main.storyboard */; };
 		DBE453F2B40A01B4818CB84E /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */; };
@@ -29,11 +30,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		03E4AF7320FDDF83D37C2E76 /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		036D9A59B92D5291BA9BB1D0 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		130EC7251F0D51E83084248A /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2EB510103FC4B601D92CF7A3 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		384497BA35A275E793B475C1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedViewController.swift; sourceTree = "<group>"; };
 		547A647EB6D311E97F592C7C /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
@@ -41,43 +44,34 @@
 		5DC2B62290580560D162A8E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		82DED1437C1DA54F0C231566 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8663BEDD1883CC408AA4A302 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
-		87FC50CF2CB761EE130CB3EE /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedTestHarnessViewController.swift; sourceTree = "<group>"; };
 		9CB61619365785F4544ED13D /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		9D26E6136C6539597C9E50A9 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
+		A05A73A257DA52CCE18DDC73 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Main.strings"; sourceTree = "<group>"; };
 		A3F518475589397A213D89DA /* ScrollingTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingTableViewController.swift; sourceTree = "<group>"; };
+		AA113FA372FB904082730474 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		AAD7ED9DCA5972361B3F5E67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
-		C955845E2B4F322F00371B62 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
-		C955845F2B4F323000371B62 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
-		C95584602B4F323500371B62 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
-		C95584612B4F323500371B62 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Main.strings"; sourceTree = "<group>"; };
+		C97A0E7F2B98D9CA006CDB92 /* AppDelegate+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Push.swift"; sourceTree = "<group>"; };
 		CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-VariableFont_wght.ttf"; sourceTree = "<group>"; };
+		CFDBB85EB221CD35EEEFA497 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		D2C0EC54920737EBD7E2961F /* AppcuesCocoapodsExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AppcuesCocoapodsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
-		EE90B470F9EABE920F7EF5EC /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
+		D6FA0A31EF53A9C9A764BE5C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		4A946992014BEB023C4C02C2 /* Frameworks */ = {
+		299D3BB2B4606C447181C0B9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2087585EFEA8F091F6D2309A /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
+				0CE027441C6FE1868C572FAA /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0025B691E7DF28D9804CD55E /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				03E4AF7320FDDF83D37C2E76 /* Pods_AppcuesCocoapodsExample.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		3271BCB89D21367EC1AA9069 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -95,6 +89,7 @@
 			children = (
 				3271BCB89D21367EC1AA9069 /* Fonts */,
 				10C713E67205D9507CE2DC80 /* AppDelegate.swift */,
+				C97A0E7F2B98D9CA006CDB92 /* AppDelegate+Push.swift */,
 				2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */,
 				5548F50894583A174A85628C /* DeepLinkNavigator.swift */,
 				97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */,
@@ -112,15 +107,6 @@
 			path = CocoapodsExample;
 			sourceTree = "<group>";
 		};
-		A7B9B8A779F85655E6075E79 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				EE90B470F9EABE920F7EF5EC /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
-				87FC50CF2CB761EE130CB3EE /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
-			);
-			path = Pods;
-			sourceTree = "<group>";
-		};
 		C743E51709EACC21B03B3A23 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -134,9 +120,26 @@
 			children = (
 				8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */,
 				C743E51709EACC21B03B3A23 /* Products */,
-				A7B9B8A779F85655E6075E79 /* Pods */,
-				0025B691E7DF28D9804CD55E /* Frameworks */,
+				ECD1930C1617C2733D254AAC /* Pods */,
+				EC85483206F1134C2AE9147A /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		EC85483206F1134C2AE9147A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				130EC7251F0D51E83084248A /* Pods_AppcuesCocoapodsExample.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		ECD1930C1617C2733D254AAC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				036D9A59B92D5291BA9BB1D0 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
+				2EB510103FC4B601D92CF7A3 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -146,12 +149,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7200554C7EB6F6E4E0D35C70 /* Build configuration list for PBXNativeTarget "AppcuesCocoapodsExample" */;
 			buildPhases = (
-				126280A64491198327F9902A /* [CP] Check Pods Manifest.lock */,
+				96026C24B67028D625A9C9CF /* [CP] Check Pods Manifest.lock */,
 				39C4F25C30C2C38F00378FED /* Sources */,
 				4B41B1A9E3D52747D92B7344 /* Resources */,
 				6D4DB9FBC4445D937FD94125 /* SwiftLint */,
-				4A946992014BEB023C4C02C2 /* Frameworks */,
-				3C6DE1DA29976BDF2C8850F2 /* [CP] Embed Pods Frameworks */,
+				299D3BB2B4606C447181C0B9 /* Frameworks */,
+				1CC41CB8816825D21B41679E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -210,29 +213,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		126280A64491198327F9902A /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-AppcuesCocoapodsExample-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		3C6DE1DA29976BDF2C8850F2 /* [CP] Embed Pods Frameworks */ = {
+		1CC41CB8816825D21B41679E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -267,6 +248,28 @@
 			shellPath = /bin/sh;
 			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.50.3\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
 		};
+		96026C24B67028D625A9C9CF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-AppcuesCocoapodsExample-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -278,6 +281,7 @@
 				68E596FD295BCC69F06AF0B4 /* DeepLinkNavigator.swift in Sources */,
 				622C6559F57A6A19F18D46C4 /* EmbedTestHarnessViewController.swift in Sources */,
 				8F7329B0046118A1DFA8B58D /* EmbedViewController.swift in Sources */,
+				C97A0E802B98D9CA006CDB92 /* AppDelegate+Push.swift in Sources */,
 				EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */,
 				64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */,
 				CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */,
@@ -294,8 +298,8 @@
 			isa = PBXVariantGroup;
 			children = (
 				82DED1437C1DA54F0C231566 /* Base */,
-				C955845F2B4F323000371B62 /* fr */,
-				C95584612B4F323500371B62 /* pt-BR */,
+				D6FA0A31EF53A9C9A764BE5C /* fr */,
+				A05A73A257DA52CCE18DDC73 /* pt-BR */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -304,8 +308,8 @@
 			isa = PBXVariantGroup;
 			children = (
 				5DC2B62290580560D162A8E7 /* Base */,
-				C955845E2B4F322F00371B62 /* fr */,
-				C95584602B4F323500371B62 /* pt-BR */,
+				AA113FA372FB904082730474 /* fr */,
+				CFDBB85EB221CD35EEEFA497 /* pt-BR */,
 			);
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
@@ -315,7 +319,7 @@
 /* Begin XCBuildConfiguration section */
 		015038143918E0C7F9D7E873 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EE90B470F9EABE920F7EF5EC /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
+			baseConfigurationReference = 036D9A59B92D5291BA9BB1D0 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -398,7 +402,7 @@
 		};
 		266E5C088CC8701B4117B193 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 87FC50CF2CB761EE130CB3EE /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
+			baseConfigurationReference = 2EB510103FC4B601D92CF7A3 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate+Push.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate+Push.swift
@@ -1,0 +1,51 @@
+//
+//  AppDelegate+Push.swift
+//  AppcuesCocoapodsExample
+//
+//  Created by Matt on 2024-03-06.
+//
+
+import Foundation
+import UserNotifications
+import AppcuesKit
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    /// Call from `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`
+    func setupPush(application: UIApplication) {
+        // 1: Register to get a device token
+        application.registerForRemoteNotifications()
+
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    // 2: Pass device token to Appcues
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Appcues.shared.setPushToken(deviceToken)
+    }
+
+    // 3: Pass the user's response to a delivered notification to Appcues
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if Appcues.shared.didReceiveNotification(response: response, completionHandler: completionHandler) {
+            return
+        }
+
+        completionHandler()
+    }
+
+    // 4: Configure handling for notifications that arrive while the app is in the foreground
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .list])
+        } else {
+            completionHandler(.alert)
+        }
+    }
+}

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -17,6 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         // Override point for customization after application launch.
 
+        setupPush(application: application)
+        
         return true
     }
 

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/Info.plist
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Examples/DeveloperCocoapodsExample/Podfile.lock
+++ b/Examples/DeveloperCocoapodsExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Appcues (3.1.5)
+  - Appcues (3.1.7)
 
 DEPENDENCIES:
   - Appcues (from `../../Appcues.podspec`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../../Appcues.podspec"
 
 SPEC CHECKSUMS:
-  Appcues: 8b99f8a1acd46d4e0c6538ffa9229ab31a9e688a
+  Appcues: b97e55a9ee6c449adffedfc3778bf0ce829adda8
 
 PODFILE CHECKSUM: 7a3abcd818687cb341a5696d302103f523e3edc0
 

--- a/Examples/DeveloperCocoapodsExample/project.yml
+++ b/Examples/DeveloperCocoapodsExample/project.yml
@@ -15,6 +15,7 @@ targets:
     entitlements:
       path: AppcuesCocoapodsExample.entitlements
       properties:
+        aps-environment: development
         com.apple.developer.associated-domains:
           - applinks:appcues-mobile-links.netlify.app
     postbuildScripts:

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -33,6 +33,7 @@ internal class ActionRegistry {
         register(action: AppcuesContinueAction.self)
         register(action: AppcuesSubmitFormAction.self)
         register(action: AppcuesRequestReviewAction.self)
+        register(action: AppcuesRequestPushAction.self)
     }
 
     @discardableResult


### PR DESCRIPTION
I put as much of the push stuff in `AppDelegate+Push` as possible and tried to structure it nicely so it can function as a reference.

Result of a [test push](https://icloud.developer.apple.com/dashboard/notifications/teams/KHSQ25769M/app/com.appcues.sdk-example-cocoapods/notifications/78bb2541-9e38-4dc5-9bd8-ba12742e1ea5/environment/DEVELOPMENT/tracking/dbbbbe12-64ce-2f0a-88ff-38feed577013) from the console :tada:

<img width="661" alt="Screenshot 2024-03-06 at 12 11 34 PM" src="https://github.com/appcues/appcues-ios-sdk/assets/845681/b5b9fe92-a25c-481a-b386-297b9c5a77df">
