### PR TITLE
Add push install verification to debugger

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -358,6 +358,7 @@ public class Appcues: NSObject {
         container.registerLazy(PushMonitoring.self, initializer: PushMonitor.init)
 
         if #available(iOS 13.0, *) {
+            container.registerLazy(PushVerifier.self, initializer: PushVerifier.init)
             container.registerLazy(DeepLinkHandling.self, initializer: DeepLinkHandler.init)
             container.registerLazy(UIDebugging.self, initializer: UIDebugger.init)
             container.registerLazy(ExperienceLoading.self, initializer: ExperienceLoader.init)

--- a/Sources/AppcuesKit/Data/Networking/Endpoint.swift
+++ b/Sources/AppcuesKit/Data/Networking/Endpoint.swift
@@ -14,6 +14,7 @@ internal enum APIEndpoint: Endpoint {
     case qualify(userID: String)
     case content(experienceID: String, queryItems: [URLQueryItem] = [])
     case preview(experienceID: String, queryItems: [URLQueryItem] = [])
+    case pushTest
     case health
 
     /// URL fragments that that are appended to the `Config.apiHost` to make the URL for a network request.
@@ -36,6 +37,8 @@ internal enum APIEndpoint: Endpoint {
                 components.path = "/v1/accounts/\(config.accountID)/users/\(storage.userID)/experience_preview/\(experienceID)"
             }
             components.queryItems = queryItems
+        case .pushTest:
+            components.path = "/v1/accounts/\(config.accountID)/push_notification_test"
         case .health:
             components.path = "/healthz"
         }

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -31,12 +31,21 @@ internal class DebugViewController: UIViewController {
     let logger: DebugLogger
     let apiVerifier: APIVerifier
     let deepLinkVerifier: DeepLinkVerifier
+    let pushVerifier: PushVerifier
 
-    init(viewModel: DebugViewModel, logger: DebugLogger, apiVerifier: APIVerifier, deepLinkVerifier: DeepLinkVerifier, mode: DebugMode) {
+    init(
+        viewModel: DebugViewModel,
+        logger: DebugLogger,
+        apiVerifier: APIVerifier,
+        deepLinkVerifier: DeepLinkVerifier,
+        pushVerifier: PushVerifier,
+        mode: DebugMode
+    ) {
         self.viewModel = viewModel
         self.logger = logger
         self.apiVerifier = apiVerifier
         self.deepLinkVerifier = deepLinkVerifier
+        self.pushVerifier = pushVerifier
         self.mode = mode
         super.init(nibName: nil, bundle: nil)
     }
@@ -67,6 +76,7 @@ internal class DebugViewController: UIViewController {
             let viewController = UIHostingController(rootView: DebugUI.MainPanelView(
                 apiVerifier: apiVerifier,
                 deepLinkVerifier: deepLinkVerifier,
+                pushVerifier: pushVerifier,
                 viewModel: viewModel
             ).environmentObject(logger))
             addChild(viewController)

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -14,6 +14,7 @@ internal enum DebugUI {
     struct MainPanelView: View {
         let apiVerifier: APIVerifier
         let deepLinkVerifier: DeepLinkVerifier
+        let pushVerifier: PushVerifier
 
         @ObservedObject var viewModel: DebugViewModel
 
@@ -23,6 +24,7 @@ internal enum DebugUI {
                 InstalledRow(accountID: viewModel.accountID, applicationID: viewModel.applicationID)
                 ConnectedRow(apiVerifier: apiVerifier)
                 DeepLinkRow(deepLinkVerifier: deepLinkVerifier)
+                PushRow(pushVerifier: pushVerifier)
                 ScreensRow(isTrackingScreens: viewModel.trackingPages)
                 UserRow(currentUserID: viewModel.currentUserID, isAnonymous: viewModel.isAnonymous)
                 GroupRow(currentGroupID: viewModel.currentGroupID)
@@ -139,6 +141,26 @@ internal enum DebugUI {
                 .foregroundColor(.secondary)
             }
             .onReceive(deepLinkVerifier.publisher) {
+                statusItem = $0
+            }
+        }
+    }
+
+    struct PushRow: View {
+        let pushVerifier: PushVerifier
+
+        @State var statusItem = StatusItem(status: .pending, title: "Push Notifications Configured")
+
+        var body: some View {
+            ListItemRowView(item: statusItem) {
+                Button {
+                    pushVerifier.verifyPush()
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath").imageScale(.small)
+                }
+                .foregroundColor(.secondary)
+            }
+            .onReceive(pushVerifier.publisher) {
                 statusItem = $0
             }
         }

--- a/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
@@ -1,0 +1,224 @@
+//
+//  PushVerifier.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-03-08.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+@available(iOS 13.0, *)
+internal class PushVerifier {
+    enum ErrorMessage: CustomStringConvertible {
+        case noToken
+        case notAuthorized
+        case permissionDenied
+        case unexpectedStatus
+        case noNotificationDelegate
+        case noReceiveHandler
+        case multipleCompletions
+        case noSDKResponse
+
+        // Verification flow errors
+        case tokenMismatch
+        case responseInitFail
+
+        var description: String {
+            switch self {
+            case .noToken:
+                return "Error 1: No push token registered with Appcues"
+            case .notAuthorized:
+                return "Error 2: Notification permissions not requested"
+            case .permissionDenied:
+                return "Error 3: Notification permissions denied"
+            case .unexpectedStatus:
+                return "Error 4: Unexpected notification permission status"
+            case .noNotificationDelegate:
+                return "Error 5: Notification delegate is not set"
+            case .noReceiveHandler:
+                return "Error 6: Receive handler not implemented"
+            case .multipleCompletions:
+                return "Error 7: Receive completion called too many times"
+            case .noSDKResponse:
+                return "Error 8: Receive response not passed to SDK"
+            case .tokenMismatch:
+                return "Error 10: Unexpected result"
+            case .responseInitFail:
+                return "Error 11: Unexpected result"
+            }
+        }
+    }
+
+    static let title = "Push Notifications Configured"
+
+    private let config: Appcues.Config
+    private let storage: DataStoring
+    private let networking: Networking
+    private let pushMonitor: PushMonitoring
+
+    /// Unique value to pass through a deep link to verify handling.
+    private var pushVerificationToken: String?
+
+    private var errors: [ErrorMessage] = [] {
+        didSet {
+            if !errors.isEmpty {
+                subject.send(
+                    StatusItem(status: .unverified, title: PushVerifier.title, subtitle: errors.map(\.description).joined(separator: "\n"))
+                )
+            }
+        }
+    }
+
+    private let subject = PassthroughSubject<StatusItem, Never>()
+    var publisher: AnyPublisher<StatusItem, Never> { subject.eraseToAnyPublisher() }
+
+    init(container: DIContainer) {
+        self.config = container.resolve(Appcues.Config.self)
+        self.storage = container.resolve(DataStoring.self)
+        self.networking = container.resolve(Networking.self)
+        self.pushMonitor = container.resolve(PushMonitoring.self)
+    }
+
+    func verifyPush(token: UUID = UUID()) {
+        subject.send(StatusItem(status: .pending, title: PushVerifier.title, subtitle: nil))
+
+        // If the previous verification attempt errored because notification permissions haven't been requested,
+        // request them before trying again.
+        if errors.contains(.notAuthorized) {
+            errors = []
+            requestPush()
+            return
+        }
+
+        errors = []
+
+        verifyDeviceConfiguration()
+        verifyClientImplementation(token: token.uuidString)
+    }
+
+    func receivedVerification(token: String) {
+        if token == pushVerificationToken {
+            verifyServerComponents(token: token)
+        } else {
+            errors.append(.tokenMismatch)
+        }
+
+        pushVerificationToken = nil
+    }
+
+    private func requestPush() {
+        let options: UNAuthorizationOptions = [.alert, .sound, .badge]
+        UNUserNotificationCenter.current().requestAuthorization(options: options) { _, _ in
+            self.pushMonitor.refreshPushStatus { _ in
+                DispatchQueue.main.async {
+                    self.verifyPush()
+                }
+            }
+        }
+    }
+
+    private func verifyDeviceConfiguration() {
+        if storage.pushToken == nil {
+            errors.append(.noToken)
+        }
+
+        switch pushMonitor.pushAuthorizationStatus {
+        case .notDetermined, .provisional:
+            errors.append(.notAuthorized)
+        case .denied:
+            errors.append(.permissionDenied)
+        case .authorized:
+            break
+        case .ephemeral:
+            fallthrough
+        @unknown default:
+            errors.append(.unexpectedStatus)
+        }
+    }
+
+    private func verifyClientImplementation(token: String) {
+        let notificationCenter = UNUserNotificationCenter.current()
+        guard let notificationDelegate = notificationCenter.delegate else {
+            errors.append(.noNotificationDelegate)
+            return
+        }
+
+        guard let receiveHandler = notificationDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:) else {
+            errors.append(.noReceiveHandler)
+            return
+        }
+
+        guard let mockResponse = UNNotificationResponse.mock(token: token) else {
+            errors.append(.responseInitFail)
+            return
+        }
+
+        pushVerificationToken = token
+        var completionCount = 0
+        receiveHandler(notificationCenter, mockResponse) { [weak self] in
+            completionCount += 1
+            if completionCount > 1 {
+                self?.errors.append(.multipleCompletions)
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            // in a valid implementation pushVerificationToken will be nil by now
+            // from receivedVerification(token:) being called from PushMonitor
+            if self.pushVerificationToken != nil {
+                self.errors.append(.noSDKResponse)
+                self.pushVerificationToken = nil
+            }
+        }
+    }
+
+    private func verifyServerComponents(token: String) {
+        // TODO: trigger remote call to verify E2E
+        if errors.isEmpty {
+            subject.send(StatusItem(status: .verified, title: PushVerifier.title))
+        }
+    }
+}
+
+private extension UNNotificationResponse {
+    final class KeyedArchiver: NSKeyedArchiver {
+        override func decodeObject(forKey _: String) -> Any { "" }
+
+        deinit {
+            // Avoid a console warning
+            finishEncoding()
+        }
+    }
+
+    static func mock(
+        token: String,
+        actionIdentifier: String = UNNotificationDefaultActionIdentifier
+    ) -> UNNotificationResponse? {
+        guard let response = UNNotificationResponse(coder: KeyedArchiver()),
+              let notification = UNNotification(coder: KeyedArchiver()) else {
+            return nil
+        }
+
+        let content = UNMutableNotificationContent()
+        content.userInfo = [
+            "_appcues_internal": true,
+            "appcues_account_id": "",
+            "appcues_user_id": "",
+            "appcues_notification_id": token
+        ]
+
+        let request = UNNotificationRequest(
+            identifier: "",
+            content: content,
+            trigger: nil
+        )
+        notification.setValue(request, forKey: "request")
+
+        response.setValue(notification, forKey: "notification")
+        response.setValue(actionIdentifier, forKey: "actionIdentifier")
+
+        return response
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -54,6 +54,7 @@ internal class UIDebugger: UIDebugging {
     private let notificationCenter: NotificationCenter
     private let analyticsPublisher: AnalyticsPublishing
     private let networking: Networking
+    private let pushVerifier: PushVerifier
 
     private let subject = PassthroughSubject<LoggedEvent, Never>()
     var eventPublisher: AnyPublisher<LoggedEvent, Never> { subject.eraseToAnyPublisher() }
@@ -69,6 +70,7 @@ internal class UIDebugger: UIDebugging {
         self.analyticsPublisher = container.resolve(AnalyticsPublishing.self)
         self.notificationCenter = container.resolve(NotificationCenter.self)
         self.networking = container.resolve(Networking.self)
+        self.pushVerifier = container.resolve(PushVerifier.self)
 
         self.screenCapturer = ScreenCapturer(
             config: config,
@@ -121,6 +123,7 @@ internal class UIDebugger: UIDebugging {
             logger: debugLogger,
             apiVerifier: APIVerifier(networking: networking),
             deepLinkVerifier: DeepLinkVerifier(applicationID: config.applicationID),
+            pushVerifier: pushVerifier,
             mode: mode
         )
         rootViewController.delegate = self

--- a/Sources/AppcuesKit/Push/ParsedNotification.swift
+++ b/Sources/AppcuesKit/Push/ParsedNotification.swift
@@ -20,6 +20,7 @@ internal struct ParsedNotification {
     let attachmentURL: URL?
     let attachmentType: String?
     let isTest: Bool
+    let isInternal: Bool
 
     init?(userInfo: [AnyHashable: Any]) {
         guard let accountID = userInfo["appcues_account_id"] as? String,
@@ -42,5 +43,6 @@ internal struct ParsedNotification {
             .flatMap { URL(string: $0) }
         self.attachmentType = userInfo["appcues_attachment_type"] as? String
         self.isTest = userInfo["appcues_test"] as? Bool ?? false
+        self.isInternal = userInfo["_appcues_internal"] as? Bool ?? false
     }
 }

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -374,10 +374,11 @@ class MockPushMonitor: PushMonitoring {
     var pushBackgroundEnabled: Bool = false
     var pushPrimerEligible: Bool = false
 
+    var pushAuthorizationStatus: UNAuthorizationStatus = .notDetermined
     var onRefreshPushStatus: (() -> Void)?
     func refreshPushStatus(completion: ((UNAuthorizationStatus) -> Void)?) {
         onRefreshPushStatus?()
-        completion?(.notDetermined)
+        completion?(pushAuthorizationStatus)
     }
 
     var onDidReceiveNotification: (([AnyHashable: Any]) -> Bool)?


### PR DESCRIPTION
I've been able to create a surprisingly full-featured push verification system for the debugger. And once we hook it up to the send test push API that can return some backend diagnostics, we should be able to provide one-tap E2E verification of an Appcues push setup.

`PushVerifier` is the doing all the heavy lifting. Since it has several dependencies and since `PushMonitor` needs to call the verifier, I've added it into the main DI container unlike `APIVerifier` and `DeepLinkVerifier`.

Overview of what's being verified (and how), corresponding to the Error numbers:

1. Verify `Appcues.setPushToken(:)` is called. I could add an additional check that `didRegisterForRemoteNotificationsWithDeviceToken` is implemented, but these are tightly coupled, so it seems like overkill. The docs (when we write them) about these errors should make it clear.
2. When the notification authorization status is `.notDetermined`. If this error occurs, if a second attempt to verify the status is made, we'll trigger the push notification permission prompt.
This is intended to be a helpful way to test quickly without having to create a permission primer flow (since we want to encourage people to create such a flow and not hardcode a permission request).
3. Push notification permission prompt was denied. User will need to use the system settings app to change the permissions.
4. `.ephemeral` (app clip only) or unknown permission status. Should never happen.
5. `UNUserNotificationCenter.current().delegate` is nil. It needs to be assigned—usually the value is the `AppDelegate. Without this value, we can't check anything else about the implementation.
Note that this check isn't 100% accurate, since iOS requires that "You must assign your delegate object to the [UNUserNotificationCenter](doc://com.apple.documentation/documentation/usernotifications/unusernotificationcenter) object before your app finishes launching." ([ref](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate)), but we're only checking it when the debugger action is triggered.
6. `userNotificationCenter(_:didReceive:withCompletionHandler:)` is not implemented. The function is an optional method of `UNUserNotificationCenterDelegate`, so we need to check it's implemented. It's required to process the user's response to a delivered notification.
7. Verifies that the completion handler in `userNotificationCenter(_:didReceive:withCompletionHandler:)` isn't called more than once. I added this because the Appcues handler calls it if the SDK handles the response, but the app might call it too. I'm not sure the consequences of multiple completions, but better safe than sorry.
8. Verify the user response is passed to `Appcues.didReceiveNotification(response:completionHandler:)`.
We generate a synthetic response object ([approach reference](https://onmyway133.com/posts/how-to-mock-unnotificationresponse-in-unit-tests)) that matches our push payload (with the addition of `_appcues_internal: true`) to call the response handler. This is super handy since it removes the need for the user to actually tap on the incoming notification to verify this part of the system.

Errors 10/11 are internal to the test loop.

Once the backend push test endpoint is implemented, we'll call that and display any diagnostics that are returned.