### PR TITLE
Add push action handler logging

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -337,8 +337,7 @@ public class Appcues: NSObject {
     }
 
     public func didReceiveNotification(response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool {
-        let userInfo = response.notification.request.content.userInfo
-        return container.resolve(PushMonitoring.self).didReceiveNotification(userInfo: userInfo, completionHandler: completionHandler)
+        return container.resolve(PushMonitoring.self).didReceiveNotification(response: response, completionHandler: completionHandler)
     }
 
     func initializeContainer() {

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
@@ -13,9 +13,16 @@ internal enum DebugLogUI {
     struct LoggerView: View {
         @EnvironmentObject var logger: DebugLogger
 
+        @State private var searchText = ""
+
+        var filteredLog: [DebugLogger.Log] {
+            guard !searchText.isEmpty else { return logger.log }
+            return logger.log.filter { $0.message.localizedCaseInsensitiveContains(searchText) }
+        }
+
         var body: some View {
             List {
-                ForEach(logger.log.suffix(20).reversed()) { log in
+                ForEach(filteredLog.suffix(20).reversed()) { log in
                     NavigationLink(destination: DetailView(log: log)) {
                         VStack(alignment: .leading) {
                             Text("\(log.level.description): \(log.timestamp.description)")
@@ -28,6 +35,7 @@ internal enum DebugLogUI {
                     }
                 }
             }
+            .searchableCompatible(text: $searchText)
             .navigationBarTitle("", displayMode: .inline)
             .navigationBarItems(trailing: ShareButton(text: logger.stringEncoded()))
         }

--- a/Sources/AppcuesKit/Push/PushMonitor.swift
+++ b/Sources/AppcuesKit/Push/PushMonitor.swift
@@ -16,8 +16,7 @@ internal protocol PushMonitoring: AnyObject {
 
     func refreshPushStatus(completion: ((UNAuthorizationStatus) -> Void)?)
 
-    // Using `userInfo` as a parameter to be able to mock notification data.
-    func didReceiveNotification(userInfo: [AnyHashable: Any], completionHandler: @escaping () -> Void) -> Bool
+    func didReceiveNotification(response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool
 }
 
 internal class PushMonitor: PushMonitoring {
@@ -76,7 +75,9 @@ internal class PushMonitor: PushMonitoring {
     }
 
     // `completionHandler` should be called iff the function returns true.
-    func didReceiveNotification(userInfo: [AnyHashable: Any], completionHandler: @escaping () -> Void) -> Bool {
+    func didReceiveNotification(response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool {
+        let userInfo = response.notification.request.content.userInfo
+
         config.logger.info("Push response received:\n%{private}@", userInfo.description)
 
         guard let parsedNotification = ParsedNotification(userInfo: userInfo) else {

--- a/Sources/AppcuesKit/Push/PushMonitor.swift
+++ b/Sources/AppcuesKit/Push/PushMonitor.swift
@@ -23,6 +23,7 @@ internal protocol PushMonitoring: AnyObject {
 internal class PushMonitor: PushMonitoring {
 
     private weak var appcues: Appcues?
+    private let config: Appcues.Config
     private let storage: DataStoring
 
     private(set) var pushAuthorizationStatus: UNAuthorizationStatus = .notDetermined
@@ -41,6 +42,7 @@ internal class PushMonitor: PushMonitoring {
 
     init(container: DIContainer) {
         self.appcues = container.owner
+        self.config = container.resolve(Appcues.Config.self)
         self.storage = container.resolve(DataStoring.self)
 
         refreshPushStatus()
@@ -75,6 +77,8 @@ internal class PushMonitor: PushMonitoring {
 
     // `completionHandler` should be called iff the function returns true.
     func didReceiveNotification(userInfo: [AnyHashable: Any], completionHandler: @escaping () -> Void) -> Bool {
+        config.logger.info("Push response received:\n%{private}@", userInfo.description)
+
         guard let parsedNotification = ParsedNotification(userInfo: userInfo) else {
             // Not an Appcues push
             return false

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -381,9 +381,9 @@ class MockPushMonitor: PushMonitoring {
         completion?(pushAuthorizationStatus)
     }
 
-    var onDidReceiveNotification: (([AnyHashable: Any]) -> Bool)?
-    func didReceiveNotification(userInfo: [AnyHashable : Any], completionHandler: @escaping () -> Void) -> Bool {
-        let result = onDidReceiveNotification?(userInfo) ?? false
+    var onDidReceiveNotification: ((UNNotificationResponse) -> Bool)?
+    func didReceiveNotification(response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool {
+        let result = onDidReceiveNotification?(response) ?? false
         if result {
             completionHandler()
         }


### PR DESCRIPTION
Also adding a basic search bar to the debug log

Edit: and now that I've figured out we can mock `UNNotificationResponse` in tests, I've updated `PushMonitor.didReceiveNotification(response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool` to take the full response object instead of just the `userInfo`. We'll need it for the `response.actionIdentifier` and other stuff in the future.

![Simulator Screenshot - iPhone 15 Pro - 2024-03-14 at 11 03 48](https://github.com/appcues/appcues-ios-sdk/assets/845681/b858c67c-d04b-494a-bd46-a1bea8869a0c)
