### PR TITLE
Send device_updated event on push status change

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestPushAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestPushAction.swift
@@ -32,14 +32,7 @@ internal class AppcuesRequestPushAction: AppcuesExperienceAction {
             }
 
             let pushMonitor = appcues.container.resolve(PushMonitoring.self)
-            let analyticsPublisher = appcues.container.resolve(AnalyticsPublishing.self)
-
-            pushMonitor.refreshPushStatus { _ in
-                analyticsPublisher.publish(TrackingUpdate(
-                    type: .event(name: Events.Device.deviceUpdated.rawValue, interactive: false),
-                    isInternal: true
-                ))
-
+            pushMonitor.refreshPushStatus(publishChange: true) { _ in
                 completion()
             }
         }

--- a/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
@@ -10,7 +10,7 @@ import UIKit
 import Combine
 
 // For mock objects
-final class KeyedArchiver: NSKeyedArchiver {
+private final class KeyedArchiver: NSKeyedArchiver {
     override func decodeObject(forKey _: String) -> Any { "" }
 
     deinit {
@@ -136,7 +136,7 @@ internal class PushVerifier {
     private func requestPush() {
         let options: UNAuthorizationOptions = [.alert, .sound, .badge]
         UNUserNotificationCenter.current().requestAuthorization(options: options) { _, _ in
-            self.pushMonitor.refreshPushStatus { _ in
+            self.pushMonitor.refreshPushStatus(publishChange: false) { _ in
                 DispatchQueue.main.async {
                     self.verifyPush()
                 }

--- a/Tests/AppcuesKitTests/Actions/AppcuesRequestPushActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesRequestPushActionTests.swift
@@ -29,20 +29,20 @@ class AppcuesRequestPushActionTests: XCTestCase {
 
     func testExecute() throws {
         // Arrange
-        var eventCount = 0
+        var refreshCount = 0
         var completionCount = 0
         let action = AppcuesRequestPushAction(appcues: appcues)
 
-        appcues.analyticsPublisher.onPublish = { update in
-            XCTAssertEqual(update.type, .event(name: Events.Device.deviceUpdated.rawValue, interactive: false))
-            eventCount += 1
+        appcues.pushMonitor.onRefreshPushStatus = { shouldPublish in
+            XCTAssertTrue(shouldPublish)
+            refreshCount += 1
         }
 
         // Act
         action?.execute(completion: { completionCount += 1 })
 
         // Assert
-        XCTAssertEqual(eventCount, 1)
+        XCTAssertEqual(refreshCount, 1)
         XCTAssertEqual(completionCount, 1)
     }
 

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -375,9 +375,9 @@ class MockPushMonitor: PushMonitoring {
     var pushPrimerEligible: Bool = false
 
     var pushAuthorizationStatus: UNAuthorizationStatus = .notDetermined
-    var onRefreshPushStatus: (() -> Void)?
-    func refreshPushStatus(completion: ((UNAuthorizationStatus) -> Void)?) {
-        onRefreshPushStatus?()
+    var onRefreshPushStatus: ((Bool) -> Void)?
+    func refreshPushStatus(publishChange: Bool, completion: ((UNAuthorizationStatus) -> Void)?) {
+        onRefreshPushStatus?(publishChange)
         completion?(pushAuthorizationStatus)
     }
 


### PR DESCRIPTION
Per [discussion](https://app.shortcut.com/appcues/story/62368/implement-appcues-device-updated-event#activity-63884), when the app is foregrounded, the push status refresh should send a `appcues:device_updated` event if the status changed.

I've moved the `appcues:device_updated` event out of the request push action and now it can be triggered with the `publishChange` argument.