### PR TITLE
Add deferred handling for push notifications received without a session

### DIFF
--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -400,6 +400,9 @@ public class Appcues: NSObject {
         storage.isAnonymous = isAnonymous
         storage.userSignature = properties?.removeValue(forKey: "appcues:user_id_signature") as? String
         analyticsPublisher.publish(TrackingUpdate(type: .profile(interactive: true), properties: properties, isInternal: false))
+
+        let pushMonitor = container.resolve(PushMonitoring.self)
+        pushMonitor.attemptDeferredNotificationResponse()
     }
 }
 

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -92,6 +92,18 @@ class AppcuesTests: XCTestCase {
         XCTAssertNil(appcues.storage.userSignature)
     }
 
+    func testIdentifyTriggersDeferredPush() throws {
+        // Arrange
+        var deferredPushAttempts = 0
+        appcues.pushMonitor.onAttemptDeferredNotificationResponse = { deferredPushAttempts += 1 }
+
+        // Act
+        appcues.identify(userID: "test-user")
+
+        // Assert
+        XCTAssertEqual(deferredPushAttempts, 1)
+    }
+
     func testReset() throws {
         // Act
         appcues.identify(userID: "test-user", properties: ["foo": 100])

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -389,4 +389,11 @@ class MockPushMonitor: PushMonitoring {
         }
         return result
     }
+
+    var onAttemptDeferredNotificationResponse: (() -> Void)?
+    func attemptDeferredNotificationResponse() -> Bool {
+        onAttemptDeferredNotificationResponse?()
+        return false
+    }
+
 }


### PR DESCRIPTION
The flow is pretty simple:

1. If we receive a push response and appcues isn't active, store the `ParsedNotification`.
2. On any `identify` call, attempt the deferred notification response.

## Notes

1. The sequence of analytics is session started, identify, push opened
2. `attemptDeferredNotificationResponse` returns a boolean which isn't currently used apart from tests. In theory it could easily have a completion handler. It's something we might need to deal with if we find the push response handling colliding with other things happening on session start or after a sign in