### PR TITLE
Determine push attachment file type using file mime type

### DIFF
--- a/Sources/AppcuesKit/Push/ParsedNotification.swift
+++ b/Sources/AppcuesKit/Push/ParsedNotification.swift
@@ -18,7 +18,6 @@ internal struct ParsedNotification {
     let deepLinkURL: URL?
     let experienceID: String?
     let attachmentURL: URL?
-    let attachmentType: String?
     let isTest: Bool
     let isInternal: Bool
 
@@ -41,7 +40,6 @@ internal struct ParsedNotification {
         self.experienceID = userInfo["appcues_experience_id"] as? String
         self.attachmentURL = (userInfo["appcues_attachment_url"] as? String)
             .flatMap { URL(string: $0) }
-        self.attachmentType = userInfo["appcues_attachment_type"] as? String
         self.isTest = userInfo["appcues_test"] != nil
         self.isInternal = userInfo["_appcues_internal"] as? Bool ?? false
     }


### PR DESCRIPTION
Removing the requirement for `appcues_attachment_type`.

`URLSession.downloadTask(with:completionHandler:)` is almost as easy as `Data(contentsOf:)`. It creates a download task that saves the results to a file which we can copy to our attachment with the mime type of the `URLResponse`. Using `UTType` means we don't need a hardcoded map of mime types to file extensions (even if the pre-ios 14 fallback is a bit ugly).
