### PR TITLE
Push debugger enhancements

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -149,7 +149,7 @@ internal enum DebugUI {
     struct PushRow: View {
         let pushVerifier: PushVerifier
 
-        @State var statusItem = StatusItem(status: .pending, title: "Push Notifications Configured")
+        @State var statusItem = StatusItem(status: .pending, title: "Push Notifications Configured", subtitle: "Tap to check configuration")
 
         var body: some View {
             ListItemRowView(item: statusItem) {

--- a/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
@@ -193,7 +193,7 @@ internal class PushVerifier {
             return
         }
 
-        guard let mockResponse = UNNotificationResponse.mock(token: token) else {
+        guard let mockResponse = UNNotificationResponse.mock(token: token, config: config) else {
             errors.append(.responseInitFail)
             return
         }
@@ -227,7 +227,7 @@ internal class PushVerifier {
             return
         }
 
-        guard let mockNotification = UNNotification.mock(token: token) else {
+        guard let mockNotification = UNNotification.mock(token: token, config: config) else {
             errors.append(.responseInitFail)
             return
         }
@@ -282,10 +282,11 @@ private extension PushVerifier {
 private extension UNNotificationResponse {
     static func mock(
         token: String,
+        config: Appcues.Config,
         actionIdentifier: String = UNNotificationDefaultActionIdentifier
     ) -> UNNotificationResponse? {
         guard let response = UNNotificationResponse(coder: KeyedArchiver()),
-              let notification = UNNotification.mock(token: token) else {
+              let notification = UNNotification.mock(token: token, config: config) else {
             return nil
         }
 
@@ -299,6 +300,7 @@ private extension UNNotificationResponse {
 private extension UNNotification {
     static func mock(
         token: String,
+        config: Appcues.Config,
         actionIdentifier: String = UNNotificationDefaultActionIdentifier
     ) -> UNNotification? {
         guard let notification = UNNotification(coder: KeyedArchiver()) else {
@@ -308,7 +310,8 @@ private extension UNNotification {
         let content = UNMutableNotificationContent()
         content.userInfo = [
             "_appcues_internal": true,
-            "appcues_account_id": "",
+            "appcues_account_id": config.accountID,
+            "appcues_app_id": config.applicationID,
             "appcues_user_id": "",
             "appcues_notification_id": token
         ]

--- a/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
@@ -46,7 +46,7 @@ internal class PushVerifier {
             case .notAuthorized:
                 return "Error 2: Notification permissions not requested"
             case .permissionDenied:
-                return "Error 3: Notification permissions denied"
+                return "Error 3: Notification permissions denied. Tap to open system settings"
             case .unexpectedStatus:
                 return "Error 4: Unexpected notification permission status"
             case .noNotificationDelegate:
@@ -114,6 +114,12 @@ internal class PushVerifier {
         if errors.contains(.notAuthorized) {
             errors = []
             requestPush()
+            return
+        }
+
+        if errors.contains(.permissionDenied), let settingsURL = URL(string: "app-settings://") {
+            errors = []
+            UIApplication.shared.open(settingsURL)
             return
         }
 


### PR DESCRIPTION
I missed that the push debugger now needs the account/app ID values set after the changes in #523.

And I saw https://github.com/appcues/appcues-android-sdk/pull/589 which made me realize we can open the app settings in the case where push permissions are denied to make it easy to unblock that issue.