### PR TITLE
Fix debugger hit test on iPad

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
@@ -25,7 +25,8 @@ internal class DebugUIWindow: UIWindow {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        guard let hitView = super.hitTest(point, with: event), hitView != self else {
+        guard let rootView = rootViewController?.view,
+              let hitView = rootView.hitTest(convert(point, to: rootView), with: event) else {
             return nil
         }
 


### PR DESCRIPTION
On iPads, the OS adds a `UIView` as a parent to the rootViewController of the window:

```
DebugUIWindow
  ↳UITransitionView
    ↳UIDropShadowView
      ↳UIView (iPadOS only, not present on iOS)
        ↳DebugViewController
          ↳DebugView
```

We want the hit test logic to ignore this view (otherwise it captures all touches), so I've changed the window hit test to start checking in the root view (ie `DebugView`) instead.

Note that `convert`-ing the point to the `rootView` isn't necessary in this case since they're the same, but it's best practice, so better safe than sorry.

Fixes appcues/appcues-react-native-module#148