### PR TITLE
Add one line push config

### DIFF
--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate+Push.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate+Push.swift
@@ -5,6 +5,9 @@
 //  Created by Matt on 2024-03-06.
 //
 
+// Disabled in favor of automatic configuration
+
+/*
 import Foundation
 import UserNotifications
 import AppcuesKit
@@ -49,3 +52,4 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
     }
 }
+*/

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -17,8 +17,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         // Override point for customization after application launch.
 
-        setupPush(application: application)
-        
+        // Automatically configure for push notifications
+        Appcues.shared.enableAutomaticPushConfig()
+
+        // Or, manually configure for push notifications
+        // setupPush(application: application)
+
         return true
     }
 

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
 
         // Automatically configure for push notifications
-        Appcues.shared.enableAutomaticPushConfig()
+        Appcues.enableAutomaticPushConfig()
 
         // Or, manually configure for push notifications
         // setupPush(application: application)

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -99,6 +99,25 @@ public class Appcues: NSObject {
         config.logger.info("Appcues SDK %{public}@ initialized", version())
     }
 
+    /// Enables automatic push notification management.
+    ///
+    /// This should be called in `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`
+    /// to ensure no incoming notifications are missed.
+    ///
+    /// The following will automatically be handled:
+    /// 1. Calling `UIApplication.registerForRemoteNotifications()`
+    /// 2. Implementing `UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
+    /// to call ``setPushToken(_:)``
+    /// 3. Ensuring `UNUserNotificationCenter.current().delegate` is set
+    /// 4. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)`
+    /// to call ``didReceiveNotification(response:completionHandler:)``
+    /// 5. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)`
+    /// to show notification while the app is in the foreground
+    @objc
+    public static func enableAutomaticPushConfig() {
+        PushAutoConfig.configureAutomatically()
+    }
+
     /// Get the current version of the Appcues SDK.
     /// - Returns: Current version of the Appcues SDK.
     @objc(sdkVersion)
@@ -310,25 +329,6 @@ public class Appcues: NSObject {
         // resolving will init UIKitScreenTracking, which sets up the swizzling of
         // UIViewController for automatic screen tracking
         _ = container.resolve(UIKitScreenTracker.self)
-    }
-
-    /// Enables automatic push notification management.
-    ///
-    /// This should be called in `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)` to ensure no incoming notifications are missed.
-    ///
-    /// The following will automatically be handled:
-    /// 1. Calling `UIApplication.registerForRemoteNotifications()`
-    /// 2. Implementing `UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
-    /// to call ``setPushToken(_:)``
-    /// 3. Ensuring `UNUserNotificationCenter.current().delegate` is set
-    /// 4. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)`
-    /// to call ``didReceiveNotification(response:completionHandler:)``
-    /// 5. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)`
-    /// to show notification while the app is in the foreground
-    @objc
-    public func enableAutomaticPushConfig() {
-        let pushMonitor = container.resolve(PushMonitoring.self)
-        pushMonitor.configureAutomatically()
     }
 
     /// Verifies if an incoming URL is intended for the Appcues SDK.

--- a/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
@@ -109,23 +109,26 @@ extension UIScrollView {
             shouldSetDelegate = true
         }
 
-        swizzle(
-            delegate,
+        Swizzler.swizzle(
+            targetInstance: delegate,
             targetSelector: NSSelectorFromString("scrollViewWillBeginDragging:"),
+            replacementOwner: UIScrollView.self,
             placeholderSelector: #selector(appcues__placeholderScrollViewWillBeginDragging),
             swizzleSelector: #selector(appcues__scrollViewWillBeginDragging)
         )
 
-        swizzle(
-            delegate,
+        Swizzler.swizzle(
+            targetInstance: delegate,
             targetSelector: NSSelectorFromString("scrollViewDidEndDecelerating:"),
+            replacementOwner: UIScrollView.self,
             placeholderSelector: #selector(appcues__placeholderScrollViewDidEndDecelerating),
             swizzleSelector: #selector(appcues__scrollViewDidEndDecelerating)
         )
 
-        swizzle(
-            delegate,
+        Swizzler.swizzle(
+            targetInstance: delegate,
             targetSelector: NSSelectorFromString("scrollViewDidEndDragging:willDecelerate:"),
+            replacementOwner: UIScrollView.self,
             placeholderSelector: #selector(appcues__placeholderScrollViewDidEndDragging),
             swizzleSelector: #selector(appcues__scrollViewDidEndDragging)
         )
@@ -141,62 +144,6 @@ extension UIScrollView {
         }
 
         return delegate
-    }
-
-    private func swizzle(
-        _ delegate: UIScrollViewDelegate,
-        targetSelector: Selector,
-        placeholderSelector: Selector,
-        swizzleSelector: Selector
-    ) {
-        // see if the currently assigned delegate has an implementation for the target selector already.
-        // these are optional methods in the protocol, and if they are not there already, we'll need to add
-        // a placeholder implementation so that we can consistently swap it with our override, which will attempt
-        // to call back into it, in case there was an implementation already - if we don't do this, we'll
-        // get invalid selector errors in these cases.
-        let originalMethod = class_getInstanceMethod(type(of: delegate), targetSelector)
-
-        if originalMethod == nil {
-            // this is the case where the existing delegate does not have an implementation for the target selector
-
-            guard let placeholderMethod = class_getInstanceMethod(UIScrollView.self, placeholderSelector) else {
-                // this really shouldn't ever be nil, as that would mean the function defined a few lines below is no
-                // longer there, but we must nil check this call
-                return
-            }
-
-            // add the placeholder, so it can be swizzled uniformly
-            class_addMethod(
-                type(of: delegate),
-                targetSelector,
-                method_getImplementation(placeholderMethod),
-                method_getTypeEncoding(placeholderMethod)
-            )
-        }
-
-        // swizzle the new implementation to inject our own custom logic
-
-        // this should never be nil, as it would mean the function defined a few lines below is no longer there,
-        // but we must nil check this call.
-        guard let swizzleMethod = class_getInstanceMethod(UIScrollView.self, swizzleSelector) else { return }
-
-        // add the swizzled version - this will only succeed once for this instance, if its already there, we've already
-        // swizzled, and we can exit early in the next guard
-        let addMethodResult = class_addMethod(
-            type(of: delegate),
-            swizzleSelector,
-            method_getImplementation(swizzleMethod),
-            method_getTypeEncoding(swizzleMethod)
-        )
-
-        guard addMethodResult,
-              let originalMethod = originalMethod ?? class_getInstanceMethod(type(of: delegate), targetSelector),
-              let swizzledMethod = class_getInstanceMethod(type(of: delegate), swizzleSelector) else {
-            return
-        }
-
-        // finally, here is where we swizzle in our custom implementation
-        method_exchangeImplementations(originalMethod, swizzledMethod)
     }
 
     @objc

--- a/Sources/AppcuesKit/Push/PushAutoConfig.swift
+++ b/Sources/AppcuesKit/Push/PushAutoConfig.swift
@@ -1,0 +1,73 @@
+//
+//  PushAutoConfig.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-04-15.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal enum PushAutoConfig {
+    // This is an array to support the (rare) case of multiple SDK instances supporting push
+    private static var pushMonitors: [WeakPushMonitoring] = []
+
+    static func register(observer: PushMonitoring) {
+        pushMonitors.append(WeakPushMonitoring(observer))
+    }
+
+    static func remove(observer: PushMonitoring) {
+        pushMonitors.removeAll { $0.value == nil || $0.value === observer }
+    }
+
+    static func configureAutomatically() {
+        UIApplication.swizzleDidRegisterForDeviceToken()
+        UIApplication.shared.registerForRemoteNotifications()
+
+        UNUserNotificationCenter.swizzleNotificationCenterGetDelegate()
+    }
+
+    static func didRegister(deviceToken: Data) {
+        // Pass device token to all observing PushMonitor instances
+        pushMonitors.forEach { weakPushMonitor in
+            if let pushMonitor = weakPushMonitor.value {
+                pushMonitor.setPushToken(deviceToken)
+            }
+        }
+    }
+
+    // Shared instance is called from the swizzled method
+    static func didReceive(
+        _ response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        // Stop at the first PushMonitor that successfully handles the notification
+        _ = pushMonitors.first { weakPushMonitor in
+            if let pushMonitor = weakPushMonitor.value {
+                return pushMonitor.didReceiveNotification(response: response, completionHandler: completionHandler)
+            }
+            return false
+        }
+    }
+
+    // Shared instance is called from the swizzled method
+    static func willPresent(
+        _ parsedNotification: ParsedNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Behavior for all Appcues notification
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .list])
+        } else {
+            completionHandler(.alert)
+        }
+    }
+}
+
+extension PushAutoConfig {
+    class WeakPushMonitoring {
+        weak var value: PushMonitoring?
+
+        init (_ wrapping: PushMonitoring) { self.value = wrapping }
+    }
+}

--- a/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
+++ b/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
@@ -1,0 +1,100 @@
+//
+//  UIApplication+AutoConfig.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-04-11.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+
+extension UIApplication {
+    static func swizzleDidRegisterForDeviceToken() {
+        guard let appDelegate = UIApplication.shared.delegate else { return }
+
+        swizzle(
+            appDelegate,
+            targetSelector: NSSelectorFromString("application:didRegisterForRemoteNotificationsWithDeviceToken:"),
+            placeholderSelector: #selector(appcues__placeholderApplicationDidRegisterForRemoteNotificationsWithDeviceToken),
+            swizzleSelector: #selector(appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken)
+        )
+    }
+
+    private static func swizzle(
+        _ delegate: UIApplicationDelegate,
+        targetSelector: Selector,
+        placeholderSelector: Selector,
+        swizzleSelector: Selector
+    ) {
+        // see if the currently assigned delegate has an implementation for the target selector already.
+        // these are optional methods in the protocol, and if they are not there already, we'll need to add
+        // a placeholder implementation so that we can consistently swap it with our override, which will attempt
+        // to call back into it, in case there was an implementation already - if we don't do this, we'll
+        // get invalid selector errors in these cases.
+        let originalMethod = class_getInstanceMethod(type(of: delegate), targetSelector)
+
+        if originalMethod == nil {
+            // this is the case where the existing delegate does not have an implementation for the target selector
+
+            guard let placeholderMethod = class_getInstanceMethod(UIApplication.self, placeholderSelector) else {
+                // this really shouldn't ever be nil, as that would mean the function defined a few lines below is no
+                // longer there, but we must nil check this call
+                return
+            }
+
+            // add the placeholder, so it can be swizzled uniformly
+            class_addMethod(
+                type(of: delegate),
+                targetSelector,
+                method_getImplementation(placeholderMethod),
+                method_getTypeEncoding(placeholderMethod)
+            )
+        }
+
+        // swizzle the new implementation to inject our own custom logic
+
+        // this should never be nil, as it would mean the function defined a few lines below is no longer there,
+        // but we must nil check this call.
+        guard let swizzleMethod = class_getInstanceMethod(UIApplication.self, swizzleSelector) else { return }
+
+        // add the swizzled version - this will only succeed once for this instance, if its already there, we've already
+        // swizzled, and we can exit early in the next guard
+        let addMethodResult = class_addMethod(
+            type(of: delegate),
+            swizzleSelector,
+            method_getImplementation(swizzleMethod),
+            method_getTypeEncoding(swizzleMethod)
+        )
+
+        guard addMethodResult,
+              let originalMethod = originalMethod ?? class_getInstanceMethod(type(of: delegate), targetSelector),
+              let swizzledMethod = class_getInstanceMethod(type(of: delegate), swizzleSelector) else {
+            return
+        }
+
+        // finally, here is where we swizzle in our custom implementation
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+
+    @objc
+    func appcues__placeholderApplicationDidRegisterForRemoteNotificationsWithDeviceToken(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        AppcuesUNUserNotificationCenterDelegate.shared.didRegister(deviceToken: deviceToken)
+
+        // Also call the original implementation
+        appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+
+    }
+}

--- a/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
+++ b/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
@@ -10,72 +10,16 @@ import UIKit
 
 extension UIApplication {
     static func swizzleDidRegisterForDeviceToken() {
-        guard let appDelegate = UIApplication.shared.delegate else { return }
+        guard let appDelegateInstance = UIApplication.shared.delegate else { return }
 
-        swizzle(
-            appDelegate,
+        Swizzler.swizzle(
+            targetInstance: appDelegateInstance,
             targetSelector: NSSelectorFromString("application:didRegisterForRemoteNotificationsWithDeviceToken:"),
+            replacementOwner: UIApplication.self,
             placeholderSelector: #selector(appcues__placeholderApplicationDidRegisterForRemoteNotificationsWithDeviceToken),
             swizzleSelector: #selector(appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken)
         )
     }
-
-    private static func swizzle(
-        _ delegate: UIApplicationDelegate,
-        targetSelector: Selector,
-        placeholderSelector: Selector,
-        swizzleSelector: Selector
-    ) {
-        // see if the currently assigned delegate has an implementation for the target selector already.
-        // these are optional methods in the protocol, and if they are not there already, we'll need to add
-        // a placeholder implementation so that we can consistently swap it with our override, which will attempt
-        // to call back into it, in case there was an implementation already - if we don't do this, we'll
-        // get invalid selector errors in these cases.
-        let originalMethod = class_getInstanceMethod(type(of: delegate), targetSelector)
-
-        if originalMethod == nil {
-            // this is the case where the existing delegate does not have an implementation for the target selector
-
-            guard let placeholderMethod = class_getInstanceMethod(UIApplication.self, placeholderSelector) else {
-                // this really shouldn't ever be nil, as that would mean the function defined a few lines below is no
-                // longer there, but we must nil check this call
-                return
-            }
-
-            // add the placeholder, so it can be swizzled uniformly
-            class_addMethod(
-                type(of: delegate),
-                targetSelector,
-                method_getImplementation(placeholderMethod),
-                method_getTypeEncoding(placeholderMethod)
-            )
-        }
-
-        // swizzle the new implementation to inject our own custom logic
-
-        // this should never be nil, as it would mean the function defined a few lines below is no longer there,
-        // but we must nil check this call.
-        guard let swizzleMethod = class_getInstanceMethod(UIApplication.self, swizzleSelector) else { return }
-
-        // add the swizzled version - this will only succeed once for this instance, if its already there, we've already
-        // swizzled, and we can exit early in the next guard
-        let addMethodResult = class_addMethod(
-            type(of: delegate),
-            swizzleSelector,
-            method_getImplementation(swizzleMethod),
-            method_getTypeEncoding(swizzleMethod)
-        )
-
-        guard addMethodResult,
-              let originalMethod = originalMethod ?? class_getInstanceMethod(type(of: delegate), targetSelector),
-              let swizzledMethod = class_getInstanceMethod(type(of: delegate), swizzleSelector) else {
-            return
-        }
-
-        // finally, here is where we swizzle in our custom implementation
-        method_exchangeImplementations(originalMethod, swizzledMethod)
-    }
-
 
     @objc
     func appcues__placeholderApplicationDidRegisterForRemoteNotificationsWithDeviceToken(

--- a/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
+++ b/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
@@ -35,10 +35,12 @@ extension UIApplication {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        AppcuesUNUserNotificationCenterDelegate.shared.didRegister(deviceToken: deviceToken)
+        PushAutoConfig.didRegister(deviceToken: deviceToken)
 
         // Also call the original implementation
-        appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-
+        appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken(
+            application,
+            didRegisterForRemoteNotificationsWithDeviceToken: deviceToken
+        )
     }
 }

--- a/Sources/AppcuesKit/Push/UNUserNotificationCenter+AutoConfig.swift
+++ b/Sources/AppcuesKit/Push/UNUserNotificationCenter+AutoConfig.swift
@@ -1,0 +1,222 @@
+//
+//  UNUserNotificationCenter+AutoConfig.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-04-10.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import Foundation
+import UserNotifications
+
+internal class AppcuesUNUserNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
+    static var shared = AppcuesUNUserNotificationCenterDelegate()
+
+    // This is an array to support the (rare) case of multiple SDK instances supporting push
+    private var pushMonitors: [WeakPushMonitoring] = []
+
+    func register(observer: PushMonitoring) {
+        pushMonitors.append(WeakPushMonitoring(observer))
+    }
+
+    func remove(observer: PushMonitoring) {
+        pushMonitors.removeAll { $0.value === observer }
+    }
+
+    func didRegister(deviceToken: Data) {
+        // Pass device token to all observing PushMonitor instances
+        pushMonitors.forEach { weakPushMonitor in
+            if let pushMonitor = weakPushMonitor.value {
+                pushMonitor.setPushToken(deviceToken)
+            }
+        }
+    }
+
+    // Shared instance is called from the swizzled method
+    func didReceive(
+        _ response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        // Stop at the first PushMonitor that successfully handles the notification
+        _ = pushMonitors.first { weakPushMonitor in
+            if let pushMonitor = weakPushMonitor.value {
+                return pushMonitor.didReceiveNotification(response: response, completionHandler: completionHandler)
+            }
+            return false
+        }
+    }
+
+    // Shared instance is called from the swizzled method
+    func willPresent(
+        _ parsedNotification: ParsedNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Behavior for all Appcues notification
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .list])
+        } else {
+            completionHandler(.alert)
+        }
+    }
+}
+
+extension AppcuesUNUserNotificationCenterDelegate {
+    class WeakPushMonitoring {
+        weak var value: PushMonitoring?
+
+        init (_ wrapping: PushMonitoring) { self.value = wrapping }
+    }
+}
+
+extension UNUserNotificationCenter {
+
+    static func swizzleNotificationCenterGetDelegate() {
+        // this will swap in a new getter for UNUserNotificationCenter.delegate - giving our code a chance to hook in
+        let originalScrollViewDelegateSelector = #selector(getter: self.delegate)
+        let swizzledScrollViewDelegateSelector = #selector(appcues__getNotificationCenterDelegate)
+
+        guard let originalScrollViewMethod = class_getInstanceMethod(self, originalScrollViewDelegateSelector),
+              let swizzledScrollViewMethod = class_getInstanceMethod(self, swizzledScrollViewDelegateSelector) else {
+            return
+        }
+
+        method_exchangeImplementations(originalScrollViewMethod, swizzledScrollViewMethod)
+    }
+
+    // this is our custom getter logic for the UNUserNotificationCenter.delegate
+    @objc
+    private func appcues__getNotificationCenterDelegate() -> UNUserNotificationCenterDelegate? {
+        let delegate: UNUserNotificationCenterDelegate
+
+        // this call looks recursive, but it is not, it is calling the swapped implementation
+        // to get the actual delegate value that has been assigned, if any - can be nil
+        if let existingDelegate = appcues__getNotificationCenterDelegate() {
+            delegate = existingDelegate
+        } else {
+            // if it is nil, then we assign our own delegate implementation so there is
+            // something hooked in to listen to notifications
+            delegate = AppcuesUNUserNotificationCenterDelegate.shared
+            self.delegate = delegate
+        }
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"),
+            placeholderSelector: #selector(appcues__placeholderUserNotificationCenterDidReceive),
+            swizzleSelector: #selector(appcues__userNotificationCenterDidReceive)
+        )
+
+        swizzle(
+            delegate,
+            targetSelector: NSSelectorFromString("userNotificationCenter:willPresentNotification:withCompletionHandler:"),
+            placeholderSelector: #selector(appcues__placeholderUserNotificationCenterWillPresent),
+            swizzleSelector: #selector(appcues__userNotificationCenterWillPresent)
+        )
+
+        return delegate
+    }
+
+    private func swizzle(
+        _ delegate: UNUserNotificationCenterDelegate,
+        targetSelector: Selector,
+        placeholderSelector: Selector,
+        swizzleSelector: Selector
+    ) {
+        // see if the currently assigned delegate has an implementation for the target selector already.
+        // these are optional methods in the protocol, and if they are not there already, we'll need to add
+        // a placeholder implementation so that we can consistently swap it with our override, which will attempt
+        // to call back into it, in case there was an implementation already - if we don't do this, we'll
+        // get invalid selector errors in these cases.
+        let originalMethod = class_getInstanceMethod(type(of: delegate), targetSelector)
+
+        if originalMethod == nil {
+            // this is the case where the existing delegate does not have an implementation for the target selector
+
+            guard let placeholderMethod = class_getInstanceMethod(UNUserNotificationCenter.self, placeholderSelector) else {
+                // this really shouldn't ever be nil, as that would mean the function defined a few lines below is no
+                // longer there, but we must nil check this call
+                return
+            }
+
+            // add the placeholder, so it can be swizzled uniformly
+            class_addMethod(
+                type(of: delegate),
+                targetSelector,
+                method_getImplementation(placeholderMethod),
+                method_getTypeEncoding(placeholderMethod)
+            )
+        }
+
+        // swizzle the new implementation to inject our own custom logic
+
+        // this should never be nil, as it would mean the function defined a few lines below is no longer there,
+        // but we must nil check this call.
+        guard let swizzleMethod = class_getInstanceMethod(UNUserNotificationCenter.self, swizzleSelector) else { return }
+
+        // add the swizzled version - this will only succeed once for this instance, if its already there, we've already
+        // swizzled, and we can exit early in the next guard
+        let addMethodResult = class_addMethod(
+            type(of: delegate),
+            swizzleSelector,
+            method_getImplementation(swizzleMethod),
+            method_getTypeEncoding(swizzleMethod)
+        )
+
+        guard addMethodResult,
+              let originalMethod = originalMethod ?? class_getInstanceMethod(type(of: delegate), targetSelector),
+              let swizzledMethod = class_getInstanceMethod(type(of: delegate), swizzleSelector) else {
+            return
+        }
+
+        // finally, here is where we swizzle in our custom implementation
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    @objc
+    func appcues__placeholderUserNotificationCenterDidReceive(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__placeholderUserNotificationCenterWillPresent(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // this gives swizzling something to replace, if the existing delegate doesn't already
+        // implement this function.
+    }
+
+    @objc
+    func appcues__userNotificationCenterDidReceive(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if ParsedNotification(userInfo: response.notification.request.content.userInfo) != nil {
+            AppcuesUNUserNotificationCenterDelegate.shared.didReceive(response, withCompletionHandler: completionHandler)
+        } else {
+            // Not an Appcues push, so pass to the original implementation
+            appcues__userNotificationCenterDidReceive(center, didReceive: response, withCompletionHandler: completionHandler)
+        }
+    }
+
+    @objc
+    func appcues__userNotificationCenterWillPresent(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        if let parsedNotification = ParsedNotification(userInfo: notification.request.content.userInfo) {
+            AppcuesUNUserNotificationCenterDelegate.shared.willPresent(parsedNotification, withCompletionHandler: completionHandler)
+        } else {
+            // Not an Appcues push, so pass to the original implementation
+            appcues__userNotificationCenterWillPresent(center, willPresent: notification, withCompletionHandler: completionHandler)
+        }
+    }
+}

--- a/Sources/AppcuesKit/Utilities/Swizzler.swift
+++ b/Sources/AppcuesKit/Utilities/Swizzler.swift
@@ -1,0 +1,82 @@
+//
+//  Swizzler.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-04-11.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import Foundation
+
+internal enum Swizzler {
+    /// Swizzling for delegate objects.
+    ///
+    /// This is unique because,
+    /// 1. We aren't certain of the class type that implements the delegate protocol at compile time.
+    /// This is the reason why this function takes an instance of the delegate instead of the delegate type.
+    /// 2. Delegate methods are frequently optional, so we can't rely on the implementation being there to swizzle.
+    /// If this is the case, we add an empty placeholder implementation and then swizzle that.
+    ///
+    /// - Parameters:
+    ///   - targetInstance: Instance of the class to replace the method in.
+    ///   - targetSelector: Selector of the method to replace.
+    ///   - replacementOwner: Class containing the methods selected by `swizzleSelector` and `placeholderSelector`.
+    ///   - placeholderSelector: Selector of the method to use the `targetSelector` method is not implemented.
+    ///   This should be an empty function.
+    ///   - swizzleSelector: Selector of the method to use as the replacement.
+    static func swizzle(
+        targetInstance: AnyObject,
+        targetSelector: Selector,
+        replacementOwner: AnyClass,
+        placeholderSelector: Selector,
+        swizzleSelector: Selector
+    ) {
+        // see if the currently assigned delegate has an implementation for the target selector already.
+        // these are optional methods in the protocol, and if they are not there already, we'll need to add
+        // a placeholder implementation so that we can consistently swap it with our override, which will attempt
+        // to call back into it, in case there was an implementation already - if we don't do this, we'll
+        // get invalid selector errors in these cases.
+        let targetClass: AnyClass = type(of: targetInstance)
+        let originalMethod = class_getInstanceMethod(targetClass, targetSelector)
+
+        if originalMethod == nil {
+            // this is the case where the existing delegate does not have an implementation for the target selector
+
+            guard let placeholderMethod = class_getInstanceMethod(replacementOwner, placeholderSelector) else {
+                // this should never be nil as it would be a developer error, but we must nil check this call
+                return
+            }
+
+            // add the placeholder, so it can be swizzled uniformly
+            class_addMethod(
+                targetClass,
+                targetSelector,
+                method_getImplementation(placeholderMethod),
+                method_getTypeEncoding(placeholderMethod)
+            )
+        }
+
+        // swizzle the new implementation to inject our own custom logic
+
+        // this should never be nil as it would be a developer error, but we must nil check this call
+        guard let swizzleMethod = class_getInstanceMethod(replacementOwner, swizzleSelector) else { return }
+
+        // add the swizzled version - this will only succeed once for this instance, if its already there, we've already
+        // swizzled, and we can exit early in the next guard
+        let addMethodResult = class_addMethod(
+            targetClass,
+            swizzleSelector,
+            method_getImplementation(swizzleMethod),
+            method_getTypeEncoding(swizzleMethod)
+        )
+
+        guard addMethodResult,
+              let originalMethod = originalMethod ?? class_getInstanceMethod(targetClass, targetSelector),
+              let swizzledMethod = class_getInstanceMethod(targetClass, swizzleSelector) else {
+            return
+        }
+
+        // finally, here is where we swizzle in our custom implementation
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+}

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -260,22 +260,10 @@ class AppcuesTests: XCTestCase {
         // Arrange
         let token = "some-token".data(using: .utf8)
 
-        // Act
-        appcues.setPushToken(token)
-
-        // Assert
-        XCTAssertEqual(appcues.storage.pushToken, "736f6d652d746f6b656e")
-    }
-
-    func testSetPushTokenActiveSession() throws {
-        // Arrange
-        appcues.sessionID = UUID()
-        let token = "some-token".data(using: .utf8)
-        let eventExpectation = expectation(description: "Device event logged")
-        appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            XCTAssertEqual(trackingUpdate.type, .event(name: Events.Device.deviceUpdated.rawValue, interactive: false))
-            XCTAssertNil(trackingUpdate.properties)
-            eventExpectation.fulfill()
+        let setExpectation = expectation(description: "Token set")
+        appcues.pushMonitor.onSetPushToken = {
+            XCTAssertEqual($0, token)
+            setExpectation.fulfill()
         }
 
         // Act
@@ -283,7 +271,6 @@ class AppcuesTests: XCTestCase {
 
         // Assert
         waitForExpectations(timeout: 1)
-        XCTAssertEqual(appcues.storage.pushToken, "736f6d652d746f6b656e")
     }
 
     func testDidHandleURL() throws {

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -385,6 +385,17 @@ class MockPushMonitor: PushMonitoring {
     var pushPrimerEligible: Bool = false
 
     var pushAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    var onConfigureAutomatically: (() -> Void)?
+    func configureAutomatically() {
+        onConfigureAutomatically?()
+    }
+
+    var onSetPushToken: ((Data?) -> Void)?
+    func setPushToken(_ deviceToken: Data?) {
+        onSetPushToken?(deviceToken)
+    }
+
     var onRefreshPushStatus: ((Bool) -> Void)?
     func refreshPushStatus(publishChange: Bool, completion: ((UNAuthorizationStatus) -> Void)?) {
         onRefreshPushStatus?(publishChange)

--- a/Tests/AppcuesKitTests/Push/PushMonitorTests.swift
+++ b/Tests/AppcuesKitTests/Push/PushMonitorTests.swift
@@ -74,6 +74,37 @@ class PushMonitorTests: XCTestCase {
         XCTAssertTrue(pushMonitor.pushPrimerEligible)
     }
 
+    // MARK: Set Token
+    func testSetPushToken() throws {
+        // Arrange
+        let token = "some-token".data(using: .utf8)
+
+        // Act
+        pushMonitor.setPushToken(token)
+
+        // Assert
+        XCTAssertEqual(appcues.storage.pushToken, "736f6d652d746f6b656e")
+    }
+
+    func testSetPushTokenActiveSession() throws {
+        // Arrange
+        appcues.sessionID = UUID()
+        let token = "some-token".data(using: .utf8)
+        let eventExpectation = expectation(description: "Device event logged")
+        appcues.analyticsPublisher.onPublish = { trackingUpdate in
+            XCTAssertEqual(trackingUpdate.type, .event(name: Events.Device.deviceUpdated.rawValue, interactive: false))
+            XCTAssertNil(trackingUpdate.properties)
+            eventExpectation.fulfill()
+        }
+
+        // Act
+        pushMonitor.setPushToken(token)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(appcues.storage.pushToken, "736f6d652d746f6b656e")
+    }
+
     // MARK: Receive Handler
 
     func testReceiveActiveSession() throws {


### PR DESCRIPTION
This PR is very much building on the approach for the `UIScrollViewDelegate` swizzling added and explained in  https://github.com/appcues/appcues-ios-sdk/pull/479.

As noted in the `Appcues.swift` docs, there's 5 things that need to happen for automatic push config:
1. Calling `UIApplication.registerForRemoteNotifications()`.
    - This is straightforward.
2. Implementing `UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` to call `Appcues.setPushToken(_:)`.
    - Because we can safely assume there's always a `UIApplicationDelegate`, we just need to add the placeholder implementation if there is none, and then swizzle the method.
3. Ensuring `UNUserNotificationCenter.current().delegate` is set.
    - This is the same approach as the `UIScrollViewDelegate` getter swizzling.
4. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)` to call `Appcues.didReceiveNotification(response:completionHandler:)`.
    - This is swizzled with a placeholder implementation from the getter of the `UNUserNotificationCenterDelegate` (same ideas as the `UIScrollView` approach.
5. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)`.
    - This is swizzled with a placeholder implementation from the getter of the `UNUserNotificationCenterDelegate` (same ideas as the `UIScrollView` approach.

`AppcuesUNUserNotificationCenterDelegate` has a static instance that the various swizzled methods call. To properly support multiple SDK instances (that each can be auto configured!) there's a list of `pushMonitors` that we can operate from (using the weak wrapper approach from `AnalyticsPublisher`).

## Structural Notes
1. I moved the implementation of `Appcues.setPushToken` into `PushMonitor` so that the swizzled implementation can also easy access it.
2. Instead of having the almost the same long swizzling block for `UIScrollViewDelegate`, `UIApplicationDelegate`, and `UNUserNotificationCenterDelegate`, I created Swizzler with one extra parameter.

## What's Next
1. I've [thought about](https://appcues.slack.com/archives/C031RLGS4F8/p1712774012435019?thread_ts=1712773510.279779&cid=C031RLGS4F8) adding config options to control what specifically gets automatically swizzled, but for now I'm comfortable with the all-or-nothing approach.
2. I'd like tests for the swizzled behaviour (and the various scenarios of what's already implemented in the existing app), but I haven't yet looked into what's doable there.