### PR TITLE
Update push auto config to be static

### DIFF
--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
 
         // Automatically configure for push notifications
-        Appcues.shared.enableAutomaticPushConfig()
+        Appcues.enableAutomaticPushConfig()
 
         // Or, manually configure for push notifications
         // setupPush(application: application)

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -99,6 +99,25 @@ public class Appcues: NSObject {
         config.logger.info("Appcues SDK %{public}@ initialized", version())
     }
 
+    /// Enables automatic push notification management.
+    ///
+    /// This should be called in `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`
+    /// to ensure no incoming notifications are missed.
+    ///
+    /// The following will automatically be handled:
+    /// 1. Calling `UIApplication.registerForRemoteNotifications()`
+    /// 2. Implementing `UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
+    /// to call ``setPushToken(_:)``
+    /// 3. Ensuring `UNUserNotificationCenter.current().delegate` is set
+    /// 4. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)`
+    /// to call ``didReceiveNotification(response:completionHandler:)``
+    /// 5. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)`
+    /// to show notification while the app is in the foreground
+    @objc
+    public static func enableAutomaticPushConfig() {
+        PushAutoConfig.configureAutomatically()
+    }
+
     /// Get the current version of the Appcues SDK.
     /// - Returns: Current version of the Appcues SDK.
     @objc(sdkVersion)
@@ -310,25 +329,6 @@ public class Appcues: NSObject {
         // resolving will init UIKitScreenTracking, which sets up the swizzling of
         // UIViewController for automatic screen tracking
         _ = container.resolve(UIKitScreenTracker.self)
-    }
-
-    /// Enables automatic push notification management.
-    ///
-    /// This should be called in `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)` to ensure no incoming notifications are missed.
-    ///
-    /// The following will automatically be handled:
-    /// 1. Calling `UIApplication.registerForRemoteNotifications()`
-    /// 2. Implementing `UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
-    /// to call ``setPushToken(_:)``
-    /// 3. Ensuring `UNUserNotificationCenter.current().delegate` is set
-    /// 4. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)`
-    /// to call ``didReceiveNotification(response:completionHandler:)``
-    /// 5. Implementing `UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)`
-    /// to show notification while the app is in the foreground
-    @objc
-    public func enableAutomaticPushConfig() {
-        let pushMonitor = container.resolve(PushMonitoring.self)
-        pushMonitor.configureAutomatically()
     }
 
     /// Verifies if an incoming URL is intended for the Appcues SDK.

--- a/Sources/AppcuesKit/Push/PushAutoConfig.swift
+++ b/Sources/AppcuesKit/Push/PushAutoConfig.swift
@@ -1,0 +1,73 @@
+//
+//  PushAutoConfig.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-04-15.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal enum PushAutoConfig {
+    // This is an array to support the (rare) case of multiple SDK instances supporting push
+    private static var pushMonitors: [WeakPushMonitoring] = []
+
+    static func register(observer: PushMonitoring) {
+        pushMonitors.append(WeakPushMonitoring(observer))
+    }
+
+    static func remove(observer: PushMonitoring) {
+        pushMonitors.removeAll { $0.value == nil || $0.value === observer }
+    }
+
+    static func configureAutomatically() {
+        UIApplication.swizzleDidRegisterForDeviceToken()
+        UIApplication.shared.registerForRemoteNotifications()
+
+        UNUserNotificationCenter.swizzleNotificationCenterGetDelegate()
+    }
+
+    static func didRegister(deviceToken: Data) {
+        // Pass device token to all observing PushMonitor instances
+        pushMonitors.forEach { weakPushMonitor in
+            if let pushMonitor = weakPushMonitor.value {
+                pushMonitor.setPushToken(deviceToken)
+            }
+        }
+    }
+
+    // Shared instance is called from the swizzled method
+    static func didReceive(
+        _ response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        // Stop at the first PushMonitor that successfully handles the notification
+        _ = pushMonitors.first { weakPushMonitor in
+            if let pushMonitor = weakPushMonitor.value {
+                return pushMonitor.didReceiveNotification(response: response, completionHandler: completionHandler)
+            }
+            return false
+        }
+    }
+
+    // Shared instance is called from the swizzled method
+    static func willPresent(
+        _ parsedNotification: ParsedNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Behavior for all Appcues notification
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .list])
+        } else {
+            completionHandler(.alert)
+        }
+    }
+}
+
+extension PushAutoConfig {
+    class WeakPushMonitoring {
+        weak var value: PushMonitoring?
+
+        init (_ wrapping: PushMonitoring) { self.value = wrapping }
+    }
+}

--- a/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
+++ b/Sources/AppcuesKit/Push/UIApplication+AutoConfig.swift
@@ -35,10 +35,12 @@ extension UIApplication {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        AppcuesUNUserNotificationCenterDelegate.shared.didRegister(deviceToken: deviceToken)
+        PushAutoConfig.didRegister(deviceToken: deviceToken)
 
         // Also call the original implementation
-        appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-
+        appcues__applicationDidRegisterForRemoteNotificationsWithDeviceToken(
+            application,
+            didRegisterForRemoteNotificationsWithDeviceToken: deviceToken
+        )
     }
 }


### PR DESCRIPTION
This is a tweak targeting #526 in its own PR for readability. I've made the swizzling automatic push config static on `Appcues` for a couple reasons:

1. Swizzling affects the whole app, not just the instance. So in the theoretical multiple Appcues instance app, it'd be very strange to suggest that you could automatically configure one instance but not the other.
2. A static config option better sets us up for x-plat success. More [here](https://appcues.slack.com/archives/C031RLGS4F8/p1712932756018019), but since the x-plat libraries create the `Appcues` instance on-demand, that may be too late for the config necessary in `didFinishLaunching`.

The static observer list pattern I've added means that,
1. If an `Appcues` instance is created before the push auto config, then it's already in the observer list for when the swizzled methods start getting called, and
2. If the auto config is done, and then a new `Appcues` instant is created, the instance will add itself to the observer list and start receiving any push events from that point forward.