### PR TITLE
Fix debugger hit test on iPad

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
@@ -25,8 +25,14 @@ internal class DebugUIWindow: UIWindow {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        guard let rootView = rootViewController?.view,
-              let hitView = rootView.hitTest(convert(point, to: rootView), with: event) else {
+        guard let hitView = super.hitTest(point, with: event), hitView != self else {
+            return nil
+        }
+
+        // On iPad, there is a system view that wraps the rootView that can capture hits,
+        // and we need to ignore that view to allow interaction with the underlying app
+        // while the debug window is overlayed.
+        if let rootView = rootViewController?.view, hitView.subviews.first == rootView {
             return nil
         }
 


### PR DESCRIPTION
Take two on 8426b9ac (#525). The first approach didn't account for a presented view controller (eg the screen capture confirm dialog) nor system menus.