### PR TITLE
Fix lint warning

### DIFF
--- a/Sources/AppcuesKit/Presentation/ContentLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ContentLoader.swift
@@ -104,8 +104,8 @@ internal class ContentLoader: ContentLoading {
             body: data
         ) { [weak self] (result: Result<Void, Error>) in
             switch result {
-            case .success(let experience):
-                break
+            case .success:
+                completion?(.success(()))
             case .failure(let error):
                 self?.config.logger.error("Loading push %{public}@ failed with error %{public}@", id, "\(error)")
                 completion?(.failure(error))


### PR DESCRIPTION
Warning `immutable value 'experience' was never used` was causing cocoapods to fail to publish. I've temporarily bypassed with `--allow-warnings`, but this fixes it for next time.

Also ensuring the completion callback is called. Didn't matter yet, but it will for push error handling.