### PR TITLE
Add push preview error feedback toast

### DIFF
--- a/Examples/DeveloperCocoapodsExample/Podfile.lock
+++ b/Examples/DeveloperCocoapodsExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Appcues (3.1.8)
+  - Appcues (3.1.9)
   - AppcuesNotificationService (0.1.0)
 
 DEPENDENCIES:
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :path: "../../AppcuesNotificationService.podspec"
 
 SPEC CHECKSUMS:
-  Appcues: e5c348611d6f77f075898b1eff6ca2a53e47d7b0
+  Appcues: 58ee609e4cff59090b20e8b251bc4ad2a5cc8cf0
   AppcuesNotificationService: f7f11e9b156c50106b64b11f55eb0e02586198bd
 
 PODFILE CHECKSUM: 24c643e3c9c013c74f5d561608aa37768cb0c43e

--- a/Sources/AppcuesKit/Data/Networking/NetworkClient.swift
+++ b/Sources/AppcuesKit/Data/Networking/NetworkClient.swift
@@ -173,11 +173,12 @@ internal class NetworkClient: Networking {
         _ urlRequest: URLRequest,
         completion: @escaping (_ result: Result<Void, Error>) -> Void
     ) {
-        let dataTask = config.urlSession.dataTask(with: urlRequest) { [weak self] _, response, error in
+        let dataTask = config.urlSession.dataTask(with: urlRequest) { [weak self] data, response, error in
             let url = (response?.url ?? urlRequest.url)?.absoluteString ?? "<unknown>"
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let logData = String(data: error?.data ?? data ?? Data.empty, encoding: .utf8) ?? ""
 
-            self?.config.logger.debug("RESPONSE: %{public}d %{public}@", statusCode, url)
+            self?.config.logger.debug("RESPONSE: %{public}d %{public}@\n%{private}@", statusCode, url, logData)
 
             if let error = error {
                 completion(.failure(error))

--- a/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
@@ -126,7 +126,7 @@ internal class DeepLinkHandler: DeepLinkHandling {
                 published: false,
                 queryItems: queryItems,
                 trigger: .preview,
-                completion: previewCompletion
+                completion: experiencePreviewCompletion
             )
         case let .show(experienceID, queryItems):
             container?.resolve(ContentLoading.self).load(
@@ -141,7 +141,7 @@ internal class DeepLinkHandler: DeepLinkHandling {
                 id: id,
                 published: false,
                 queryItems: queryItems,
-                completion: nil
+                completion: pushPreviewCompletion
             )
         case let .pushContent(id):
             container?.resolve(ContentLoading.self).loadPush(
@@ -159,7 +159,7 @@ internal class DeepLinkHandler: DeepLinkHandling {
         }
     }
 
-    private func previewCompletion(_ result: Result<Void, Error>) {
+    private func experiencePreviewCompletion(_ result: Result<Void, Error>) {
         guard case let .failure(error) = result else {
             return
         }
@@ -177,6 +177,25 @@ internal class DeepLinkHandler: DeepLinkHandling {
             message = "Preview of \(experience.name) failed: \(errorMessage)"
         default:
             message = "Mobile flow preview failed."
+        }
+
+        let toast = DebugToast(message: .custom(text: message), style: .failure)
+        container?.resolve(UIDebugging.self).showToast(toast)
+    }
+
+    private func pushPreviewCompletion(_ result: Result<Void, Error>) {
+        guard case let .failure(error) = result else {
+            return
+        }
+
+        let message: String
+        switch error {
+        case NetworkingError.nonSuccessfulStatusCode(404):
+            message = "Push notification not found."
+        case is NetworkingError:
+            message = "Error loading push notification preview."
+        default:
+            message = "Push notification preview failed."
         }
 
         let toast = DebugToast(message: .custom(text: message), style: .failure)

--- a/Sources/AppcuesKit/Push/PushMonitor.swift
+++ b/Sources/AppcuesKit/Push/PushMonitor.swift
@@ -74,7 +74,7 @@ internal class PushMonitor: PushMonitoring {
 
         if appcues?.sessionID != nil {
             analyticsPublisher.publish(TrackingUpdate(
-                type: .event(name: Events.Device.deviceUpdated.rawValue, interactive: false),
+                type: .event(name: Events.Device.deviceUpdated.rawValue, interactive: true),
                 isInternal: true
             ))
         }
@@ -95,7 +95,7 @@ internal class PushMonitor: PushMonitoring {
 
             if shouldPublish {
                 self?.analyticsPublisher.publish(TrackingUpdate(
-                    type: .event(name: Events.Device.deviceUpdated.rawValue, interactive: false),
+                    type: .event(name: Events.Device.deviceUpdated.rawValue, interactive: true),
                     isInternal: true
                 ))
             }

--- a/Tests/AppcuesKitTests/Push/PushMonitorTests.swift
+++ b/Tests/AppcuesKitTests/Push/PushMonitorTests.swift
@@ -92,7 +92,7 @@ class PushMonitorTests: XCTestCase {
         let token = "some-token".data(using: .utf8)
         let eventExpectation = expectation(description: "Device event logged")
         appcues.analyticsPublisher.onPublish = { trackingUpdate in
-            XCTAssertEqual(trackingUpdate.type, .event(name: Events.Device.deviceUpdated.rawValue, interactive: false))
+            XCTAssertEqual(trackingUpdate.type, .event(name: Events.Device.deviceUpdated.rawValue, interactive: true))
             XCTAssertNil(trackingUpdate.properties)
             eventExpectation.fulfill()
         }


### PR DESCRIPTION
Gives some immediate feedback if something went wrong on the push preview request, similar to flow preview issues.
![Screenshot 2024-05-07 at 12 56 08 PM](https://github.com/appcues/appcues-ios-sdk/assets/19266448/f17bf123-9a05-421a-8eab-0d0a4d4d9f68)

Also, now provides error detail in the detailed log with the response body error messages to troubleshoot. (note: some work going in api/pushserv soon to improve a few cases here to be more helpful)
![Screenshot 2024-05-07 at 12 56 28 PM](https://github.com/appcues/appcues-ios-sdk/assets/19266448/ac8a2ad5-b58b-4c3d-aab9-4e1bf8078fbd)

