### PR TITLE
Add support for automatic push environment detection

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -148,8 +148,7 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             "_pushToken": pushToken,
             "_pushEnabled": pushMonitor.pushEnabled,
             "_pushEnabledBackground": pushMonitor.pushBackgroundEnabled,
-            // TODO: more properties
-            // _pushSubscriptionStatus
+            "_pushEnvironment": pushMonitor.pushEnvironment.environmentValue
         ]
 
         if let language = deviceLanguage {

--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -147,9 +147,12 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             "_deviceId": storage.deviceID,
             "_pushToken": pushToken,
             "_pushEnabled": pushMonitor.pushEnabled,
-            "_pushEnabledBackground": pushMonitor.pushBackgroundEnabled,
-            "_pushEnvironment": pushMonitor.pushEnvironment.environmentValue
+            "_pushEnabledBackground": pushMonitor.pushBackgroundEnabled
         ]
+
+        if let environment = pushMonitor.pushEnvironment.environmentValue {
+            properties["_pushEnvironment"] = environment
+        }
 
         if let language = deviceLanguage {
             properties["_language"] = language

--- a/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
@@ -22,6 +22,7 @@ private final class KeyedArchiver: NSKeyedArchiver {
 @available(iOS 13.0, *)
 internal class PushVerifier {
     enum ErrorMessage: Equatable, CustomStringConvertible {
+        case noPushEnvironment(String)
         case noToken
         case notAuthorized
         case permissionDenied
@@ -41,6 +42,8 @@ internal class PushVerifier {
 
         var description: String {
             switch self {
+            case .noPushEnvironment(let error):
+                return "Error 0: Could not determine push environment\n(\(error))"
             case .noToken:
                 return "Error 1: No push token registered with Appcues"
             case .notAuthorized:
@@ -153,6 +156,10 @@ internal class PushVerifier {
     }
 
     private func verifyDeviceConfiguration() {
+        if case .unknown(let reason) = pushMonitor.pushEnvironment {
+            errors.append(.noPushEnvironment(reason.description))
+        }
+
         if storage.pushToken == nil {
             errors.append(.noToken)
         }

--- a/Sources/AppcuesKit/Push/PushEnvironment.swift
+++ b/Sources/AppcuesKit/Push/PushEnvironment.swift
@@ -1,0 +1,144 @@
+//
+//  PushEnvironment.swift
+//  Appcues
+//
+//  Created by Matt on 2024-05-21.
+//
+
+import UIKit
+
+internal enum PushEnvironment {
+    case unknown(Reason)
+    case development
+    case production
+
+    enum PushEnvironmentError: LocalizedError {
+        case noEntitlementsKey
+        case noEnvironmentKey
+        case unexpectedEnvironment(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .noEntitlementsKey: return "No 'Entitlements' key"
+            case .noEnvironmentKey: return "No entitlement 'aps-environment' key"
+            case .unexpectedEnvironment(let value): return "Unexpected 'aps-environment' value '\(value)'"
+            }
+        }
+    }
+
+    enum Reason {
+        case notComputed, error(Error)
+
+        var description: String {
+            switch self {
+            case .notComputed: return "Value not computed"
+            case .error(let error): return error.localizedDescription
+            }
+        }
+    }
+
+    var environmentValue: String {
+        // The environment to request from the backend must be "development" or "production".
+        // If we haven't been able to determine the environment, default to "production".
+        switch self {
+        case .development: return "development"
+        case .unknown, .production: return "production"
+        }
+    }
+
+    init?(value: String) {
+        switch value {
+        case "development": self = .development
+        case "production": self = .production
+        default: return nil
+        }
+    }
+}
+
+extension UIDevice {
+    enum ProvisioningProfileError: LocalizedError {
+        case noEmbeddedProfile
+        case plistScanFailed
+        case plistSerializationFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .noEmbeddedProfile: return "No 'embedded.mobileprovision' found in bundle"
+            case .plistScanFailed: return "Property list scan failed"
+            case .plistSerializationFailed: return "Property list serialization failed"
+            }
+        }
+    }
+
+    func pushEnvironment() -> PushEnvironment {
+    #if targetEnvironment(simulator)
+    return .development
+    #else
+    do {
+        let provisioningProfile = try UIDevice.current.provisioningProfile()
+
+        guard let entitlements = provisioningProfile["Entitlements"] as? [String: Any] else {
+            return .unknown(.error(PushEnvironment.PushEnvironmentError.noEntitlementsKey))
+        }
+
+        guard let environment = entitlements["aps-environment"] as? String else {
+            return .unknown(.error(PushEnvironment.PushEnvironmentError.noEnvironmentKey))
+        }
+
+        guard let pushEnvironment = PushEnvironment(value: environment) else {
+            return .unknown(.error(PushEnvironment.PushEnvironmentError.unexpectedEnvironment(environment)))
+        }
+
+        return pushEnvironment
+    } catch ProvisioningProfileError.noEmbeddedProfile {
+        // App Store apps do not contain an embedded provisioning profile,
+        // and since we know we're not on a simulator, that means it's "production".
+        return .production
+    } catch {
+        return .unknown(.error(error))
+    }
+    #endif
+    }
+
+    private func provisioningProfile() throws -> [String: Any] {
+        guard let path = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") else {
+            throw ProvisioningProfileError.noEmbeddedProfile
+        }
+
+        let binaryString = try String(contentsOfFile: path, encoding: .isoLatin1)
+
+        let scanner = Scanner(string: binaryString)
+        let plistString: String
+
+        if #available(iOS 13.0, *) {
+            guard scanner.scanUpToString("<plist") != nil,
+                  let targetString = scanner.scanUpToString("</plist>")
+            else {
+                throw ProvisioningProfileError.plistScanFailed
+            }
+            plistString = targetString
+        } else {
+            // swiftlint:disable:next legacy_objc_type
+            var targetString: NSString?
+
+            guard scanner.scanUpTo("<plist", into: nil),
+                  scanner.scanUpTo("</plist>", into: &targetString),
+                  let targetString = targetString
+            else {
+                throw ProvisioningProfileError.plistScanFailed
+            }
+            plistString = targetString as String
+        }
+
+        guard let plistData = (plistString + "</plist>").data(using: .isoLatin1) else {
+            throw ProvisioningProfileError.plistScanFailed
+        }
+
+        guard let serializedPlist = try PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any]
+        else {
+            throw ProvisioningProfileError.plistSerializationFailed
+        }
+
+        return serializedPlist
+    }
+}

--- a/Sources/AppcuesKit/Push/PushEnvironment.swift
+++ b/Sources/AppcuesKit/Push/PushEnvironment.swift
@@ -37,12 +37,11 @@ internal enum PushEnvironment {
         }
     }
 
-    var environmentValue: String {
-        // The environment to request from the backend must be "development" or "production".
-        // If we haven't been able to determine the environment, default to "production".
+    var environmentValue: String? {
         switch self {
         case .development: return "development"
-        case .unknown, .production: return "production"
+        case .production: return "production"
+        case .unknown: return nil
         }
     }
 

--- a/Sources/AppcuesKit/Push/PushMonitor.swift
+++ b/Sources/AppcuesKit/Push/PushMonitor.swift
@@ -10,6 +10,7 @@ import UIKit
 
 internal protocol PushMonitoring: AnyObject {
     var pushAuthorizationStatus: UNAuthorizationStatus { get }
+    var pushEnvironment: PushEnvironment { get }
     var pushEnabled: Bool { get }
     var pushBackgroundEnabled: Bool { get }
     var pushPrimerEligible: Bool { get }
@@ -32,6 +33,8 @@ internal class PushMonitor: PushMonitoring {
 
     private(set) var pushAuthorizationStatus: UNAuthorizationStatus = .notDetermined
 
+    private(set) var pushEnvironment: PushEnvironment = .unknown(.notComputed)
+
     var pushEnabled: Bool {
         pushAuthorizationStatus == .authorized && storage.pushToken != nil
     }
@@ -53,6 +56,7 @@ internal class PushMonitor: PushMonitoring {
         self.analyticsPublisher = container.resolve(AnalyticsPublishing.self)
 
         refreshPushStatus(publishChange: false)
+        getPushEnvironment()
 
         NotificationCenter.default.addObserver(
             self,
@@ -208,6 +212,12 @@ internal class PushMonitor: PushMonitoring {
             actionRegistry.enqueue(actionInstances: actions, completion: completionHandler)
         } else {
             completionHandler()
+        }
+    }
+
+    private func getPushEnvironment() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            self?.pushEnvironment = UIDevice.current.pushEnvironment()
         }
     }
 

--- a/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
@@ -56,7 +56,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
         let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionRandomizer", "_sessionId", "_pushPrimerEligible"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.identityAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
-        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_pushToken", "_pushEnabledBackground", "_pushEnabled", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
+        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_pushToken", "_pushEnabledBackground", "_pushEnabled", "_pushEnvironment", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.deviceAutoProperties).keys).symmetricDifference(expectedEventDeviceAutoPropertyKeys))
     }
 

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -380,6 +380,7 @@ class MockAnalyticsTracker: AnalyticsTracking {
 }
 
 class MockPushMonitor: PushMonitoring {
+    var pushEnvironment: AppcuesKit.PushEnvironment = .development
     var pushEnabled: Bool = false
     var pushBackgroundEnabled: Bool = false
     var pushPrimerEligible: Bool = false


### PR DESCRIPTION
Add a `_pushEnvironment` device auto property with a value of `development` or `production`. The value starts as unknown (which tracks as `production`) until a background thread can read and parse the provisioning profile data, if it's available.

There's a few options here:

1. No `embedded.mobileprovision`. This could be a simulator build ( so want `development`) or an App Store one (`production`):
    > App Store apps do not contain an embedded provisioning profile because the App Store checks that the app is signed and provisioned correctly as part of its app ingestion process.
      - https://developer.apple.com/documentation/technotes/tn3125-inside-code-signing-provisioning-profiles#Profile-location
2. There is an `embedded.mobileprovision`. This could a development build (`development`) or an Ad Hoc build (`production`). In this case we can deserialize the provisioning profile and determine the correct environment, falling back to `production` if anything is unexpected. There's [a](https://www.process-one.net/blog/reading-ios-provisioning-profile-in-swift/) [few](https://gist.github.com/mremond/7c62e85e2f1ee6ae311ee039b959fcc0) [examples](https://stackoverflow.com/a/69905152) of doing this out there.

I haven't been able to test most of the error cases in a meaningful way because I can't modify the `embedded.mobileprovision` to do something unexpected. From what I've observed, most of the errors should never happen, but at least we'll be able to narrow things down if they do.

I have tested with a simulator, development build, and TestFlight (App Store) build. Our alpha/beta period will provide more opportunities to test different configuration.