### PR TITLE
Ensure latest device prop values are always sent

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestPushAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestPushAction.swift
@@ -32,7 +32,7 @@ internal class AppcuesRequestPushAction: AppcuesExperienceAction {
             }
 
             let pushMonitor = appcues.container.resolve(PushMonitoring.self)
-            pushMonitor.refreshPushStatus(publishChange: true) { _ in
+            pushMonitor.refreshPushStatus { _ in
                 completion()
             }
         }

--- a/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
@@ -147,7 +147,7 @@ internal class PushVerifier {
     private func requestPush() {
         let options: UNAuthorizationOptions = [.alert, .sound, .badge]
         UNUserNotificationCenter.current().requestAuthorization(options: options) { _, _ in
-            self.pushMonitor.refreshPushStatus(publishChange: true) { _ in
+            self.pushMonitor.refreshPushStatus { _ in
                 DispatchQueue.main.async {
                     self.verifyPush()
                 }

--- a/Tests/AppcuesKitTests/Actions/AppcuesRequestPushActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesRequestPushActionTests.swift
@@ -33,8 +33,7 @@ class AppcuesRequestPushActionTests: XCTestCase {
         var completionCount = 0
         let action = AppcuesRequestPushAction(appcues: appcues)
 
-        appcues.pushMonitor.onRefreshPushStatus = { shouldPublish in
-            XCTAssertTrue(shouldPublish)
+        appcues.pushMonitor.onRefreshPushStatus = {
             refreshCount += 1
         }
 

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -397,9 +397,9 @@ class MockPushMonitor: PushMonitoring {
         onSetPushToken?(deviceToken)
     }
 
-    var onRefreshPushStatus: ((Bool) -> Void)?
-    func refreshPushStatus(publishChange: Bool, completion: ((UNAuthorizationStatus) -> Void)?) {
-        onRefreshPushStatus?(publishChange)
+    var onRefreshPushStatus: (() -> Void)?
+    func refreshPushStatus(completion: ((UNAuthorizationStatus) -> Void)?) {
+        onRefreshPushStatus?()
         completion?(pushAuthorizationStatus)
     }
 

--- a/Tests/AppcuesKitTests/Push/PushMonitorTests.swift
+++ b/Tests/AppcuesKitTests/Push/PushMonitorTests.swift
@@ -105,6 +105,24 @@ class PushMonitorTests: XCTestCase {
         XCTAssertEqual(appcues.storage.pushToken, "736f6d652d746f6b656e")
     }
 
+    func testSetPushTokenNoAnalyticsWhenSameValue() throws {
+        // Arrange
+        appcues.storage.pushToken = "736f6d652d746f6b656e"
+        appcues.sessionID = UUID()
+        let token = "some-token".data(using: .utf8)
+        let eventExpectation = expectation(description: "Device event logged")
+        eventExpectation.isInverted = true
+        appcues.analyticsPublisher.onPublish = { trackingUpdate in
+            eventExpectation.fulfill()
+        }
+
+        // Act
+        pushMonitor.setPushToken(token)
+
+        // Assert
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(appcues.storage.pushToken, "736f6d652d746f6b656e")
+    }
     // MARK: Receive Handler
 
     func testReceiveActiveSession() throws {


### PR DESCRIPTION
James [noted](https://appcues.slack.com/archives/C031RLGS4F8/p1717616763921679) a while back that there can be a race where `pushEnabled` is read and sent to the backend at startup before the correct value can be determined.

To fix this, we want to make sure the initial request for the permission status will send a device updated event if the value is different than the one that was used. This initial request was the only place with a false argument like `refreshPushStatus(publishChange: false)`.

So I've removed the `publishChange` parameter in favour of calculating a `shouldPublish` property that confirms that the value has changed AND (new) that there's an active session (this means that the previous value was used).

I've also added the same check to `setPushToken` so we're not triggering device update events with an unchanged push token value.