### PR TITLE
Ensure push completion handlers are always called

### DIFF
--- a/Sources/AppcuesKit/Push/UNUserNotificationCenter+AutoConfig.swift
+++ b/Sources/AppcuesKit/Push/UNUserNotificationCenter+AutoConfig.swift
@@ -72,6 +72,7 @@ extension UNUserNotificationCenter {
     ) {
         // this gives swizzling something to replace, if the existing delegate doesn't already
         // implement this function.
+        completionHandler()
     }
 
     @objc
@@ -82,6 +83,7 @@ extension UNUserNotificationCenter {
     ) {
         // this gives swizzling something to replace, if the existing delegate doesn't already
         // implement this function.
+        completionHandler([])
     }
 
     @objc


### PR DESCRIPTION
Was working on push docs and noticed a two gaps in how the automatic push configuration calls completion handlers. For context:

[Docs](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/usernotificationcenter(_:didreceive:withcompletionhandler:)) for `userNotificationCenter(_:didReceive:withCompletionHandler:)`:
> You must execute this block at some point after processing the user’s response to let the system know that you are done.

Docs for `userNotificationCenter(_:willPresent:withCompletionHandler:`:
> Always execute this block at some point during your implementation of this method.

First off, in `PushAutoConfig`, the completion handler wasn't being called in the case where there's not an Appcues instance to immediately handle the push, but we save it for deferred handling. I've added the call and some inline docs to make it clearer what's happening.

Then, for the cases where an incoming notification isn't an Appcues one and the app hasn't already implemented the methods, the swizzling implementation [falls back](https://github.com/appcues/appcues-ios-sdk/blob/9e561d758b9f397ed1d09e9bf7bb6e150dae4382/Sources/AppcuesKit/Utilities/Swizzler.swift#L42-L57) ([here](https://github.com/appcues/appcues-ios-sdk/blob/9e561d758b9f397ed1d09e9bf7bb6e150dae4382/Sources/AppcuesKit/Push/UNUserNotificationCenter%2BAutoConfig.swift#L96-L97) and [here](https://github.com/appcues/appcues-ios-sdk/blob/9e561d758b9f397ed1d09e9bf7bb6e150dae4382/Sources/AppcuesKit/Push/UNUserNotificationCenter%2BAutoConfig.swift#L110-L111)) to an "empty" default implementation that we provide. So those default implementations need to call the completion block as well.
