### PR TITLE
Ensure Xcode 16/iOS 18 compiles

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -73,7 +73,7 @@ internal class AppcuesLinkAction: AppcuesExperienceAction {
             } else {
                 if openExternally {
                     logger.info("@appcues/link: external link opening %{private}@", url.absoluteString)
-                    urlOpener.open(url, options: [:]) { _ in completion() }
+                    urlOpener.open(url, completionHandler: completion)
                 } else {
                     logger.info("@appcues/link: in-app link opening %{private}@", url.absoluteString)
                     urlOpener.topViewController()?.present(SFSafariViewController(url: url), animated: true, completion: completion)
@@ -82,7 +82,7 @@ internal class AppcuesLinkAction: AppcuesExperienceAction {
         } else {
             // Scheme link
             logger.info("@appcues/link: scheme link opening %{private}@", url.absoluteString)
-            urlOpener.open(url, options: [:]) { _ in completion() }
+            urlOpener.open(url, completionHandler: completion)
         }
     }
 

--- a/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
@@ -17,7 +17,7 @@ internal protocol TopControllerGetting {
 internal protocol URLOpening {
     var universalLinkHostAllowList: [String]? { get }
 
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?)
+    func open(_ url: URL, completionHandler: @escaping (() -> Void))
     func open(potentialUniversalLink: URL) -> Bool
 }
 
@@ -89,6 +89,10 @@ extension UIApplication: TopControllerGetting {
 extension UIApplication: URLOpening {
     var universalLinkHostAllowList: [String]? {
         Bundle.main.object(forInfoDictionaryKey: "AppcuesUniversalLinkHostAllowList") as? [String]
+    }
+
+    func open(_ url: URL, completionHandler: @escaping (() -> Void)) {
+        open(url, options: [:]) { _ in completionHandler() }
     }
 
     func open(potentialUniversalLink url: URL) -> Bool {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEffectsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEffectsTrait.swift
@@ -69,9 +69,9 @@ private extension AppcuesEffectsTrait {
             let container = try decoder.container(keyedBy: CodingKeys.self)
 
             self.presentationStyle = try container.decode(PresentationStyle.self, forKey: .presentationStyle)
-            self.duration = (try container.decodeIfPresent(Int.self, forKey: .duration)) ?? 2000
+            self.duration = (try container.decodeIfPresent(Int.self, forKey: .duration)) ?? 2_000
             self.intensity = (try container.decodeIfPresent(Double.self, forKey: .intensity)) ?? 1
-            self.style = (try container.decodeIfPresent(EffectStyle.self, forKey: AppcuesEffectsTrait.Config.CodingKeys.style)) ?? EffectStyle(colors: nil)
+            self.style = (try container.decodeIfPresent(EffectStyle.self, forKey: .style)) ?? EffectStyle(colors: nil)
         }
     }
 
@@ -97,7 +97,7 @@ private extension AppcuesEffectsTrait {
                 defer {
                     UIGraphicsEndImageContext()
                 }
-                
+
                 guard let context = UIGraphicsGetCurrentContext() else { return nil }
                 context.setFillColor(UIColor.white.cgColor)
 
@@ -124,7 +124,7 @@ private extension AppcuesEffectsTrait {
         }()
 
         init(config: Config) {
-            self.duration = Double(config.duration) / 1000
+            self.duration = Double(config.duration) / 1_000
             self.intensity = config.intensity
             self.colors = (config.style.colors ?? ["#5C5CFF", "#20E0D6", "#FF5290"]).compactMap { UIColor(hex: $0) }
             super.init(frame: .zero)

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -293,9 +293,9 @@ extension AppcuesLinkActionTests {
         var universalLinkHostAllowList: [String]?
 
         var onOpen: ((URL) -> Void)?
-        func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler: ((Bool) -> Void)?) {
+        func open(_ url: URL, completionHandler: @escaping (() -> Void)) {
             onOpen?(url)
-            completionHandler?(true)
+            completionHandler()
         }
 
         var onUniversalOpen: ((URL) -> Bool)?

--- a/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/QualifyResponseDecodeTests.swift
@@ -226,7 +226,11 @@ class QualifyResponseDecodeTests: XCTestCase {
 
 
         XCTAssertEqual(item0.error, "Error parsing Experience JSON data: Expected key \'type\' not found at codingPath: experiences.0.steps.0.children.0.content")
-        XCTAssertEqual(item5.error, "Error parsing Experience JSON data: Cannot get unkeyed decoding container -- found null value instead codingPath: experiences.5.steps.0.children.0.type")
+        if #available(iOS 18.0, *) {
+            XCTAssertEqual(item5.error, "Error parsing Experience JSON data: Cannot get value of type String -- found null value instead codingPath: experiences.5.steps.0.children.0.type")
+        } else {
+            XCTAssertEqual(item5.error, "Error parsing Experience JSON data: Cannot get unkeyed decoding container -- found null value instead codingPath: experiences.5.steps.0.children.0.type")
+        }
         XCTAssertEqual(item7.error, "Error parsing Experience JSON data: Expected to decode String but found number instead. codingPath: experiences.7.steps.0.type")
     }
 }


### PR DESCRIPTION
As noted in #549, there's a compile error for Xcode 16/iOS 18 caused by the addition of `@MainActor @Sendable` to `UIApplication.open(_:options:completionHandler:)`. To maintain backwards compatibility I've added a different function to the protocol and then called `UIApplication.open` instead of updating the protocol to include `@MainActor @Sendable`.

Also updated tests to pass.

We still need to complete a wider audit of things on iOS 18 to ensure there's no issues, but this ensures teams aren't blocked by a compile error.