### PR TITLE
Add configuration option for step recovery observer

### DIFF
--- a/Sources/AppcuesKit/Appcues+Config.swift
+++ b/Sources/AppcuesKit/Appcues+Config.swift
@@ -50,6 +50,8 @@ public extension Appcues {
 
         var enableTextScaling = false
 
+        var enableStepRecoveryObserver = true
+
         /// Create an Appcues SDK configuration
         /// - Parameter accountID: Appcues Account ID - a string containing an integer, copied from the Account settings page in Studio.
         /// - Parameter applicationID: Appcues Application ID - a string containing a UUID,
@@ -206,6 +208,22 @@ public extension Appcues {
         @objc
         public func enableTextScaling(_ enabled: Bool) -> Self {
             self.enableTextScaling = enabled
+            return self
+        }
+
+        /// Set the step recovery observation preference for the configuration.
+        ///
+        /// When this option is enabled, Appcues will detect recoverable step errors and attempt to retry when scroll changes
+        /// are observed. Observation uses method swizzling on `UIScrollView`.
+        ///
+        /// The default value for this configuration is `true`.
+        ///
+        /// - Parameter enabled: Whether step recovery observation is enabled.
+        /// - Returns: The `Configuration` object.
+        @discardableResult
+        @objc
+        public func enableStepRecoveryObserver(_ enabled: Bool) -> Self {
+            self.enableStepRecoveryObserver = enabled
             return self
         }
     }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -196,7 +196,7 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
             // we always add an analytics observer, it will internally filter out unpublished flows (builder previews)
             stateMachine.addObserver(analyticsObserver)
 
-            if experience.renderContext == .modal {
+            if experience.renderContext == .modal && config.enableStepRecoveryObserver {
                 // add recovery observer - on recoverable step errors, initiate recovery and retry
                 stateMachine.addObserver(stepRecoveryObserver)
             }

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -32,6 +32,7 @@ class PublicAPITests: XCTestCase {
             .additionalAutoProperties(["test": "value"])
             .enableUniversalLinks(true)
             .enableTextScaling(true)
+            .enableStepRecoveryObserver(true)
 
         let appcuesInstance = Appcues(config: config)
 


### PR DESCRIPTION
Setting this config to false will disable swizzling of UIScrollView but also disable our ability to show tooltips below the fold as the user scrolls