### PR TITLE
Add support for swipe-to-dismiss of slideouts

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -51,8 +51,8 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
             self.view = closeButton
         }
 
-        // Allow interactive dismissal
-        containerController.isModalInPresentation = false
+        // Allow interactive dismissal if the backdrop is configured to be dismissable
+        containerController.isModalInPresentation = ignoreBackdropTap
     }
 
     func undecorate(containerController: AppcuesExperienceContainerViewController) throws {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController+DragDirection.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController+DragDirection.swift
@@ -1,0 +1,91 @@
+//
+//  ExperienceWrapperViewController+DragDirection.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-09-27.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+extension ExperienceWrapperViewController {
+    struct DragDirection {
+        enum Edge {
+            case left, right, up, down
+        }
+
+        let xDirection: Edge
+        let yDirection: Edge
+
+        private let initialPoint: CGPoint
+        private let newPoint: CGPoint
+
+        init(initial: CGPoint, new: CGPoint) {
+            self.initialPoint = initial
+            self.newPoint = new
+            self.xDirection = new.x > initial.x ? .right : .left
+            self.yDirection = new.y > initial.y ? .down : .up
+        }
+
+        /// Determine which edges are eligible for drag-to-dismiss.
+        static func allowedEdges(horizontalAlignment: HorizontalAlignment, verticalAlignment: VerticalAlignment) -> Set<Edge> {
+            switch (horizontalAlignment, verticalAlignment) {
+            case (.leading, _):
+                return [.left]
+            case (.trailing, _):
+                return [.right]
+            case (_, .top):
+                return [.up]
+            case (_, .bottom),
+                (.center, .center):
+                return [.down]
+            default:
+                return []
+            }
+        }
+
+        /// Calculate the new center point, applying rubber-banding if dragging towards an ineligible edge.
+        func newPoint(allowedEdges: Set<Edge>) -> CGPoint {
+            let newX: CGFloat
+            let newY: CGFloat
+
+            if allowedEdges.contains(xDirection) {
+                newX = newPoint.x
+            } else {
+                let deltaX = newPoint.x - initialPoint.x
+                newX = initialPoint.x + (deltaX > 0 ? pow(deltaX, 0.5) : -pow(-deltaX, 0.5))
+            }
+
+            if allowedEdges.contains(yDirection) {
+                newY = newPoint.y
+            } else {
+                let deltaY = newPoint.y - initialPoint.y
+                newY = initialPoint.y + (deltaY > 0 ? pow(deltaY, 0.5) : -pow(-deltaY, 0.5))
+            }
+
+            return CGPoint(x: newX, y: newY)
+        }
+
+        /// Confirm if the new position will be entirely outsize the visible bounds on an eligible edge.
+        func isSufficientToDismiss(allowedEdges: Set<Edge>, size: CGRect, bounds: CGRect) -> Bool {
+            if allowedEdges.contains(.left) && newPoint.x + size.width / 2 < bounds.minX {
+                return true
+            }
+
+            if allowedEdges.contains(.right) && newPoint.x - size.width / 2 > bounds.maxX {
+                return true
+            }
+
+            if allowedEdges.contains(.up) && newPoint.y + size.height / 2 < bounds.minY {
+                return true
+            }
+
+            if allowedEdges.contains(.down) && newPoint.y - size.height / 2 > bounds.maxY {
+                return true
+            }
+
+            return false
+        }
+    }
+}


### PR DESCRIPTION
The idea here is to allow slideouts to swipe-to-dismiss similar to how a cover/half sheet would. That means a few things:
1. Only allowed when `isModalInPresentation == false`. This is controlled by the skippable trait. Otherwise the view can be dragged a bit, but rubber-bands back to the original position.
2. The view can be dragged in the dismissal direction (down for a sheet, to an adjacent edge for a slideout). Dragging otherwise (up for a sheet, towards non-adjacent edges for a slideout) will respond, but with a rubber-band effect to indicate it's being dragged in an unsupported direction.
3. The drag gestures are appropriately responsive, smooth, and feel "right".

Nothing here is too complicated. Process is as follows:
1. On presenting the modal, figure out which edges are allowed for drag-to-dismiss (`DragDirection.allowedEdges`) and attach the pan gesture
2. On pan, move the view around, scaling back the distance if dragging in a disallowed direction (`DragDirection.newPoint`)
3. On pan end, figure out if the view would end up outside the screen bounds and and dismiss the view controller if it will (`DragDirection.isSufficientToDismiss`)

The actual gesture handling is quite similar to the debugger floating button and uses the techniques from the classic [Building Fluid Interfaces](https://medium.com/@nathangitter/building-fluid-interfaces-ios-swift-9732bb934bf5) article.