### PR TITLE
Update modal context traits to present in their own UIWindow

### DIFF
--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
@@ -1,0 +1,95 @@
+//
+//  ModalContextManager.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-09-25.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+internal class ModalContextManager {
+    var presentingWindow: AppcuesUIWindow?
+
+    func present(viewController: UIViewController, useSameWindow: Bool = false, completion: (() -> Void)?) throws {
+        guard !useSameWindow else {
+            try presentInSameWindow(viewController: viewController, completion: completion)
+            return
+        }
+
+        guard let windowScene = UIApplication.shared.activeWindowScenes.first else {
+            throw AppcuesTraitError(description: "No active window scene")
+        }
+
+        let window = AppcuesUIWindow(windowScene: windowScene)
+
+        guard let rootViewController = window.rootViewController else {
+            throw AppcuesTraitError(description: "No root view controller")
+        }
+
+        rootViewController.present(viewController, animated: true, completion: completion)
+
+        presentingWindow = window
+    }
+
+    private func presentInSameWindow(viewController: UIViewController, completion: (() -> Void)?) throws {
+        guard let topViewController = UIApplication.shared.topViewController() else {
+            throw AppcuesTraitError(description: "No top VC found")
+        }
+
+        topViewController.present(viewController, animated: true, completion: completion)
+    }
+
+    func remove(viewController: UIViewController, completion: (() -> Void)?) {
+        viewController.dismiss(animated: true) {
+            self.presentingWindow = nil
+            completion?()
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension ModalContextManager {
+    class AppcuesUIWindow: UIWindow {
+        override init(windowScene: UIWindowScene) {
+            super.init(windowScene: windowScene)
+
+            rootViewController = AppcuesWindowRootViewController()
+            isHidden = false
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+            guard let hitView = super.hitTest(point, with: event), hitView != self else {
+                return nil
+            }
+
+            // Ignore UITransitionViews to allow interaction with the underlying app while the window is overlayed.
+            if String(describing: type(of: hitView)) == "UITransitionView" {
+                return nil
+            }
+
+            return hitView
+        }
+    }
+
+    class AppcuesWindowRootViewController: UIViewController {
+        init() {
+            super.init(nibName: nil, bundle: nil)
+
+            // Ensure this root view isn't eligible for a hitTest
+            // (any ViewController it presents will be though)
+            view.alpha = 0
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -34,6 +34,8 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
+    let modalContextManager = ModalContextManager()
+
     private let presentationStyle: PresentationStyle
     private let modalStyle: ExperienceComponent.Style?
     private let transition: Transition
@@ -79,15 +81,15 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
     }
 
     func present(viewController: UIViewController, completion: (() -> Void)?) throws {
-        guard let topViewController = UIApplication.shared.topViewController() else {
-            throw AppcuesTraitError(description: "No top VC found")
-        }
-
-        topViewController.present(viewController, animated: true, completion: completion)
+        try modalContextManager.present(
+            viewController: viewController,
+            useSameWindow: presentationStyle.useSameWindow,
+            completion: completion
+        )
     }
 
     func remove(viewController: UIViewController, completion: (() -> Void)?) {
-        viewController.dismiss(animated: true, completion: completion)
+        modalContextManager.remove(viewController: viewController, completion: completion)
     }
 }
 
@@ -109,6 +111,15 @@ extension AppcuesModalTrait {
                 return .formSheet
             case .halfSheet:
                 return .formSheet
+            }
+        }
+
+        var useSameWindow: Bool {
+            switch self {
+            case .full, .dialog:
+                return false
+            case .sheet, .halfSheet:
+                return true
             }
         }
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
@@ -23,6 +23,8 @@ internal class AppcuesTooltipTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCr
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
+    let modalContextManager = ModalContextManager()
+
     let tooltipStyle: ExperienceComponent.Style?
     let hidePointer: Bool
     let pointerSize: CGSize
@@ -80,14 +82,10 @@ internal class AppcuesTooltipTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCr
     }
 
     func present(viewController: UIViewController, completion: (() -> Void)?) throws {
-        guard let topViewController = UIApplication.shared.topViewController() else {
-            throw AppcuesTraitError(description: "No top VC found")
-        }
-
-        topViewController.present(viewController, animated: true, completion: completion)
+        try modalContextManager.present(viewController: viewController, completion: completion)
     }
 
     func remove(viewController: UIViewController, completion: (() -> Void)?) {
-        viewController.dismiss(animated: true, completion: completion)
+        modalContextManager.remove(viewController: viewController, completion: completion)
     }
 }


### PR DESCRIPTION
The `@appcues/modal` and `@appcues/tooltip` trait now present via the new `ModalContextManager` which manages the lifecycle of a `UIWindow` that's overlaid over the application to present modals and tooltips. This PR sets the foundation for the backdrop passthrough logic that's up next.

## Notes
1. I created `ModalContextManager` to avoid having the exact same code in both the modal and tooltip traits. 
2. I considered having `ModalContextManager` only create a single window for the whole `Appcues` instance, but then ownership gets complicated and it's the job of the state machine anyways to make sure there's not multiple modals being presented.
3. There's an exception `useSameWindow: false` for the sheet modals that uses the old approach to preserve the scale animation of the presenting view controller.
4. `AppcuesUIWindow` needs an empty root view controller (instead of using the modal controller) to be able to do the expected presentation animation of the modal controller.
5. `AppcuesUIWindow` is similar to the `DebugUIWindow` in how it ignores hit events.
