### PR TITLE
Ignore touches on backdrop with no traits

### DIFF
--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/Base.lproj/Main.storyboard
@@ -722,7 +722,6 @@ With embeds, this paradigm changes, and a qualification response may contain zer
                                         <buttonConfiguration key="configuration" style="tinted" title="Trigger Event 3"/>
                                         <connections>
                                             <action selector="buttonThreeTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="CgE-x1-GH2"/>
-                                            <action selector="buttonTwoTapped:" destination="IV4-7k-Qev" eventType="touchUpInside" id="Mrc-oW-IJA"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="1003" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2Eb-Go-11n">

--- a/Sources/AppcuesKit/Presentation/Extensions/FrameObserverView.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/FrameObserverView.swift
@@ -12,6 +12,16 @@ internal class FrameObserverView: UIView {
     private var oldBounds: CGRect = .zero
     var onChange: ((_ bounds: CGRect) -> Void)?
 
+    init() {
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         if oldBounds != bounds {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -19,6 +19,7 @@ internal class AppcuesBackdropTrait: AppcuesBackdropDecoratingTrait {
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
     private let backgroundColor: UIColor
+    private var backdropBackgroundView: UIView?
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
         guard let config = configuration.decode(Config.self),
@@ -30,23 +31,36 @@ internal class AppcuesBackdropTrait: AppcuesBackdropDecoratingTrait {
 
     func decorate(backdropView: UIView) throws {
         guard let metadataDelegate = metadataDelegate else {
-            backdropView.backgroundColor = backgroundColor
+            handleAdd(backdropColor: backgroundColor, to: backdropView)
             return
         }
 
         metadataDelegate.set(["backdropBackgroundColor": backgroundColor])
 
-        metadataDelegate.registerHandler(for: Self.type, animating: true) { metadata in
-            backdropView.backgroundColor = metadata["backdropBackgroundColor"]
+        metadataDelegate.registerHandler(for: Self.type, animating: true) { [weak self] metadata in
+            self?.handleAdd(backdropColor: metadata["backdropBackgroundColor"], to: backdropView)
         }
     }
 
     func undecorate(backdropView: UIView) throws {
         guard let metadataDelegate = metadataDelegate else {
-            backdropView.backgroundColor = nil
+            backdropBackgroundView?.removeFromSuperview()
+            backdropBackgroundView = nil
             return
         }
 
         metadataDelegate.unset(keys: [ "backdropBackgroundColor" ])
+    }
+
+    private func handleAdd(backdropColor: UIColor?, to backdropView: UIView) {
+        if let backdropBackgroundView = self.backdropBackgroundView {
+            backdropBackgroundView.backgroundColor = backdropColor
+        } else {
+            let backdropBackgroundView = UIView()
+            backdropBackgroundView.backgroundColor = backdropColor
+            backdropView.insertSubview(backdropBackgroundView, at: 0)
+            backdropBackgroundView.pin(to: backdropView)
+            self.backdropBackgroundView = backdropBackgroundView
+        }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEffectsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEffectsTrait.swift
@@ -32,6 +32,7 @@ internal class AppcuesEffectsTrait: AppcuesBackdropDecoratingTrait {
             effectView = confettiView
         }
 
+        effectView.isUserInteractionEnabled = false
         backdropView.addSubview(effectView)
         effectView.pin(to: backdropView)
         self.effectView = effectView

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -66,7 +66,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
     }
 
     private func handle(backdropView: UIView, metadata: AppcuesTraitMetadata) {
-        guard var newTarget: CGRect = metadata["targetRectangle"] else {
+        guard var newTarget: CGRect = metadata["targetRectangle"], metadata["backdropBackgroundColor"] != nil else {
             targetView.removeFromSuperview()
             return
         }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
@@ -9,11 +9,11 @@
 import UIKit
 
 @available(iOS 13.0, *)
-internal class ExperienceWrapperView: UIView {
+internal class ExperienceWrapperView: HitTestingOverrideUIView {
 
     var preferredContentSize: CGSize?
 
-    let backdropView = UIView()
+    let backdropView = HitTestingOverrideUIView(overrideApproach: .ignoreSelf)
 
     let contentWrapperView: UIView = {
         // contentWrapperView can take a tooltip shape mask, so ignore hits outside that shape when it's set.
@@ -27,7 +27,7 @@ internal class ExperienceWrapperView: UIView {
     let shadowWrappingView: UIView = HitTestingOverrideUIView(overrideApproach: .ignoreSelf)
 
     required init() {
-        super.init(frame: .zero)
+        super.init(overrideApproach: .ignoreSelf)
 
         backgroundColor = .clear
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController+DragDirection.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController+DragDirection.swift
@@ -37,8 +37,7 @@ extension ExperienceWrapperViewController {
                 return [.right]
             case (_, .top):
                 return [.up]
-            case (_, .bottom),
-                (.center, .center):
+            case (_, .bottom):
                 return [.down]
             default:
                 return []


### PR DESCRIPTION
Here's the idea:
1. The `ExperienceWrapperView` becomes a `HitTestingOverrideUIView(overrideApproach: .ignoreSelf)` so only hits in it's content are captured
2. The `ExperienceWrapperView.backdropView` also becomes a `HitTestingOverrideUIView(overrideApproach: .ignoreSelf)` so it doesn't capture any hits unless it has subviews that do.
3. We update the `AppcuesBackdropDecoratingTrait` to make sure they use subviews that do/don't capture hits as desired
    1. `@appcues/backdrop` adds a subview now (instead of setting the color directly) that **does** capture hits
    2. `@appcues/effects` does `effectView.isUserInteractionEnabled` so it **does not** capture hits (note that we can still have effects without a backdrop and in that case the user can interact with the app under the confetti)
    3. `@appcues/target-element` and `@appcues/target-rectangle` use a `FrameObserverView` in the backdrop which now has `isUserInteractionEnabled = false` so it **does not** capture hits
    4. `@appcues/target-interaction` now checks for `metadata["backdropBackgroundColor"] != nil` before adding the target view to ensure that there's no target capture view if there's no backdrop (because it's weird to have an invisible section of the screen do something different)
    5. `@appcues/skippable` is unchanged, but it adds a gesture recognizer to `backdropView` so the skip backdrop tap only applies if the backdrop view is capturing a hit from one of the other traits

To summarize, touches will flow through to the app if there is no `@appcues/backdrop` trait 😎 

# Other approaches
My first attempt at this set `backdropView.alpha = 0` to disable hits and then had the backdrop trait set the alpha back to 1, but this was very fragile because other traits theoretically might need too change that value too and then slideout animator would change it and lots of things could go wrong, even if I could make it work right now. The backdrop subview approach is much nicer, and actually is what we recommend in the trait docs, so that;'s a win for forward thinking:
```
/// Prefer adding a subview to `backdropView` over modifying `backdropView` itself where possible
/// to preserve composability of multiple traits.
```

I also included the slideout swipe-to-dismiss update to not allow swiping for centered slideouts in this PR