### PR TITLE
Add _timezoneOffset auto property

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AutoPropertyDecorator.swift
@@ -35,7 +35,8 @@ internal class AutoPropertyDecorator: AnalyticsDecorating {
             "_sdkName": "appcues-ios",
             "_osVersion": UIDevice.current.systemVersion,
             "_deviceType": UIDevice.current.userInterfaceIdiom.analyticsName,
-            "_deviceModel": UIDevice.current.modelName
+            "_deviceModel": UIDevice.current.modelName,
+            "_timezoneOffset": TimeZone.current.minutesFromGMT()
         ]
     }()
 
@@ -180,6 +181,12 @@ extension UIDevice {
             guard let value = element.value as? Int8, value != 0 else { return }
             identifier += String(UnicodeScalar(UInt8(value)))
         }
+    }
+}
+
+extension TimeZone {
+    func minutesFromGMT() -> Int {
+        TimeZone.current.secondsFromGMT() / 60
     }
 }
 

--- a/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AutoPropertyDecoratorTests.swift
@@ -37,7 +37,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
         let expectedPropertyKeys = ["_identity", "CUSTOM"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId", "_pushPrimerEligible"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_timezoneOffset", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId", "_pushPrimerEligible"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.identityAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
         XCTAssertNil(decorated.deviceAutoProperties)
     }
@@ -54,9 +54,9 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
         let expectedPropertyKeys = ["_identity", "_device", "CUSTOM"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionRandomizer", "_sessionId", "_pushPrimerEligible"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_timezoneOffset", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionRandomizer", "_sessionId", "_pushPrimerEligible"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.identityAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
-        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_pushToken", "_pushEnabledBackground", "_pushEnabled", "_pushEnvironment", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
+        let expectedEventDeviceAutoPropertyKeys = ["_deviceId", "_language", "_pushToken", "_pushEnabledBackground", "_pushEnabled", "_pushEnvironment", "_deviceType", "_appBuild", "_appId", "_operatingSystem", "_bundlePackageId", "_deviceModel", "_timezoneOffset", "_appVersion", "_sdkVersion", "_osVersion", "_sdkName", "_appName"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.deviceAutoProperties).keys).symmetricDifference(expectedEventDeviceAutoPropertyKeys))
     }
 
@@ -70,7 +70,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         // Assert
         let expectedContextKeys = ["app_id", "app_version"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
-        let expectedPropertyKeys = ["CUSTOM", "userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId", "_pushPrimerEligible"]
+        let expectedPropertyKeys = ["CUSTOM", "userId",  "_deviceModel", "_timezoneOffset", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId", "_pushPrimerEligible"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
         XCTAssertNil(decorated.identityAutoProperties)
         XCTAssertNil(decorated.deviceAutoProperties)
@@ -105,7 +105,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         let decorated = decorator.decorate(update)
 
         // Assert
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId", "_pushPrimerEligible", "_myProp"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_timezoneOffset", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_currentScreenTitle", "_sessionId", "_pushPrimerEligible", "_myProp"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.identityAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
         XCTAssertNil(decorated.deviceAutoProperties)
 
@@ -130,7 +130,7 @@ class AutoPropertyDecoratorTests: XCTestCase {
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.context).keys).symmetricDifference(expectedContextKeys))
         let expectedPropertyKeys = ["_identity"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.properties).keys).symmetricDifference(expectedPropertyKeys))
-        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId", "_pushPrimerEligible", "PROFILE_PROPERTY"]
+        let expectedEventAutoPropertyKeys = ["userId",  "_deviceModel", "_timezoneOffset", "_bundlePackageId", "_lastBrowserLanguage", "_localId", "_appName", "_lastSeenAt", "_updatedAt", "_sdkVersion", "_osVersion", "_operatingSystem", "_deviceType", "_appVersion", "_isAnonymous", "_appBuild", "_sdkName", "_appId", "_sessionPageviews", "_sessionId", "_pushPrimerEligible", "PROFILE_PROPERTY"]
         XCTAssertEqual([], Set(try XCTUnwrap(decorated.identityAutoProperties).keys).symmetricDifference(expectedEventAutoPropertyKeys))
         XCTAssertNil(decorated.deviceAutoProperties)
     }


### PR DESCRIPTION
Will help support options in the future to only send push notifications within certain time windows in the device's timezone. This property is set at the user level (last known value) and each device level.

<img width="759" alt="Screenshot 2024-10-07 at 9 22 26 AM" src="https://github.com/user-attachments/assets/fbbfc90f-81b7-4a8c-b5f4-ea624e7618fa">
