### PR TITLE
Small window edge case enhancements

### DIFF
--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesTraitMetadata.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesTraitMetadata.swift
@@ -43,6 +43,11 @@ internal class AppcuesTraitMetadata: NSObject {
     }
 
     /// Accesses the value associated with the given key for reading.
+    internal subscript(isSet key: String) -> Bool {
+        newData[key] != nil
+    }
+
+    /// Accesses the value associated with the given key for reading.
     internal subscript<T>(_ key: String) -> T? {
         newData[key] as? T
     }

--- a/Sources/AppcuesKit/Presentation/Public/UIWindow+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Public/UIWindow+Appcues.swift
@@ -16,7 +16,7 @@ public extension UIWindow {
     /// that are overlaid on top of the application, when capturing screen layout information.
     var isAppcuesWindow: Bool {
         if #available(iOS 13.0, *) {
-            return self is DebugUIWindow
+            return self is DebugUIWindow || self is ModalContextManager.AppcuesUIWindow
         } else {
             return false
         }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -66,7 +66,7 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
     }
 
     private func handle(backdropView: UIView, metadata: AppcuesTraitMetadata) {
-        guard var newTarget: CGRect = metadata["targetRectangle"], metadata["backdropBackgroundColor"] != nil else {
+        guard var newTarget: CGRect = metadata["targetRectangle"], metadata[isSet: "backdropBackgroundColor"] else {
             targetView.removeFromSuperview()
             return
         }


### PR DESCRIPTION
A couple little tweaks in the wake of the UIWindow (#566) and backdrop (#567) changes. I haven't seen these impact 4.1.0, but they're things that could potentially cause unexpected behaviours.

1. The `isAppcuesWindow` check now also catches the `ModalContextManager.AppcuesUIWindow`. This could matter when determining the window to screen capture. It's unlikely to actually matter because "array orders the windows from back to front by window level" ([ref](https://developer.apple.com/documentation/uikit/uiapplication/1623104-windows#discussion)), and screen capture looks for the first non-appcues window, but good to be safe here.
2. Doing `metadata["backdropBackgroundColor"] != nil` isn't quite doing what you'd expect because of the generic <T> casting, so I added a `metadata[isSet:]` subscript that makes the callsite a lot clearer.