### PR TITLE
Add support for @appcues/target-interaction pass through

### DIFF
--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -135,19 +135,21 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
 
 @available(iOS 13.0, *)
 extension AppcuesTargetInteractionTrait {
-    class TargetView: UIView {
+    class TargetView: UIView, UIGestureRecognizerDelegate {
         private weak var appWindow: UIWindow?
         private weak var trait: AppcuesTargetInteractionTrait?
 
         private lazy var tapRecognizer: UITapGestureRecognizer = {
             let recognizer = UITapGestureRecognizer(target: self, action: #selector(didTapInApp(recognizer:)))
             recognizer.cancelsTouchesInView = false
+            recognizer.delegate = self
             return recognizer
         }()
 
         private lazy var longPressRecognizer: UILongPressGestureRecognizer = {
             let recognizer = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressInApp(recognizer:)))
             recognizer.cancelsTouchesInView = false
+            recognizer.delegate = self
             return recognizer
         }()
 
@@ -198,6 +200,10 @@ extension AppcuesTargetInteractionTrait {
             } else {
                 return self
             }
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            true
         }
 
         @objc


### PR DESCRIPTION
Add support for interacting with the app through the tooltip target keyhole. I explored a lot of different approaches here and settled on this because:
1. it works
2. it's less likely to interfere with the customer's app or impact performance (no swizzling)
3. it requires no configuration (some delegate or custom window approach)
4. it should work x-plat (need to test and confirm)
5. it's all isolated in the target interaction trait where it belongs and is simple enough to understand

## How it works
1. We override the `hitTest` in the `TargetView` created by the `@appcues/target-interaction` trait to
    1. find the view in the app window that will be hit
    2. attach a tap gesture recognizer to that view with `cancelsTouchesInView = false` (`cancelsTouchesInView` is the key to ensure the app still does the interaction it’s supposed to)
        - I've tested UIButton's, views with `isUserInteractionEnabled = true/false`, added gesture recognizers, scrolling. Interesting, UITextFields won't focus which is honestly kinda nice)
    3. return
2. when the gesture recognizer is triggered
    1. remove the gesture recognizer (it'll be re-added if necessary)
    2. call the target interaction actions
3. add other safe guard to guarantee that the gesture recognizer gets removed when the target view does (ie override `willMove` in the case that the gesture in the target area isn’t actually a tap (ie pan/swipe)

If `enablePassThrough == false` (or isn't set, like all our existing published experiences), the `appWindow` will be `nil` and we attach the gesture recognizers to the `TargetView` so target interaction works the way it always has by triggering actions, but blocking interaction.

## How it could break
1. If the app has multiple windows layered, we could be looking in the wrong one.
    - I'm using the same approach as screen capturing, and we haven't had any issues there.
2. Adding gesture recognizers could cause issues with app logic. It shouldn't in most cases because `cancelsTouchesInView` essentially makes it transparent, but if there's logic in-app that checks the `view.gestureRecognizers` array or something like that, it could be unexpected.
    - If there is a conflict, a customer can just toggle of the pass through in the mobile builder.

Otherwise, I'm using the same hit detection in the app window that UIKit uses, so there should be no issues there, and I'm making sure the added gesture recognizers get removed when the target view disappears so there's no oddness when the flow is hidden. If the user doesn't interact with the target area, nothing happens to the app.

I'll look into some UI tests to test the functionality since I don't think it's really possible to unit test.