### PR TITLE
Custom components

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -13,10 +13,11 @@
 		31B667E890BBB65B74BD7B75 /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 98AA47DD8A38D313178BD4DA /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3EADA9762D050C3E2ED69514 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */; };
 		40A181AE1ED5DE1982FA05CC /* Mulish-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */; };
-		4E653010DACC7F8D3954F618 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67397D745827CC2653C2408E /* Pods_AppcuesCocoapodsExample.framework */; };
 		622C6559F57A6A19F18D46C4 /* EmbedTestHarnessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */; };
 		64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB61619365785F4544ED13D /* GroupViewController.swift */; };
 		68E596FD295BCC69F06AF0B4 /* DeepLinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5548F50894583A174A85628C /* DeepLinkNavigator.swift */; };
+		6C3E045C72D46C97D77C0D6A /* Pods_NotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CFF8DE34B367525EC992CF2 /* Pods_NotificationServiceExtension.framework */; };
+		7E34FE77B4FD542D82D7F627 /* LiveStreamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D589CCB0B728CB0A41B9783 /* LiveStreamViewController.swift */; };
 		866AA363BEFB1A42C8C1D149 /* Lato-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 547A647EB6D311E97F592C7C /* Lato-Black.ttf */; };
 		8F7329B0046118A1DFA8B58D /* EmbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */; };
 		9E6FF9F4B22B8874E5AA6544 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93D50517BBE18B336D130E13 /* LaunchScreen.storyboard */; };
@@ -24,10 +25,10 @@
 		A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */; };
 		B246D604B3AA669DFA5E25FB /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34615287562F7C453579B60 /* NotificationService.swift */; };
 		B62E50722A74862AEBD2DE44 /* ScrollingTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F518475589397A213D89DA /* ScrollingTableViewController.swift */; };
+		BF898BFDE8EF4586D3214DD6 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D1E400AA9BF2D0A2CA7991B /* Pods_AppcuesCocoapodsExample.framework */; };
 		CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384497BA35A275E793B475C1 /* ProfileViewController.swift */; };
 		CD156254F042866368E77CC3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 024025AF9E2E0D38C368A6AC /* Main.storyboard */; };
 		DBE453F2B40A01B4818CB84E /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */; };
-		E3A34502A41D8EA10E921375 /* Pods_NotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BCC36F620615082E7875EA5 /* Pods_NotificationServiceExtension.framework */; };
 		E92BC1A5B0C87A1E9A3E08EE /* AppDelegate+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD624398B79925BABBF277E4 /* AppDelegate+Push.swift */; };
 		EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D26E6136C6539597C9E50A9 /* EventsViewController.swift */; };
 /* End PBXBuildFile section */
@@ -57,32 +58,33 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0CFF8DE34B367525EC992CF2 /* Pods_NotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		33558EA87F74CF18DDF92F09 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		384497BA35A275E793B475C1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
-		406EEBD76B1C0EE3B163A63D /* Pods-NotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		3D589CCB0B728CB0A41B9783 /* LiveStreamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStreamViewController.swift; sourceTree = "<group>"; };
+		3FD923C72C74ED29B9E97F28 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedViewController.swift; sourceTree = "<group>"; };
-		53E05622C33B9E513477CD1B /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
 		547A647EB6D311E97F592C7C /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
 		5548F50894583A174A85628C /* DeepLinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkNavigator.swift; sourceTree = "<group>"; };
 		5DC2B62290580560D162A8E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		67397D745827CC2653C2408E /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6BCC36F620615082E7875EA5 /* Pods_NotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82DED1437C1DA54F0C231566 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8663BEDD1883CC408AA4A302 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
-		86CAABEE395765AD8830295B /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
+		86661CE04BD4FF7FDD382219 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedTestHarnessViewController.swift; sourceTree = "<group>"; };
 		98AA47DD8A38D313178BD4DA /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		9BDAE6518AD9511CC678055E /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		9CB61619365785F4544ED13D /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
+		9D1E400AA9BF2D0A2CA7991B /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D26E6136C6539597C9E50A9 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
+		9D9FA1799591E9C64207CF1E /* Pods-NotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		A05A73A257DA52CCE18DDC73 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Main.strings"; sourceTree = "<group>"; };
 		A3F518475589397A213D89DA /* ScrollingTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingTableViewController.swift; sourceTree = "<group>"; };
 		AA113FA372FB904082730474 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		AAD7ED9DCA5972361B3F5E67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		AB39F364E2EF869EFEEFAB55 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
 		CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		CFDBB85EB221CD35EEEFA497 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
@@ -94,34 +96,25 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		0ED793C4076205C0E3BEB55F /* Frameworks */ = {
+		486AAF6326EA0A45AA2B4882 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E3A34502A41D8EA10E921375 /* Pods_NotificationServiceExtension.framework in Frameworks */,
+				6C3E045C72D46C97D77C0D6A /* Pods_NotificationServiceExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9362A60303EF300A106A33F4 /* Frameworks */ = {
+		DD3C0A4D21FA69AC36BD607D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E653010DACC7F8D3954F618 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
+				BF898BFDE8EF4586D3214DD6 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		199BE04372E7427C6ABD3EC9 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				67397D745827CC2653C2408E /* Pods_AppcuesCocoapodsExample.framework */,
-				6BCC36F620615082E7875EA5 /* Pods_NotificationServiceExtension.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		1FE3F3C97CB4A18213B00765 /* NotificationServiceExtension */ = {
 			isa = PBXGroup;
 			children = (
@@ -143,6 +136,18 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		63A939EBC46015615C5C670C /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				86661CE04BD4FF7FDD382219 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
+				3FD923C72C74ED29B9E97F28 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+				9D9FA1799591E9C64207CF1E /* Pods-NotificationServiceExtension.debug.xcconfig */,
+				9BDAE6518AD9511CC678055E /* Pods-NotificationServiceExtension.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */ = {
 			isa = PBXGroup;
 			children = (
@@ -157,6 +162,7 @@
 				9CB61619365785F4544ED13D /* GroupViewController.swift */,
 				AAD7ED9DCA5972361B3F5E67 /* Info.plist */,
 				93D50517BBE18B336D130E13 /* LaunchScreen.storyboard */,
+				3D589CCB0B728CB0A41B9783 /* LiveStreamViewController.swift */,
 				024025AF9E2E0D38C368A6AC /* Main.storyboard */,
 				384497BA35A275E793B475C1 /* ProfileViewController.swift */,
 				25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */,
@@ -181,21 +187,18 @@
 				8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */,
 				1FE3F3C97CB4A18213B00765 /* NotificationServiceExtension */,
 				C743E51709EACC21B03B3A23 /* Products */,
-				CE5FC4E6086E051EC079213A /* Pods */,
-				199BE04372E7427C6ABD3EC9 /* Frameworks */,
+				63A939EBC46015615C5C670C /* Pods */,
+				D6601FAA5169FDC608FBD384 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
-		CE5FC4E6086E051EC079213A /* Pods */ = {
+		D6601FAA5169FDC608FBD384 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				AB39F364E2EF869EFEEFAB55 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
-				53E05622C33B9E513477CD1B /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
-				406EEBD76B1C0EE3B163A63D /* Pods-NotificationServiceExtension.debug.xcconfig */,
-				86CAABEE395765AD8830295B /* Pods-NotificationServiceExtension.release.xcconfig */,
+				9D1E400AA9BF2D0A2CA7991B /* Pods_AppcuesCocoapodsExample.framework */,
+				0CFF8DE34B367525EC992CF2 /* Pods_NotificationServiceExtension.framework */,
 			);
-			name = Pods;
-			path = Pods;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -205,9 +208,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA0D3F7775224770E811557C /* Build configuration list for PBXNativeTarget "NotificationServiceExtension" */;
 			buildPhases = (
-				08613277940A0339C5C52E30 /* [CP] Check Pods Manifest.lock */,
+				8B8F8747DD1AFBED516329A9 /* [CP] Check Pods Manifest.lock */,
 				0C533839B37BFF02997B30E6 /* Sources */,
-				0ED793C4076205C0E3BEB55F /* Frameworks */,
+				486AAF6326EA0A45AA2B4882 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,13 +225,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7200554C7EB6F6E4E0D35C70 /* Build configuration list for PBXNativeTarget "AppcuesCocoapodsExample" */;
 			buildPhases = (
-				EF125766F80FF937120F988F /* [CP] Check Pods Manifest.lock */,
+				19F658B1782213E98BB3DB06 /* [CP] Check Pods Manifest.lock */,
 				39C4F25C30C2C38F00378FED /* Sources */,
 				4B41B1A9E3D52747D92B7344 /* Resources */,
 				7F6C967FB8B2DE55E93EC3B1 /* Embed Foundation Extensions */,
 				6D4DB9FBC4445D937FD94125 /* SwiftLint */,
-				9362A60303EF300A106A33F4 /* Frameworks */,
-				9F5A5A3C05B9194E11D10AFA /* [CP] Embed Pods Frameworks */,
+				DD3C0A4D21FA69AC36BD607D /* Frameworks */,
+				A5B080497E77B72019AEDAAD /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -291,7 +294,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		08613277940A0339C5C52E30 /* [CP] Check Pods Manifest.lock */ = {
+		19F658B1782213E98BB3DB06 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -306,7 +309,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NotificationServiceExtension-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-AppcuesCocoapodsExample-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -331,24 +334,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.50.3\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
 		};
-		9F5A5A3C05B9194E11D10AFA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		EF125766F80FF937120F988F /* [CP] Check Pods Manifest.lock */ = {
+		8B8F8747DD1AFBED516329A9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -363,11 +349,28 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-AppcuesCocoapodsExample-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-NotificationServiceExtension-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A5B080497E77B72019AEDAAD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -392,6 +395,7 @@
 				8F7329B0046118A1DFA8B58D /* EmbedViewController.swift in Sources */,
 				EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */,
 				64C809F864D3002CD52993CD /* GroupViewController.swift in Sources */,
+				7E34FE77B4FD542D82D7F627 /* LiveStreamViewController.swift in Sources */,
 				CCD458B6662FC0AC5C80CAFF /* ProfileViewController.swift in Sources */,
 				A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */,
 				B62E50722A74862AEBD2DE44 /* ScrollingTableViewController.swift in Sources */,
@@ -435,7 +439,7 @@
 /* Begin XCBuildConfiguration section */
 		015038143918E0C7F9D7E873 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB39F364E2EF869EFEEFAB55 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
+			baseConfigurationReference = 86661CE04BD4FF7FDD382219 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -518,7 +522,7 @@
 		};
 		266E5C088CC8701B4117B193 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 53E05622C33B9E513477CD1B /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
+			baseConfigurationReference = 3FD923C72C74ED29B9E97F28 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -537,7 +541,7 @@
 		};
 		4F94E6007A88D980CC63B06F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 406EEBD76B1C0EE3B163A63D /* Pods-NotificationServiceExtension.debug.xcconfig */;
+			baseConfigurationReference = 9D9FA1799591E9C64207CF1E /* Pods-NotificationServiceExtension.debug.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -553,7 +557,7 @@
 		};
 		B77C4DA932BE4B036BA18244 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 86CAABEE395765AD8830295B /* Pods-NotificationServiceExtension.release.xcconfig */;
+			baseConfigurationReference = 9BDAE6518AD9511CC678055E /* Pods-NotificationServiceExtension.release.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/AppDelegate.swift
@@ -23,6 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Or, manually configure for push notifications
         // setupPush(application: application)
 
+        Appcues.registerCustomComponent(identifier: "liveStream", type: LiveStreamViewController.self)
+
         return true
     }
 

--- a/Examples/DeveloperCocoapodsExample/CocoapodsExample/LiveStreamViewController.swift
+++ b/Examples/DeveloperCocoapodsExample/CocoapodsExample/LiveStreamViewController.swift
@@ -1,0 +1,95 @@
+//
+//  LiveStreamViewController.swift
+//  AppcuesCocoapodsExample
+//
+//  Created by Matt on 2024-06-27.
+//
+
+import Foundation
+import AppcuesKit
+import AVKit
+
+#if DEBUG
+extension LiveStreamViewController {
+    static var debugConfig: [String: Any]? {
+        [
+            "url": "https://zssd-koala.hls.camzonecdn.com/CamzoneStreams/zssd-koala/Playlist.m3u8",
+            "showControls": false,
+            "isMuted": true
+        ]
+    }
+}
+#endif
+
+class LiveStreamViewController: UIViewController, AppcuesCustomComponentViewController {
+    struct Config: Decodable {
+        let url: URL
+        let showControls: Bool
+        let isMuted: Bool
+
+        enum CodingKeys: CodingKey {
+            case url
+            case showControls
+            case isMuted
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.url = try container.decode(URL.self, forKey: .url)
+            self.showControls = try container.decodeIfPresent(Bool.self, forKey: .showControls) ?? true
+            self.isMuted = try container.decodeIfPresent(Bool.self, forKey: .isMuted) ?? false
+        }
+    }
+
+    let config: Config
+    let actionController: AppcuesExperienceActions
+
+    var playerView: UIView?
+
+    required init?(configuration: AppcuesKit.AppcuesExperiencePluginConfiguration, actionController: AppcuesExperienceActions) {
+        guard let config = configuration.decode(Config.self) else { return nil }
+        self.config = config
+        self.actionController = actionController
+
+        super.init(nibName: nil, bundle: nil)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLayoutSubviews() {
+        print(view.frame, view.intrinsicContentSize)
+        preferredContentSize = CGSize(width: view.frame.width, height: view.frame.width * 0.5625)
+    }
+
+    func setup() {
+        let player = AVPlayer(url: config.url)
+        player.isMuted = config.isMuted
+
+        let viewController = AVPlayerViewController()
+        viewController.player = player
+        viewController.showsPlaybackControls = config.showControls
+
+        let playerView = viewController.view!
+        playerView.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(viewController)
+        view.addSubview(playerView)
+
+        NSLayoutConstraint.activate([
+            playerView.topAnchor.constraint(equalTo: view.topAnchor),
+            playerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            playerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            playerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        viewController.didMove(toParent: self)
+
+        self.playerView = playerView
+        player.play()
+    }
+}

--- a/Examples/DeveloperCocoapodsExample/Podfile.lock
+++ b/Examples/DeveloperCocoapodsExample/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Appcues (3.1.9)
-  - AppcuesNotificationService (0.1.0)
+  - Appcues (4.2.0)
+  - AppcuesNotificationService (4.2.0)
 
 DEPENDENCIES:
   - Appcues (from `../../Appcues.podspec`)
@@ -13,9 +13,9 @@ EXTERNAL SOURCES:
     :path: "../../AppcuesNotificationService.podspec"
 
 SPEC CHECKSUMS:
-  Appcues: 58ee609e4cff59090b20e8b251bc4ad2a5cc8cf0
-  AppcuesNotificationService: f7f11e9b156c50106b64b11f55eb0e02586198bd
+  Appcues: 0d2ccd7577dbf1b5e6c65d33630d6058abf1640e
+  AppcuesNotificationService: 0cebce4f4417b31881ee21e080a39d1a30fd3126
 
 PODFILE CHECKSUM: 24c643e3c9c013c74f5d561608aa37768cb0c43e
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		B8DB7327A11245904C6B908F /* DeepLinkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C043606EC23556B49010D3 /* DeepLinkNavigator.swift */; };
 		BF24A197BFEAF23D84AC3462 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6901798B6E99F34ACF2F707B /* SceneDelegate.swift */; };
 		DD6A303F8B4B0A8075C32454 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288554133C93206378D963AB /* SignInViewController.swift */; };
+		DF78178BBBBE4FED7E798294 /* LiveStreamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1AE834DEFD8BD28E3A26E8 /* LiveStreamViewController.swift */; };
 		EE6124C9BB7FB8ACF18B1503 /* GroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C55D469D39EFF3296C5387 /* GroupViewController.swift */; };
 		F897157F45696443B145C383 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723869D8744D77D8EC9B55F1 /* ProfileViewController.swift */; };
 		FAD74CCC7D11B9407A5162D7 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F46FEDAF7B878A4794848F30 /* Lato-Regular.ttf */; };
@@ -47,6 +48,7 @@
 		8F18BFFBC809004FCDB520DF /* appcues-ios-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "appcues-ios-sdk"; path = ../..; sourceTree = SOURCE_ROOT; };
 		8F2DFA61ED06BF8D237F254A /* ScrollingTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingTableViewController.swift; sourceTree = "<group>"; };
 		91C043606EC23556B49010D3 /* DeepLinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkNavigator.swift; sourceTree = "<group>"; };
+		9A1AE834DEFD8BD28E3A26E8 /* LiveStreamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStreamViewController.swift; sourceTree = "<group>"; };
 		9B3A37A53533FAF07E10D9ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		9C8326722CA53EE0F53AA012 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		AF7C790690C785694C7F24F8 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
@@ -103,7 +105,7 @@
 				8F18BFFBC809004FCDB520DF /* appcues-ios-sdk */,
 			);
 			name = Packages;
-			sourceTree = SOURCE_ROOT;
+			sourceTree = "<group>";
 		};
 		9AE84678383C3F4AB5EF9718 /* SPMExample */ = {
 			isa = PBXGroup;
@@ -118,6 +120,7 @@
 				87C55D469D39EFF3296C5387 /* GroupViewController.swift */,
 				476767533B954304A7121A53 /* Info.plist */,
 				ED2A2106A39811D89703AE5F /* LaunchScreen.storyboard */,
+				9A1AE834DEFD8BD28E3A26E8 /* LiveStreamViewController.swift */,
 				8757BA449145145EAF8FE061 /* Main.storyboard */,
 				723869D8744D77D8EC9B55F1 /* ProfileViewController.swift */,
 				6901798B6E99F34ACF2F707B /* SceneDelegate.swift */,
@@ -173,6 +176,9 @@
 				"pt-BR",
 			);
 			mainGroup = 00D57936BE4D8040097BA252;
+			packageReferences = (
+				F95E3E563418244E3D063AA9 /* XCLocalSwiftPackageReference "../.." */,
+			);
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -231,6 +237,7 @@
 				9EF6EF267BBE750196BB8852 /* EmbedViewController.swift in Sources */,
 				64EFAB6E2ED72F70B75B98F1 /* EventsViewController.swift in Sources */,
 				EE6124C9BB7FB8ACF18B1503 /* GroupViewController.swift in Sources */,
+				DF78178BBBBE4FED7E798294 /* LiveStreamViewController.swift in Sources */,
 				F897157F45696443B145C383 /* ProfileViewController.swift in Sources */,
 				BF24A197BFEAF23D84AC3462 /* SceneDelegate.swift in Sources */,
 				23B54BD171539D75DB26478D /* ScrollingTableViewController.swift in Sources */,
@@ -443,6 +450,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		F95E3E563418244E3D063AA9 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		781D0ABDB3436955E4EA34B9 /* AppcuesKit */ = {

--- a/Examples/DeveloperSPMExample/SPMExample/AppDelegate.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/AppDelegate.swift
@@ -17,6 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         // Override point for customization after application launch.
 
+        Appcues.registerCustomComponent(identifier: "video", type: LiveStreamViewController.self)
+
         return true
     }
 

--- a/Examples/DeveloperSPMExample/SPMExample/LiveStreamViewController.swift
+++ b/Examples/DeveloperSPMExample/SPMExample/LiveStreamViewController.swift
@@ -1,0 +1,95 @@
+//
+//  LiveStreamViewController.swift
+//  AppcuesSPMExample
+//
+//  Created by Matt on 2024-06-27.
+//
+
+import Foundation
+import AppcuesKit
+import AVKit
+
+#if DEBUG
+extension LiveStreamViewController {
+    static var debugConfig: [String: Any]? {
+        [
+            "url": "https://zssd-koala.hls.camzonecdn.com/CamzoneStreams/zssd-koala/Playlist.m3u8",
+            "showControls": false,
+            "isMuted": true
+        ]
+    }
+}
+#endif
+
+class LiveStreamViewController: UIViewController, AppcuesCustomComponentViewController {
+    struct Config: Decodable {
+        let url: URL
+        let showControls: Bool
+        let isMuted: Bool
+
+        enum CodingKeys: CodingKey {
+            case url
+            case showControls
+            case isMuted
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.url = try container.decode(URL.self, forKey: .url)
+            self.showControls = try container.decodeIfPresent(Bool.self, forKey: .showControls) ?? true
+            self.isMuted = try container.decodeIfPresent(Bool.self, forKey: .isMuted) ?? false
+        }
+    }
+
+    let config: Config
+    let actionController: AppcuesExperienceActions
+
+    var playerView: UIView?
+
+    required init?(configuration: AppcuesKit.AppcuesExperiencePluginConfiguration, actionController: AppcuesExperienceActions) {
+        guard let config = configuration.decode(Config.self) else { return nil }
+        self.config = config
+        self.actionController = actionController
+
+        super.init(nibName: nil, bundle: nil)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLayoutSubviews() {
+        print(view.frame, view.intrinsicContentSize)
+        preferredContentSize = CGSize(width: view.frame.width, height: view.frame.width * 0.5625)
+    }
+
+    func setup() {
+        let player = AVPlayer(url: config.url)
+        player.isMuted = config.isMuted
+
+        let viewController = AVPlayerViewController()
+        viewController.player = player
+        viewController.showsPlaybackControls = config.showControls
+
+        let playerView = viewController.view!
+        playerView.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(viewController)
+        view.addSubview(playerView)
+
+        NSLayoutConstraint.activate([
+            playerView.topAnchor.constraint(equalTo: view.topAnchor),
+            playerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            playerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            playerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        viewController.didMove(toParent: self)
+
+        self.playerView = playerView
+        player.play()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The SDK is a Swift library for sending user properties and events to the Appcues
     - [Tracking Screens and Events](#tracking-screens-and-events)
     - [Anchored Tooltips](#anchored-tooltips)
     - [Embedded Experiences](#embedded-experiences)
+    - [Custom Components](#custom-components)
   - [📝 Documentation](#-documentation)
   - [🎬 Examples](#-examples)
   - [👷 Contributing](#-contributing)
@@ -134,6 +135,10 @@ Anchored tooltips use element targeting to point directly at specific views in y
 ### Embedded Experiences
 
 Add `AppcuesFrameView` instances in your application layouts to support embedded experience content, with a non-modal presentation. For more information about how to configure your application layouts to use frame views, refer to the guide on [Configuring an Appcues Frame](https://appcues.github.io/appcues-ios-sdk/documentation/appcueskit/frameconfiguring).
+
+### Custom Components
+
+Implement `AppcuesCustomComponentViewController` instances and register them with Appcues to take advantage of building your own components and using them in experiences. For more information refer to the guide on [Configuring an AppcuesCustomComponentView](https://appcues.github.io/appcues-ios-sdk/documentation/appcueskit/customcomponentconfiguring)
 
 Refer to the full [Getting Started Guide](https://appcues.github.io/appcues-ios-sdk/documentation/appcueskit/gettingstarted) for more details.
 

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -21,6 +21,9 @@ public class Appcues: NSObject {
     @available(iOS 13.0, *)
     public static var elementTargeting: AppcuesElementTargeting = UIKitElementTargeting()
 
+    @available(iOS 13.0, *)
+    internal static var customComponentRegistry = CustomComponentRegistry()
+
     let container = DIContainer()
     let config: Appcues.Config
 
@@ -116,6 +119,17 @@ public class Appcues: NSObject {
     @objc
     public static func enableAutomaticPushConfig() {
         PushAutoConfig.configureAutomatically()
+    }
+
+    /// Register a view controller that can be rendered in an `Experience`.
+    /// - Parameters:
+    ///   - identifier: View name
+    ///   - type: View controller type
+    public static func registerCustomComponent(identifier: String, type: AppcuesCustomComponentViewController.Type) {
+        // NOTE: this can't be @objc because the AppcuesCustomComponentView protocol inherits from UIView
+        guard #available(iOS 13.0, *) else { return }
+
+        customComponentRegistry.registerCustomComponent(identifier: identifier, type: type)
     }
 
     /// Get the current version of the Appcues SDK.

--- a/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/AppcuesKit.md
@@ -52,6 +52,13 @@ A Swift library for sending user properties and events to the Appcues API and re
 - ``SwiftUI/View/appcuesView(identifier:)``
 - ``UIKit/UIWindow/isAppcuesWindow``
 
+### Custom Components
+
+- <doc:CustomComponentConfiguring>
+- ``AppcuesCustomComponentViewController``
+- ``AppcuesExperienceActions``
+- ``AppcuesExperiencePluginConfiguration``
+
 ### Use Cases
 
 - <doc:UseCases>

--- a/Sources/AppcuesKit/AppcuesKit.docc/CustomComponentConfiguring.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/CustomComponentConfiguring.md
@@ -1,0 +1,67 @@
+# Configuring a Custom Component
+
+Define a custom component to be rendered in an experience.
+
+## Overview 
+
+An ``AppcuesCustomComponentViewController`` allows your app to define a custom component that can be rendered in an experience containing a custom component block using the registered `identifier` for the component.
+
+## Implementing a custom component 
+
+Conform a `UIViewController` to the ``AppcuesCustomComponentViewController`` protocol by implementing an initializer, ``AppcuesCustomComponentViewController/init(configuration:actionController:)``.
+
+The initializer provides a ``AppcuesExperiencePluginConfiguration`` object which includes a ``AppcuesExperiencePluginConfiguration/decode(_:)`` method to deserialize the component configuration into a `Decodable` type:
+
+```swift
+extension MyViewController: AppcuesCustomComponentViewController {
+    struct Config: Decodable {
+        let stringProperty: String
+        let numberProperty: Double
+        let boolProperty: Bool 
+    }
+
+    convenience init?(configuration: AppcuesKit.AppcuesExperiencePluginConfiguration, actionController: AppcuesExperienceActions) {
+        guard let config = configuration.decode(Config.self) else { return nil }
+        
+        // Initialize your view controller with the decoded configuration:
+        // config.stringProperty, etc
+        self.init()
+    }
+}
+```
+
+> Note: It is required that the `UIViewController.preferredContentSize` property be set to the size required by your component. If `preferredContentSize` is not set your custom component may not be allocated any space when rendering in an Appcues experience. There are several approaches to accomplish this including overriding `preferredContentSize` or setting `preferredContentSize` from `viewDidLayoutSubviews()`.
+
+### Invoking actions
+
+Your custom component may want to interact with the Appcues context and manipulate the experience it's embedded in. ``AppcuesCustomComponentViewController/init(configuration:actionController:)`` provides an action controller (``AppcuesExperienceActions``) to accomplish this.
+
+Note that ``AppcuesExperienceActions/triggerBlockActions()`` will invoke the actions added to the custom component in the Appcues Mobile Builder.
+
+### Registering a custom component
+
+Registering a custom component by calling  ``Appcues/registerCustomComponent(identifier:type:)`` when your app starts. Ensure the identifier is an unique string when registering multiple custom components.
+
+```swift
+Appcues.registerCustomComponent(identifier: "myViewController", type: MyViewController.self)
+```
+
+### Testing a custom component
+
+All registered custom view are listed in the `Debugger` under the `Plugins` section. Refer to <doc:Debugging>.
+
+Provide a ``AppcuesCustomComponentViewController/debugConfig-57bo8`` on your custom component view controller to test an instance of your custom component:
+
+```swift
+extension MyViewController {
+    static var debugConfig: [String: Any]? {
+        [
+            "stringProperty": "some string",
+            "numberProperty": 3.14,
+            "boolProperty": true
+        ]
+    }
+}
+```
+
+The debugger page for a custom component instance will also show a list of actions invoked by the custom component.

--- a/Sources/AppcuesKit/AppcuesKit.docc/Debugging.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/Debugging.md
@@ -62,6 +62,20 @@ If there is an experience currently showing in your app, the debugger will the n
 
 If an experience fails to show, the debugger will note it with "Content Omitted" and the error message describing why the experience was not presented.
 
+## Finding Additional Information
+
+### Available Fonts
+
+This page lists the fonts installed in the application that are available for use from the Appcues Mobile Builder.
+
+### Plugins
+
+This page lists plugins that are registered with the Appcues SDK.
+
+### Detailed Log
+
+This page shows network traffic and other internal details for in-depth debugging.
+
 ## Inspecting Events
 
 The Recent Events section of the debugger shows the list of all events that have passed through the Appcues SDK, with the most recent events at the top of the list. The list of events can be filtered by type by selecting the Filter icon in the header row and selecting an event type.

--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -27,6 +27,7 @@ internal indirect enum ExperienceComponent {
     case embed(EmbedModel)
     case optionSelect(OptionSelectModel)
     case textInput(TextInputModel)
+    case customComponent(CustomComponentModel)
 
     subscript<T>(dynamicMember keyPath: KeyPath<ComponentModel, T>) -> T {
         switch self {
@@ -39,6 +40,7 @@ internal indirect enum ExperienceComponent {
         case .embed(let model): return model[keyPath: keyPath]
         case .optionSelect(let model): return model[keyPath: keyPath]
         case .textInput(let model): return model[keyPath: keyPath]
+        case .customComponent(let model): return model[keyPath: keyPath]
         }
     }
 }
@@ -80,6 +82,8 @@ extension ExperienceComponent: Decodable {
             self = .optionSelect(try modelContainer.decode(OptionSelectModel.self))
         case "textInput":
             self = .textInput(try modelContainer.decode(TextInputModel.self))
+        case "customComponent":
+            self = .customComponent(try modelContainer.decode(CustomComponentModel.self))
         default:
             let context = DecodingError.Context(codingPath: container.codingPath, debugDescription: "unknown type '\(type)'")
             throw DecodingError.valueNotFound(Self.self, context)
@@ -279,6 +283,18 @@ extension ExperienceComponent {
         var textDescription: String? { label.textDescription }
     }
 
+    struct CustomComponentModel: ComponentModel {
+        let id: UUID
+
+        let identifier: String
+
+        let configDecoder: PluginDecoder
+
+        let style: Style?
+
+        var textDescription: String? { nil }
+    }
+
     struct SpacerModel: ComponentModel, Decodable {
         let id: UUID
         let spacing: Double?
@@ -358,5 +374,31 @@ extension ExperienceComponent.Style {
         let verticalAlignment: String?
         let horizontalAlignment: String?
         let intrinsicSize: ExperienceComponent.IntrinsicSize?
+    }
+}
+
+extension ExperienceComponent.CustomComponentModel: Decodable {
+    private enum CodingKeys: CodingKey {
+        case id, identifier, style, config
+    }
+
+    private struct CustomComponentDecoder: PluginDecoder {
+        private let container: KeyedDecodingContainer<CodingKeys>
+
+        init(_ container: KeyedDecodingContainer<CodingKeys>) {
+            self.container = container
+        }
+
+        func decode<T: Decodable>(_ type: T.Type) -> T? {
+            try? container.decode(T.self, forKey: .config)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        identifier = try container.decode(String.self, forKey: .identifier)
+        configDecoder = CustomComponentDecoder(container)
+        style = try container.decodeIfPresent(ExperienceComponent.Style.self, forKey: .style)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
@@ -30,6 +30,12 @@ internal class AppcuesCloseAction: AppcuesExperienceAction {
         markComplete = config?.markComplete ?? false
     }
 
+    init(appcues: Appcues?, renderContext: RenderContext, markComplete: Bool) {
+        self.appcues = appcues
+        self.renderContext = renderContext
+        self.markComplete = markComplete
+    }
+
     func execute(completion: @escaping ActionRegistry.Completion) {
         guard let appcues = appcues else { return completion() }
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
@@ -40,6 +40,12 @@ internal class AppcuesContinueAction: AppcuesExperienceAction {
         }
     }
 
+    init(appcues: Appcues?, renderContext: RenderContext, stepReference: StepReference) {
+        self.appcues = appcues
+        self.renderContext = renderContext
+        self.stepReference = stepReference
+    }
+
     func execute(completion: @escaping ActionRegistry.Completion) {
         guard let appcues = appcues else { return completion() }
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
@@ -30,6 +30,12 @@ internal class AppcuesTrackAction: AppcuesExperienceAction {
         self.attributes = config.attributes
     }
 
+    init(appcues: Appcues?, eventName: String, attributes: [String: Any]? = nil) {
+        self.appcues = appcues
+        self.eventName = eventName
+        self.attributes = attributes
+    }
+
     func execute(completion: ActionRegistry.Completion) {
         guard let appcues = appcues else { return completion() }
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesUpdateProfileAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesUpdateProfileAction.swift
@@ -31,6 +31,11 @@ internal class AppcuesUpdateProfileAction: AppcuesExperienceAction {
         }
     }
 
+    init(appcues: Appcues?, properties: [String: Any]) {
+        self.appcues = appcues
+        self.properties = properties
+    }
+
     func execute(completion: ActionRegistry.Completion) {
         guard let appcues = appcues else { return completion() }
 

--- a/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
+++ b/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
@@ -1,0 +1,13 @@
+//
+//  AppcuesCustomComponentViewController.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-10-22.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+
+public protocol AppcuesCustomComponentViewController: UIViewController {
+    init?(configuration: AppcuesExperiencePluginConfiguration, actionController: AppcuesExperienceActions)
+}

--- a/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
+++ b/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
@@ -10,16 +10,16 @@ import UIKit
 
 /// A protocol that a  `UIViewController` must adopt to allow usage as an Appcues custom component.
 public protocol AppcuesCustomComponentViewController: UIViewController {
-    
+
+    /// Optional component configuration for testing in the Appcues Mobile Debugger.
+    /// Refer to <doc:CustomComponentConfiguring>.
+    static var debugConfig: [String: Any]? { get }
+
     /// Creates a view controller for use as an Appcues custom component.
     /// - Parameters:
     ///   - configuration: Configuration object that decodes instances of a plugin configuration from an Experience JSON model.
     ///   - actionController: Action options for a custom component to invoke.
     init?(configuration: AppcuesExperiencePluginConfiguration, actionController: AppcuesExperienceActions)
-
-    /// Optional component configuration for testing in the Appcues Mobile Debugger.
-    /// Refer to <doc:CustomComponentConfiguring>.
-    static var debugConfig: [String: Any]? { get }
 }
 
 // Default value to make `debugConfig` optional

--- a/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
+++ b/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
@@ -8,13 +8,23 @@
 
 import UIKit
 
+/// A protocol that a  `UIViewController` must adopt to allow usage as an Appcues custom component.
 public protocol AppcuesCustomComponentViewController: UIViewController {
+    
+    /// Creates a view controller for use as an Appcues custom component.
+    /// - Parameters:
+    ///   - configuration: Configuration object that decodes instances of a plugin configuration from an Experience JSON model.
+    ///   - actionController: Action options for a custom component to invoke.
     init?(configuration: AppcuesExperiencePluginConfiguration, actionController: AppcuesExperienceActions)
 
+    /// Optional component configuration for testing in the Appcues Mobile Debugger.
+    /// Refer to <doc:CustomComponentConfiguring>.
     static var debugConfig: [String: Any]? { get }
 }
 
 // Default value to make `debugConfig` optional
 public extension AppcuesCustomComponentViewController {
+    /// Optional component configuration for testing in the Appcues Mobile Debugger.
+    /// Refer to <doc:CustomComponentConfiguring>.
     static var debugConfig: [String: Any]? { nil }
 }

--- a/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
+++ b/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesCustomComponentViewController.swift
@@ -10,4 +10,11 @@ import UIKit
 
 public protocol AppcuesCustomComponentViewController: UIViewController {
     init?(configuration: AppcuesExperiencePluginConfiguration, actionController: AppcuesExperienceActions)
+
+    static var debugConfig: [String: Any]? { get }
+}
+
+// Default value to make `debugConfig` optional
+public extension AppcuesCustomComponentViewController {
+    static var debugConfig: [String: Any]? { nil }
 }

--- a/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesExperienceActions.swift
+++ b/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesExperienceActions.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+/// Action options for a custom component to invoke.
 public class AppcuesExperienceActions {
     private weak var appcues: Appcues?
     private let renderContext: RenderContext
@@ -21,6 +22,7 @@ public class AppcuesExperienceActions {
         self.identifier = identifier
     }
 
+    /// Trigger the actions associated with the custom component in the Appcues Mobile Builder.
     @available(iOS 13.0, *)
     public func triggerBlockActions() {
         guard let actions = actions, let actionRegistry = appcues?.container.resolve(ActionRegistry.self) else { return }
@@ -33,26 +35,36 @@ public class AppcuesExperienceActions {
         )
     }
 
+    /// Track a custom event for an action taken by a user.
+    /// - Parameters:
+    ///   - name: Name of the event.
+    ///   - properties: Optional properties that provide additional context about the event.
     @available(iOS 13.0, *)
     public func track(name: String, properties: [String: Any]? = nil) {
         enqueue(AppcuesTrackAction(appcues: appcues, eventName: name, attributes: properties))
     }
 
+    /// Advance the flow to the next step. If the flow is on its final step, the flow will dismiss as completed.
     @available(iOS 13.0, *)
     public func nextStep() {
         enqueue(AppcuesContinueAction(appcues: appcues, renderContext: renderContext, stepReference: .offset(1)))
     }
 
+    /// Navigate the flow to the previous step. If the flow is on its initial step, nothing will happen.
     @available(iOS 13.0, *)
     public func previousStep() {
         enqueue(AppcuesContinueAction(appcues: appcues, renderContext: renderContext, stepReference: .offset(-1)))
     }
 
+    /// Dismiss the flow.
+    /// - Parameter markComplete: Whether the flow should be marked as complete for analytics purposes. Defaults to `false`.
     @available(iOS 13.0, *)
     public func close(markComplete: Bool = false) {
         enqueue(AppcuesCloseAction(appcues: appcues, renderContext: renderContext, markComplete: markComplete))
     }
 
+    /// Update the Appcues profile of the current user.
+    /// - Parameter properties: Properties to add to the Appcues profile of the current user.
     @available(iOS 13.0, *)
     public func updateProfile(properties: [String: Any]) {
         enqueue(AppcuesUpdateProfileAction(appcues: appcues, properties: properties))

--- a/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesExperienceActions.swift
+++ b/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesExperienceActions.swift
@@ -1,0 +1,66 @@
+//
+//  AppcuesExperienceActions.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-10-22.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import UIKit
+
+public class AppcuesExperienceActions {
+    private weak var appcues: Appcues?
+    private let renderContext: RenderContext
+    private let identifier: String
+
+    var actions: [Experience.Action]?
+
+    init(appcues: Appcues?, renderContext: RenderContext, identifier: String) {
+        self.appcues = appcues
+        self.renderContext = renderContext
+        self.identifier = identifier
+    }
+
+    @available(iOS 13.0, *)
+    public func triggerBlockActions() {
+        guard let actions = actions, let actionRegistry = appcues?.container.resolve(ActionRegistry.self) else { return }
+        actionRegistry.enqueue(
+            actionModels: actions,
+            level: .step,
+            renderContext: renderContext,
+            interactionType: "Button Tapped",
+            viewDescription: "Custom component \(identifier)"
+        )
+    }
+
+    @available(iOS 13.0, *)
+    public func track(name: String, properties: [String: Any]? = nil) {
+        enqueue(AppcuesTrackAction(appcues: appcues, eventName: name, attributes: properties))
+    }
+
+    @available(iOS 13.0, *)
+    public func nextStep() {
+        enqueue(AppcuesContinueAction(appcues: appcues, renderContext: renderContext, stepReference: .offset(1)))
+    }
+
+    @available(iOS 13.0, *)
+    public func previousStep() {
+        enqueue(AppcuesContinueAction(appcues: appcues, renderContext: renderContext, stepReference: .offset(-1)))
+    }
+
+    @available(iOS 13.0, *)
+    public func close(markComplete: Bool = false) {
+        enqueue(AppcuesCloseAction(appcues: appcues, renderContext: renderContext, markComplete: markComplete))
+    }
+
+    @available(iOS 13.0, *)
+    public func updateProfile(properties: [String: Any]) {
+        enqueue(AppcuesUpdateProfileAction(appcues: appcues, properties: properties))
+    }
+
+    @available(iOS 13.0, *)
+    private func enqueue(_ action: AppcuesExperienceAction) {
+        guard let actionRegistry = appcues?.container.resolve(ActionRegistry.self) else { return }
+        actionRegistry.enqueue(actionInstances: [action]) {}
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugPluginUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugPluginUI.swift
@@ -1,0 +1,171 @@
+//
+//  DebugPluginUI.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-10-22.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal enum DebugPluginUI {
+    struct PluginListView: View {
+        let componentDebugInfo: [(identifier: String, debuggableConfig: [String: Any]?)]
+
+        init() {
+            self.componentDebugInfo = Appcues.customComponentRegistry.componentDebugInfo
+        }
+
+        var body: some View {
+            List {
+                Section {
+                    ForEach(componentDebugInfo, id: \.identifier) { debugInfo in
+                        if let debuggableConfig = debugInfo.debuggableConfig {
+                            NavigationLink(
+                                destination: PluginDetailView(identifier: debugInfo.identifier, debuggableConfig: debuggableConfig)
+                            ) {
+                                Text(debugInfo.identifier)
+                                    .font(Font.system(.body, design: .monospaced))
+                            }
+                        } else {
+                            Text(debugInfo.identifier)
+                                .font(Font.system(.body, design: .monospaced))
+                        }
+                    }
+                } header: {
+                    Text("Custom Components")
+                } footer: {
+                    Text("Register custom components with ")
+                    + Text("Appcues.registerCustomComponent()").font(Font.system(.caption, design: .monospaced))
+                }
+            }
+            .navigationBarTitle("", displayMode: .inline)
+        }
+    }
+
+    private struct PluginDetailView: View {
+        private let identifier: String
+        private let debuggableConfig: [String: Any]
+        private let model: ExperienceComponent.CustomComponentModel
+
+        @ObservedObject private var debugActions: DebugAppcuesExperienceActions
+        @ObservedObject private var debuggableViewModal: ExperienceStepViewModel
+        @State private var showFrame = true
+
+        private var formattedConfig: String {
+            debuggableConfig.keys.reduce(into: "") { acc, key in
+                let value: String = debuggableConfig[key] is String
+                ? "\"\(debuggableConfig[key] ?? "")\""
+                : "\(debuggableConfig[key] ?? "")"
+                acc += "\n\t\(key)=\(value)"
+            }
+        }
+
+        init(identifier: String, debuggableConfig: [String: Any]) {
+            self.identifier = identifier
+            self.debuggableConfig = debuggableConfig
+
+            let viewModel = DebugExperienceViewModel()
+            debugActions = viewModel.debugActions
+            debuggableViewModal = viewModel
+
+            self.model = ExperienceComponent.CustomComponentModel(
+                id: UUID(),
+                identifier: identifier,
+                configDecoder: DebuggableDecoder(properties: debuggableConfig),
+                style: nil
+            )
+        }
+
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading) {
+                    ScrollView(.horizontal) {
+                        Text("<\(identifier)\(formattedConfig)\n/>")
+                            .font(.system(.body, design: .monospaced))
+                            .padding()
+                    }
+
+                    VStack(alignment: .leading) {
+                        AppcuesCustomComponent(model: model)
+                            .environmentObject(debuggableViewModal)
+                            .border(showFrame ? Color.appcuesBlurple : Color.clear)
+
+                        Toggle("Show frame", isOn: $showFrame)
+
+                        Text("Actions called:")
+                            .font(.system(.headline))
+                        Text(debugActions.actionLog)
+                    }
+                    .padding()
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+private extension DebugPluginUI {
+
+    class DebugExperienceViewModel: ExperienceStepViewModel {
+        static let renderContext = RenderContext.embed(frameID: "PLUGIN_DEBUG")
+        let debugActions = DebugAppcuesExperienceActions(appcues: nil, renderContext: DebugExperienceViewModel.renderContext, identifier: "")
+
+        init() {
+            super.init(renderContext: DebugExperienceViewModel.renderContext, appcues: nil)
+        }
+
+        override func customComponent(for model: ExperienceComponent.CustomComponentModel) -> CustomComponentData? {
+            guard let componentData = super.customComponent(for: model) else { return nil }
+            return CustomComponentData(
+                type: componentData.type,
+                config: componentData.config,
+                actionController: debugActions
+            )
+        }
+    }
+
+    class DebugAppcuesExperienceActions: AppcuesExperienceActions, ObservableObject {
+        @Published var actionLog: String = ""
+
+        override func triggerBlockActions() {
+            actionLog = "triggerBlockActions()\n" + actionLog
+        }
+
+        override func track(name: String, properties: [String: Any]? = nil) {
+            actionLog = "track(name: \(name), properties: \(properties?.description ?? "nil"))\n" + actionLog
+        }
+
+        override func nextStep() {
+            actionLog = "nextStep()\n" + actionLog
+        }
+
+        override func previousStep() {
+            actionLog = "previousStep()\n" + actionLog
+        }
+
+        override func close(markComplete: Bool = false) {
+            actionLog = "close(markComplete: \(markComplete))\n" + actionLog
+        }
+
+        override func updateProfile(properties: [String: Any]) {
+            actionLog = "updateProfile(properties: \(properties.description))\n" + actionLog
+        }
+    }
+
+    class DebuggableDecoder: PluginDecoder {
+        let properties: [String: Any]
+
+        init(properties: [String: Any]) {
+            self.properties = properties
+        }
+
+        func decode<T>(_ type: T.Type) -> T? where T: Decodable {
+            guard let data = try? JSONSerialization.data(withJSONObject: properties) else {
+                return nil
+            }
+            return try? JSONDecoder().decode(type, from: data)
+        }
+    }
+}

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugPluginUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugPluginUI.swift
@@ -110,7 +110,11 @@ private extension DebugPluginUI {
 
     class DebugExperienceViewModel: ExperienceStepViewModel {
         static let renderContext = RenderContext.embed(frameID: "PLUGIN_DEBUG")
-        let debugActions = DebugAppcuesExperienceActions(appcues: nil, renderContext: DebugExperienceViewModel.renderContext, identifier: "")
+        let debugActions = DebugAppcuesExperienceActions(
+            appcues: nil,
+            renderContext: DebugExperienceViewModel.renderContext,
+            identifier: ""
+        )
 
         init() {
             super.init(renderContext: DebugExperienceViewModel.renderContext, appcues: nil)

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -54,6 +54,9 @@ internal enum DebugUI {
                         NavigationLink(destination: DebugFontUI.FontListView(), isActive: $viewModel.navigationDestinationIsFonts) {
                             Text("Available Fonts")
                         }
+                        NavigationLink(destination: DebugPluginUI.PluginListView(), isActive: $viewModel.navigationDestinationIsPlugins) {
+                            Text("Plugins")
+                        }
                         NavigationLink(destination: DebugLogUI.LoggerView()) {
                             Text("Detailed Log")
                         }

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
@@ -21,6 +21,10 @@ internal class DebugViewModel: ObservableObject {
         get { navigationDestination == .fonts }
         set { navigationDestination = newValue ? .fonts : nil }
     }
+    var navigationDestinationIsPlugins: Bool {
+        get { navigationDestination == .plugins }
+        set { navigationDestination = newValue ? .plugins : nil }
+    }
 
     private var events: [LoggedEvent] = []
 

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -27,10 +27,12 @@ internal protocol ScreenCaptureUI {
 internal enum DebugDestination {
     /// Font list screen
     case fonts
+    case plugins
 
     init?(pathToken: String?) {
         switch pathToken {
         case "fonts": self = .fonts
+        case "plugins": self = .plugins
         default: return nil
         }
     }

--- a/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
+++ b/Sources/AppcuesKit/Presentation/Public/Plugins/AppcuesExperiencePluginConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// An object that decodes instances of a plugin configuration from an Experience JSON model.
 @objc
-internal class AppcuesExperiencePluginConfiguration: NSObject {
+public class AppcuesExperiencePluginConfiguration: NSObject {
 
     /// Context in which a plugin can be applied.
     @objc
@@ -43,7 +43,7 @@ internal class AppcuesExperiencePluginConfiguration: NSObject {
     /// Returns a value of the type you specify, decoded from a JSON object.
     /// - Parameter type: The type of the value to decode from the supplied plugin decoder.
     /// - Returns: A value of the specified type, if the decoder can parse the data.
-    internal func decode<T: Decodable>(_ type: T.Type) -> T? {
+    public func decode<T: Decodable>(_ type: T.Type) -> T? {
         return decoder.decode(type)
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -18,6 +18,7 @@ internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, Appcue
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 
+    private weak var appcues: Appcues?
     private let renderContext: RenderContext
 
     private let level: AppcuesExperiencePluginConfiguration.Level
@@ -26,6 +27,7 @@ internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, Appcue
     private weak var backgroundViewController: UIViewController?
 
     required init?(configuration: AppcuesExperiencePluginConfiguration) {
+        self.appcues = configuration.appcues
         self.renderContext = configuration.renderContext
 
         guard let config = configuration.decode(Config.self) else { return nil }
@@ -46,7 +48,7 @@ internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, Appcue
     func decorate(containerController: AppcuesExperienceContainerViewController) throws {
         guard level == .group || level == .experience else { return }
 
-        let emptyViewModel = ExperienceStepViewModel(renderContext: renderContext)
+        let emptyViewModel = ExperienceStepViewModel(renderContext: renderContext, appcues: appcues)
 
         backgroundViewController = applyBackground(with: emptyViewModel, parent: containerController)
     }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -202,7 +202,10 @@ extension AppcuesTargetInteractionTrait {
             }
         }
 
-        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
             true
         }
 

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -16,12 +16,14 @@ internal protocol TraitComposing: AnyObject {
 @available(iOS 13.0, *)
 internal class TraitComposer: TraitComposing {
 
+    private weak var appcues: Appcues?
     private let traitRegistry: TraitRegistry
     private let actionRegistry: ActionRegistry
     private let config: Appcues.Config
     private let notificationCenter: NotificationCenter
 
     init(container: DIContainer) {
+        appcues = container.owner
         traitRegistry = container.resolve(TraitRegistry.self)
         actionRegistry = container.resolve(ActionRegistry.self)
         notificationCenter = container.resolve(NotificationCenter.self)
@@ -89,7 +91,8 @@ internal class TraitComposer: TraitComposing {
                 step: $0.step,
                 actionRegistry: actionRegistry,
                 renderContext: experience.renderContext,
-                config: config
+                config: config,
+                appcues: appcues
             )
             let stepViewController = ExperienceStepViewController(
                 viewModel: viewModel,

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesCustomComponent.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesCustomComponent.swift
@@ -1,0 +1,46 @@
+//
+//  AppcuesCustomComponent.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2024-10-22.
+//  Copyright © 2024 Appcues. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+internal struct CustomComponentRepresentable: UIViewControllerRepresentable {
+    private let type: AppcuesCustomComponentViewController.Type
+    private let configuration: AppcuesExperiencePluginConfiguration
+    private let actionController: AppcuesExperienceActions
+
+    init?(on viewModel: ExperienceStepViewModel, for model: ExperienceComponent.CustomComponentModel) {
+        guard let customComponentData = viewModel.customComponent(for: model) else { return nil }
+        self.type = customComponentData.type
+        self.configuration = customComponentData.config
+        self.actionController = customComponentData.actionController
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        let viewController = type.init(configuration: configuration, actionController: actionController)
+        return viewController ?? UIViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        // no-op
+    }
+}
+
+@available(iOS 13.0, *)
+internal struct AppcuesCustomComponent: View {
+    let model: ExperienceComponent.CustomComponentModel
+
+    @EnvironmentObject var viewModel: ExperienceStepViewModel
+
+    var body: some View {
+        let style = AppcuesStyle(from: model.style)
+
+        CustomComponentRepresentable(on: viewModel, for: model)
+            .applyAllAppcues(style)
+    }
+}

--- a/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
@@ -30,6 +30,8 @@ extension ExperienceComponent {
             AnyView(AppcuesTextInput(model: model))
         case .optionSelect(let model):
             AnyView(AppcuesOptionSelect(model: model))
+        case .customComponent(let model):
+            AnyView(AppcuesCustomComponent(model: model))
         case .spacer(let model):
             AnyView(Spacer(minLength: CGFloat(model.spacing)))
         }

--- a/Sources/AppcuesKit/Presentation/UI/CustomComponentRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/UI/CustomComponentRegistry.swift
@@ -18,6 +18,14 @@ internal struct CustomComponentData {
 internal class CustomComponentRegistry {
     private var registeredComponents: [String: AppcuesCustomComponentViewController.Type] = [:]
 
+    var componentDebugInfo: [(identifier: String, debuggableConfig: [String: Any]?)] {
+        registeredComponents
+            .map { key, value in
+                (key, value.debugConfig)
+            }
+            .sorted { $0.0 < $1.0 }
+    }
+
     init() {}
 
     func registerCustomComponent(identifier: String, type: AppcuesCustomComponentViewController.Type) {

--- a/Sources/AppcuesKit/Presentation/UI/CustomComponentRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/UI/CustomComponentRegistry.swift
@@ -1,0 +1,49 @@
+//
+//  CustomComponentRegistry.swift
+//  AppcuesKit
+//
+//  Created by Matt on 2023-05-19.
+//  Copyright © 2023 Appcues. All rights reserved.
+//
+
+import UIKit
+
+internal struct CustomComponentData {
+    let type: AppcuesCustomComponentViewController.Type
+    let config: AppcuesExperiencePluginConfiguration
+    let actionController: AppcuesExperienceActions
+}
+
+@available(iOS 13.0, *)
+internal class CustomComponentRegistry {
+    private var registeredComponents: [String: AppcuesCustomComponentViewController.Type] = [:]
+
+    init() {}
+
+    func registerCustomComponent(identifier: String, type: AppcuesCustomComponentViewController.Type) {
+        registeredComponents[identifier] = type
+    }
+
+    func customComponent(
+        for model: ExperienceComponent.CustomComponentModel,
+        renderContext: RenderContext,
+        appcuesInstance: Appcues?
+    ) -> CustomComponentData? {
+        guard let type = registeredComponents[model.identifier] else { return nil }
+
+        return CustomComponentData(
+            type: type,
+            config: AppcuesExperiencePluginConfiguration(
+                model.configDecoder,
+                level: .step,
+                renderContext: renderContext,
+                appcues: appcuesInstance
+            ),
+            actionController: AppcuesExperienceActions(
+                appcues: appcuesInstance,
+                renderContext: renderContext,
+                identifier: model.identifier
+            )
+        )
+    }
+}

--- a/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
@@ -21,10 +21,12 @@ class AppcuesCloseActionTests: XCTestCase {
     func testInit() throws {
         // Act
         let action = AppcuesCloseAction(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))
+        let directInitAction = AppcuesCloseAction(appcues: appcues, renderContext: .modal, markComplete: true)
 
         // Assert
         XCTAssertEqual(AppcuesCloseAction.type, "@appcues/close")
         XCTAssertNotNil(action)
+        XCTAssertNotNil(directInitAction)
     }
 
     func testExecute() throws {

--- a/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
@@ -44,6 +44,7 @@ class AppcuesContinueActionTests: XCTestCase {
                 appcues: appcues
             )
         )
+        let directInitAction = AppcuesContinueAction(appcues: appcues, renderContext: .modal, stepReference: .offset(1))
 
         // Assert
         XCTAssertEqual(AppcuesContinueAction.type, "@appcues/continue")
@@ -51,6 +52,7 @@ class AppcuesContinueActionTests: XCTestCase {
         XCTAssertNotNil(offsetAction)
         XCTAssertNotNil(stepIDAction)
         XCTAssertNotNil(defaultAction)
+        XCTAssertNotNil(directInitAction)
 
         guard case .index(1) = indexAction?.stepReference else { return XCTFail() }
         guard case .offset(-1) = offsetAction?.stepReference else { return XCTFail() }

--- a/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
@@ -20,13 +20,15 @@ class AppcuesTrackActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesTrackAction(appcues: appcues, eventName: "My Custom Event")
+        let action = AppcuesTrackAction(fromDecoderWith: appcues, eventName: "My Custom Event")
+        let directInitAction = AppcuesTrackAction(appcues: appcues, eventName: "My Custom Event")
         let failedAction = AppcuesTrackAction(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))
 
         // Assert
         XCTAssertEqual(AppcuesTrackAction.type, "@appcues/track")
         XCTAssertNotNil(action)
         XCTAssertEqual(action?.eventName, "My Custom Event")
+        XCTAssertNotNil(directInitAction)
         XCTAssertNil(failedAction)
     }
 
@@ -39,7 +41,7 @@ class AppcuesTrackActionTests: XCTestCase {
             XCTAssertNil(trackingUpdate.properties)
             trackCount += 1
         }
-        let action = AppcuesTrackAction(appcues: appcues, eventName: "My Custom Event")
+        let action = AppcuesTrackAction(fromDecoderWith: appcues, eventName: "My Custom Event")
 
         // Act
         action?.execute(completion: { completionCount += 1 })
@@ -65,7 +67,7 @@ class AppcuesTrackActionTests: XCTestCase {
             
             trackCount += 1
         }
-        let action = AppcuesTrackAction(appcues: appcues, 
+        let action = AppcuesTrackAction(fromDecoderWith: appcues,
                                         eventName: "My Custom Event",
                                         attributes: [
                                             "boolean": true,
@@ -100,7 +102,7 @@ extension AppcuesTrackAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))
     }
-    convenience init?(appcues: Appcues?, eventName: String, attributes: [String: Any]? = nil) {
+    convenience init?(fromDecoderWith appcues: Appcues?, eventName: String, attributes: [String: Any]? = nil) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesTrackAction.Config(eventName: eventName, attributes: attributes), appcues: appcues))
     }
 }

--- a/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
@@ -20,13 +20,15 @@ class AppcuesUpdateProfileActionTests: XCTestCase {
 
     func testInit() throws {
         // Act
-        let action = AppcuesUpdateProfileAction(appcues: appcues, properties: ["profile_attribute": "value"])
+        let action = AppcuesUpdateProfileAction(fromDecoderWith: appcues, properties: ["profile_attribute": "value"])
+        let directInitAction = AppcuesUpdateProfileAction(appcues: appcues, properties: ["profile_attribute": "value"])
         let failedAction = AppcuesUpdateProfileAction(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))
 
         // Assert
         XCTAssertEqual(AppcuesUpdateProfileAction.type, "@appcues/update-profile")
         XCTAssertNotNil(action)
         XCTAssertEqual(action?.properties["profile_attribute"] as? String, "value")
+        XCTAssertNotNil(directInitAction)
         XCTAssertNil(failedAction)
     }
 
@@ -71,7 +73,7 @@ class AppcuesUpdateProfileActionTests: XCTestCase {
             identifyCount += 1
         }
         let action = AppcuesUpdateProfileAction(
-            appcues: appcues,
+            fromDecoderWith: appcues,
             properties: [
                 "profile_attribute": "value",
                 "int_value": 5,
@@ -90,7 +92,7 @@ class AppcuesUpdateProfileActionTests: XCTestCase {
     func testExecuteCompletesWithoutAppcuesInstance() throws {
         // Arrange
         var completionCount = 0
-        let action = try XCTUnwrap(AppcuesUpdateProfileAction(appcues: nil, properties: ["profile_attribute": "value"]))
+        let action = try XCTUnwrap(AppcuesUpdateProfileAction(fromDecoderWith: nil, properties: ["profile_attribute": "value"]))
 
         // Act
         action.execute(completion: { completionCount += 1 })
@@ -105,7 +107,7 @@ extension AppcuesUpdateProfileAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))
     }
-    convenience init?(appcues: Appcues?, properties: [String: Any]) {
+    convenience init?(fromDecoderWith appcues: Appcues?, properties: [String: Any]) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(AppcuesUpdateProfileAction.Config(properties: properties), appcues: appcues))
     }
 }


### PR DESCRIPTION
## How it works

1. Register a custom component (a `UIViewController` that conforms to `AppcuesCustomComponentViewController`) statically with `Appcues.registerCustomComponent()`
2. Add a new experience JSON component type `customComponent` that takes an identifier and arbitrary config dictionary
3. The `AppcuesCustomComponent` SwiftUI view uses a `CustomComponentRepresentable` that wraps the view controller that was registered

The config decoding is entirely configurable from the client app and the provided `AppcuesExperienceActions` allows a developer to easily interact with the appcues context. A bunch of the Appcues actions were updated to have inits that `AppcuesExperienceActions` can easily use.

The debugger was updated with a Plugins section where custom components are listed, and if they add a `static var debugConfig: [String: Any]?` property, there's a detail screen that renders the component with the provided properties. To do this we:
1. Have a `DebuggableDecoder` that serializes the debug config and provides it to the controller to deserialize normally
2. Create a `CustomComponentModel`, feeding it the `DebuggableDecoder` to render the view 
3. Have a debug `ExperienceStepViewModel` that injects a `DebugAppcuesExperienceActions` to log the actions instead of actually execute them

There's an example `video` component implementation in the example apps that we'll reference in a tutorial doc (coming soon). I also need to add docs to some of the new public interface, but I'm opening the PR first to gets some eyes on it.