### PR TITLE
AppcuesUIWindow fixes

### DIFF
--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestReviewAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestReviewAction.swift
@@ -19,7 +19,7 @@ internal class AppcuesRequestReviewAction: AppcuesExperienceAction {
     }
 
     func execute(completion: @escaping ActionRegistry.Completion) {
-        if #available(iOS 14.0, *), let windowScene = UIApplication.shared.activeWindowScenes.first {
+        if #available(iOS 14.0, *), let windowScene = UIApplication.shared.mainWindowScene {
             SKStoreReviewController.requestReview(in: windowScene)
         } else {
             SKStoreReviewController.requestReview()

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -103,7 +103,7 @@ internal class UIDebugger: UIDebugging {
 
         // Set up the debugger
 
-        guard let windowScene = UIApplication.shared.activeWindowScenes.first else {
+        guard let windowScene = UIApplication.shared.mainWindowScene else {
             config.logger.error("Could not open debugger")
             return
         }
@@ -161,7 +161,7 @@ internal class UIDebugger: UIDebugging {
         }
 
         // One-time on-demand set up of the toast window
-        if toastWindow == nil, let windowScene = UIApplication.shared.activeWindowScenes.first {
+        if toastWindow == nil, let windowScene = UIApplication.shared.mainWindowScene {
             toastWindow = ToastUIWindow(windowScene: windowScene)
         }
 

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
@@ -43,6 +43,8 @@ internal class ModalContextManager {
 
     func remove(viewController: UIViewController, completion: (() -> Void)?) {
         viewController.dismiss(animated: true) {
+            // Ensure the window is removed from the hierarchy even if something outside the SDK has a reference to it
+            self.presentingWindow?.windowScene = nil
             self.presentingWindow = nil
             completion?()
         }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
@@ -18,8 +18,8 @@ internal class ModalContextManager {
             return
         }
 
-        guard let windowScene = UIApplication.shared.activeWindowScenes.first else {
-            throw AppcuesTraitError(description: "No active window scene")
+        guard let windowScene = UIApplication.shared.mainWindowScene else {
+            throw AppcuesTraitError(description: "No main window scene")
         }
 
         let window = AppcuesUIWindow(windowScene: windowScene)

--- a/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
@@ -24,10 +24,16 @@ internal protocol URLOpening {
 extension UIApplication: TopControllerGetting {
 
     @available(iOS 13.0, *)
-    var activeWindowScenes: [UIWindowScene] {
+    private var activeWindowScenes: [UIWindowScene] {
         self.connectedScenes
             .filter { $0.activationState == .foregroundActive }
             .compactMap { $0 as? UIWindowScene }
+    }
+
+    // Prefer the active window scene, but in the case where there's no active scene, use the one from the main app window.
+    @available(iOS 13.0, *)
+    var mainWindowScene: UIWindowScene? {
+        activeWindowScenes.first ?? windows.first(where: { !$0.isAppcuesWindow })?.windowScene
     }
 
     // We expose this property because a unit test cannot init a UIWindowScene for mocking different states.


### PR DESCRIPTION
Two separate issues here, both related to the `UIWindow` presentation changes.

1. There's a case where an experience being presented while the app is closing (think event triggered experience on an open URL in external browser button tap) doesn't show because there's no _active_ window scene. If there's an active scene, we want to use it, but if there's not, we can fallback to the window scene for whatever the main app window is. This is essential the same check we use [here](https://github.com/appcues/appcues-ios-sdk/blob/ae53fa37e66ca44e5777542a5783749db753fc04/Sources/AppcuesKit/Presentation/Extensions/UIApplication%2BTopViewController.swift#L58-L60) for the computation of `UIApplication.topViewController()` as used by the sheet presentation styles. I've updated all the places that used `UIApplication.shared.activeWindowScenes` for safety.
2. We have a scenario where the `AppcuesUIWindow` created by `ModalContextManager` isn't being removed from the view hierarchy after dismissal. The way that we were removing the `AppcuesUIWindow` was a bit flimsy: we were just setting the owning reference to `nil`. So if there are no other strong references to the window, it gets removed. But if something else happens to have a reference to the window, it stays in the view hierarchy. Setting `windowScene = nil` removes it from the hierarchy even if something else has a reference to it.