### PR TITLE
[SDK5] Update iOS deployment target to 13

### DIFF
--- a/Appcues.podspec
+++ b/Appcues.podspec
@@ -16,7 +16,7 @@ A Swift library for sending user properties and events to the Appcues API and re
   s.source           = { :git => 'https://github.com/appcues/appcues-ios-sdk.git', :tag => s.version.to_s }
 
   s.swift_version = '5.0'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '13.0'
 
   s.source_files = 'Sources/AppcuesKit/**/*.swift'
   s.exclude_files = 'Sources/AppcuesKit/AppcuesKit.docc'

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Appcues",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsBroadcaster.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsBroadcaster.swift
@@ -47,9 +47,8 @@ private extension MutableCollection where Element == Any {
     /// It's required to be this way because Dictionary doesn't conform to MutableCollection, only Dictionary.Values.
     mutating func sanitize() {
         for key in self.indices {
-            if #available(iOS 13.0, *), let stepState = self[key] as? ExperienceData.StepState {
-                // This needs to be separate from the switch for the version check,
-                // but it also means the switch applies to the dictionary value, ensuring it's also sanitized.
+            if let stepState = self[key] as? ExperienceData.StepState {
+                // Setting this outside the switch means the switch applies to the dictionary value, ensuring it's also sanitized.
                 self[key] = stepState.formattedAsAny() ?? NSNull()
             }
 

--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsTracker.swift
@@ -176,20 +176,14 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
         activityProcessor.process(activity) { [weak self] result in
             switch result {
             case .success(let qualifyResponse):
-                if #available(iOS 13.0, *) {
-                    let experienceRenderer = self?.container?.resolve(ExperienceRendering.self)
-                    experienceRenderer?.processAndShow(
-                        qualifiedExperiences: self?.process(qualifyResponse: qualifyResponse, activity: activity) ?? [],
-                        reason: .qualification(reason: qualifyResponse.qualificationReason)
-                    )
+                let experienceRenderer = self?.container?.resolve(ExperienceRendering.self)
+                experienceRenderer?.processAndShow(
+                    qualifiedExperiences: self?.process(qualifyResponse: qualifyResponse, activity: activity) ?? [],
+                    reason: .qualification(reason: qualifyResponse.qualificationReason)
+                )
 
-                    if qualifyResponse.experiences.isEmpty {
-                        // common case, nothing qualified - we know there was nothing to render, so just remove tracking
-                        SdkMetrics.remove(activity.requestID)
-                    }
-                } else {
-                    self?.config.logger.info("iOS 13 or above is required to render an Appcues experience")
-                    // nothing will render, we can remove tracking
+                if qualifyResponse.experiences.isEmpty {
+                    // common case, nothing qualified - we know there was nothing to render, so just remove tracking
                     SdkMetrics.remove(activity.requestID)
                 }
             case .failure(let error):
@@ -199,7 +193,6 @@ internal class AnalyticsTracker: AnalyticsTracking, AnalyticsSubscribing {
         }
     }
 
-    @available(iOS 13.0, *)
     private func process(qualifyResponse: QualifyResponse, activity: Activity) -> [ExperienceData] {
         let experiments = qualifyResponse.experiments ?? []
         return qualifyResponse.experiences.map { item in

--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -186,8 +186,7 @@ extension Experience: Decodable {
 
         // Check for an experience-level or first group-level embed trait
         let eligibleTraits = traits + (steps.first?.traits ?? [])
-        if #available(iOS 13.0, *),
-           let embedTrait = eligibleTraits.first(where: { $0.type == AppcuesEmbeddedTrait.type }),
+        if let embedTrait = eligibleTraits.first(where: { $0.type == AppcuesEmbeddedTrait.type }),
            let config = embedTrait.configDecoder.decode(AppcuesEmbeddedTrait.Config.self) {
             renderContext = .embed(frameID: config.frameID)
         } else {
@@ -198,8 +197,7 @@ extension Experience: Decodable {
 
 extension Experience {
     /// Returns a function that creates the post experience actions given an ``Appcues`` instance.
-    @available(iOS 13.0, *)
-    var postExperienceActionFactory: ((Appcues?) -> [AppcuesExperienceAction]) {
+        var postExperienceActionFactory: ((Appcues?) -> [AppcuesExperienceAction]) {
         return { appcues in
             var actions: [AppcuesExperienceAction] = []
 

--- a/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
@@ -26,8 +26,7 @@ internal enum StepReference: Equatable {
         }
     }
 
-    @available(iOS 13.0, *)
-    func resolve(experience: ExperienceData, currentIndex: Experience.StepIndex) -> Experience.StepIndex? {
+        func resolve(experience: ExperienceData, currentIndex: Experience.StepIndex) -> Experience.StepIndex? {
         switch self {
         case .index(let index):
             return experience.stepIndices[safe: index]
@@ -68,7 +67,6 @@ extension Experience {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceData {
     var stepIndices: [Experience.StepIndex] {
         model.steps.enumerated().flatMap { groupOffset, element in

--- a/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
+++ b/Sources/AppcuesKit/Data/Networking/DynamicCodingKeys.swift
@@ -43,7 +43,7 @@ extension KeyedEncodingContainer where K == DynamicCodingKeys {
                 // "_sdkMetrics" is a special case - the Experience rendering timing metrics
                 var autopropContainer = self.nestedContainer(keyedBy: DynamicCodingKeys.self, forKey: codingKey)
                 try autopropContainer.encodeSkippingInvalid(nestedProps, logger: logger)
-            } else if #available(iOS 13.0, *), let stepState = value as? ExperienceData.StepState {
+            } else if let stepState = value as? ExperienceData.StepState {
                 // Allow encoding the nested StepState structure since platform expects it
                 try self.encode(stepState, forKey: codingKey)
             } else {

--- a/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/ActionRegistry.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal class ActionRegistry {
     typealias Completion = () -> Void
 

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesCloseAction.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesCloseAction: AppcuesExperienceAction {
     struct Config: Decodable {
         let markComplete: Bool

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesContinueAction.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal class AppcuesContinueAction: AppcuesExperienceAction {
     struct Config: Decodable {
         let index: Int?

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesDelayAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesDelayAction.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal class AppcuesDelayAction: AppcuesExperienceAction {
     struct Config: Decodable {
         let duration: Int

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal class AppcuesLaunchExperienceAction: AppcuesExperienceAction {
     struct Config: Decodable {
         let experienceID: String

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLinkAction.swift
@@ -9,7 +9,6 @@
 import UIKit
 import SafariServices
 
-@available(iOS 13.0, *)
 internal class AppcuesLinkAction: AppcuesExperienceAction {
     struct Config: Decodable {
         let url: URL

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestPushAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestPushAction.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UserNotifications
 
-@available(iOS 13.0, *)
 internal class AppcuesRequestPushAction: AppcuesExperienceAction {
 
     static let type = "@appcues/request-push"

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestReviewAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesRequestReviewAction.swift
@@ -9,7 +9,6 @@
 import Foundation
 import StoreKit
 
-@available(iOS 13.0, *)
 internal class AppcuesRequestReviewAction: AppcuesExperienceAction {
 
     static let type = "@appcues/request-review"

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesStepInteractionAction.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 /// Internal-only action: This action isn't registered in the `ActionRegistry`.
-@available(iOS 13.0, *)
 internal class AppcuesStepInteractionAction: AppcuesExperienceAction {
 
     static let type = "@appcues/step_interaction"

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesSubmitFormAction.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal class AppcuesSubmitFormAction: AppcuesExperienceAction, ExperienceActionQueueTransforming {
     struct Config: Decodable {
         let skipValidation: Bool

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesTrackAction.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal class AppcuesTrackAction: AppcuesExperienceAction {
     struct Config {
         let eventName: String
@@ -44,7 +43,6 @@ internal class AppcuesTrackAction: AppcuesExperienceAction {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesTrackAction.Config: Decodable {
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesUpdateProfileAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesUpdateProfileAction.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal class AppcuesUpdateProfileAction: AppcuesExperienceAction {
     struct Config {
         let properties: [String: Any]
@@ -45,7 +44,6 @@ internal class AppcuesUpdateProfileAction: AppcuesExperienceAction {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesUpdateProfileAction.Config: Decodable {
     // Custom decoding for this one - we want to just gather up all the key/value
     // pairs from the trait config as raw user property values. We trim the set to

--- a/Sources/AppcuesKit/Presentation/Actions/InteractionLoggingAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/InteractionLoggingAction.swift
@@ -16,25 +16,21 @@ internal protocol InteractionLoggingAction {
 // MARK: - Implementations
 // These are the actions that can define the step_interaction analytic values.
 
-@available(iOS 13.0, *)
 extension AppcuesLinkAction: InteractionLoggingAction {
     var category: String { "link" }
     var destination: String { url.absoluteString }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesLaunchExperienceAction: InteractionLoggingAction {
     var category: String { "internal" }
     var destination: String { experienceID }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesContinueAction: InteractionLoggingAction {
     var category: String { "internal" }
     var destination: String { stepReference.description }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesCloseAction: InteractionLoggingAction {
     var category: String { "internal" }
     var destination: String { "end-experience" }

--- a/Sources/AppcuesKit/Presentation/ContentLoader.swift
+++ b/Sources/AppcuesKit/Presentation/ContentLoader.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal protocol ContentLoading: AnyObject {
     func load(
         experienceID: String,
@@ -26,7 +25,6 @@ internal protocol ContentLoading: AnyObject {
     )
 }
 
-@available(iOS 13.0, *)
 internal class ContentLoader: ContentLoading {
 
     private let config: Appcues.Config

--- a/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesExperienceActions.swift
+++ b/Sources/AppcuesKit/Presentation/CustomComponents/AppcuesExperienceActions.swift
@@ -23,7 +23,6 @@ public class AppcuesExperienceActions {
     }
 
     /// Trigger the actions associated with the custom component in the Appcues Mobile Builder.
-    @available(iOS 13.0, *)
     public func triggerBlockActions() {
         guard let actions = actions, let actionRegistry = appcues?.container.resolve(ActionRegistry.self) else { return }
         actionRegistry.enqueue(
@@ -39,38 +38,32 @@ public class AppcuesExperienceActions {
     /// - Parameters:
     ///   - name: Name of the event.
     ///   - properties: Optional properties that provide additional context about the event.
-    @available(iOS 13.0, *)
     public func track(name: String, properties: [String: Any]? = nil) {
         enqueue(AppcuesTrackAction(appcues: appcues, eventName: name, attributes: properties))
     }
 
     /// Advance the flow to the next step. If the flow is on its final step, the flow will dismiss as completed.
-    @available(iOS 13.0, *)
     public func nextStep() {
         enqueue(AppcuesContinueAction(appcues: appcues, renderContext: renderContext, stepReference: .offset(1)))
     }
 
     /// Navigate the flow to the previous step. If the flow is on its initial step, nothing will happen.
-    @available(iOS 13.0, *)
     public func previousStep() {
         enqueue(AppcuesContinueAction(appcues: appcues, renderContext: renderContext, stepReference: .offset(-1)))
     }
 
     /// Dismiss the flow.
     /// - Parameter markComplete: Whether the flow should be marked as complete for analytics purposes. Defaults to `false`.
-    @available(iOS 13.0, *)
     public func close(markComplete: Bool = false) {
         enqueue(AppcuesCloseAction(appcues: appcues, renderContext: renderContext, markComplete: markComplete))
     }
 
     /// Update the Appcues profile of the current user.
     /// - Parameter properties: Properties to add to the Appcues profile of the current user.
-    @available(iOS 13.0, *)
     public func updateProfile(properties: [String: Any]) {
         enqueue(AppcuesUpdateProfileAction(appcues: appcues, properties: properties))
     }
 
-    @available(iOS 13.0, *)
     private func enqueue(_ action: AppcuesExperienceAction) {
         guard let actionRegistry = appcues?.container.resolve(ActionRegistry.self) else { return }
         actionRegistry.enqueue(actionInstances: [action]) {}

--- a/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/APIVerifier.swift
@@ -9,7 +9,6 @@
 import Foundation
 import Combine
 
-@available(iOS 13.0, *)
 internal class APIVerifier {
     static let title = "Connected to Appcues"
     let networking: Networking

--- a/Sources/AppcuesKit/Presentation/Debugger/DebugLogger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/DebugLogger.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal class DebugLogger: ObservableObject, Logging {
     let previousLogger: Logging?
 
@@ -73,7 +72,6 @@ internal class DebugLogger: ObservableObject, Logging {
     }
 }
 
-@available(iOS 13.0, *)
 extension DebugLogger {
     struct Log: Identifiable, Encodable {
         let id = UUID()

--- a/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/DeepLinkVerifier.swift
@@ -9,7 +9,6 @@
 import UIKit
 import Combine
 
-@available(iOS 13.0, *)
 internal class DeepLinkVerifier {
     let title = "Appcues Deep Link"
     let applicationID: String

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class DebugUIWindow: UIWindow {
 
     init(windowScene: UIWindowScene, rootViewController: UIViewController) {

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugView+GestureCalculator.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugView+GestureCalculator.swift
@@ -10,7 +10,6 @@ import UIKit
 
 // swiftlint:disable identifier_name
 
-@available(iOS 13.0, *)
 extension DebugView {
     struct GestureCalculator {
         /// Calculate a scaled damping value from an initial magnitude.

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugView.swift
@@ -8,12 +8,10 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal protocol DebugViewDelegate: AnyObject {
     func debugView(did event: DebugView.Event)
 }
 
-@available(iOS 13.0, *)
 // swiftlint:disable:next type_body_length attributes
 internal class DebugView: UIView {
 
@@ -449,7 +447,6 @@ internal class DebugView: UIView {
     }
 }
 
-@available(iOS 13.0, *)
 extension DebugView {
     enum Event {
         case show

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal class DebugViewController: UIViewController {
 
     var delegate: DebugViewDelegate? {
@@ -136,7 +135,6 @@ internal class DebugViewController: UIViewController {
     }
 }
 
-@available(iOS 13.0, *)
 extension DebugViewController: FloatingViewDelegate {
     func floatingViewActivated() {
         switch mode {
@@ -150,7 +148,6 @@ extension DebugViewController: FloatingViewDelegate {
     }
 }
 
-@available(iOS 13.0, *)
 private extension DebugMode {
     var accessibilityLabel: String {
         switch self {

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DismissDropZoneView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DismissDropZoneView.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class DismissDropZoneView: UIView {
 
     /// Distance from the snapPoint at which the floating view locks to the snapPoint.

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FleetingItemView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FleetingItemView.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class FleetingItemView: UIView {
     private var stackView: UIStackView = {
         let stack = UIStackView()

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FleetingLogView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FleetingLogView.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class FleetingLogView: UIView {
     typealias Orientation = (x: XOrientation, y: YOrientation)
 

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FloatingView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FloatingView.swift
@@ -12,7 +12,6 @@ internal protocol FloatingViewDelegate: AnyObject {
     func floatingViewActivated()
 }
 
-@available(iOS 13.0, *)
 internal class FloatingView: UIView {
 
     private let tapRecognizer = UITapGestureRecognizer()

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugFontUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugFontUI.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 /// Namespaced Views used in the debug panel.
-@available(iOS 13.0, *)
 internal enum DebugFontUI {
     struct FontListView: View {
         static let sections: [(title: String, names: [String])] = {
@@ -107,7 +106,6 @@ internal enum DebugFontUI {
     }
 }
 
-@available(iOS 13.0, *)
 extension View {
     func searchableCompatible(text: Binding<String>) -> some View {
         modifier(DebugFontUI.Searchable(text: text))
@@ -117,7 +115,6 @@ extension View {
 // These extensions follow the interfaces of `CaseIterable` and `CustomStringConvertible`, but do not conform to those protocols
 // so that the extension methods aren't required to be public.
 
-@available(iOS 13.0, *)
 extension Font.Design {
     static var allCases: [Font.Design] {
         [.default, monospaced, .rounded, .serif]
@@ -132,7 +129,6 @@ extension Font.Design {
         }
     }
 }
-@available(iOS 13.0, *)
 extension Font.Weight {
     static var allCases: [Font.Weight] {
         [.ultraLight, .thin, .light, .regular, .medium, .semibold, .bold, .heavy, .black]

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugLogUI.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal enum DebugLogUI {
     struct LoggerView: View {
         @EnvironmentObject var logger: DebugLogger

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugPluginUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugPluginUI.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal enum DebugPluginUI {
     struct PluginListView: View {
         let componentDebugInfo: [(identifier: String, debuggableConfig: [String: Any]?)]
@@ -105,7 +104,6 @@ internal enum DebugPluginUI {
     }
 }
 
-@available(iOS 13.0, *)
 private extension DebugPluginUI {
 
     class DebugExperienceViewModel: ExperienceStepViewModel {

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugUI.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 /// Namespaced Views used in the debug panel.
-@available(iOS 13.0, *)
 internal enum DebugUI {
     struct MainPanelView: View {
         let apiVerifier: APIVerifier
@@ -352,7 +351,6 @@ internal enum DebugUI {
 
 }
 
-@available(iOS 13.0, *)
 extension DebugUI.ListItemRowView where Action == EmptyView {
     init(item: StatusItem) {
         self.init(item: item) { EmptyView() }

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/DebugViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 import Combine
 
-@available(iOS 13.0, *)
 internal class DebugViewModel: ObservableObject {
     private let storage: DataStoring
     private var cancellables = Set<AnyCancellable>()

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/LoggedEvent.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal struct LoggedEvent: Identifiable {
     typealias Pair = (title: String, value: String?)
 
@@ -127,7 +126,6 @@ internal struct LoggedEvent: Identifiable {
     }
 }
 
-@available(iOS 13.0, *)
 extension LoggedEvent {
     enum EventType: CaseIterable, CustomStringConvertible {
         case screen

--- a/Sources/AppcuesKit/Presentation/Debugger/Panel/StatusItem.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Panel/StatusItem.swift
@@ -46,7 +46,6 @@ extension StatusItem {
             }
         }
 
-        @available(iOS 13.0, *)
         var tintColor: Color {
             switch self {
             case .verified: return .green

--- a/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/PushVerifier.swift
@@ -19,7 +19,6 @@ private final class KeyedArchiver: NSKeyedArchiver {
     }
 }
 
-@available(iOS 13.0, *)
 internal class PushVerifier {
     enum ErrorMessage: Equatable, CustomStringConvertible {
         case noPushEnvironment(String)
@@ -296,7 +295,6 @@ internal class PushVerifier {
     }
 }
 
-@available(iOS 13.0, *)
 private extension PushVerifier {
     struct PushTestResponse: Decodable {
         let ok: Bool

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/AppcuesTargetView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/AppcuesTargetView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct ACTagView: UIViewRepresentable {
     let identifier: String?
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/DebugModalViewController.swift
@@ -16,7 +16,6 @@ import SwiftUI
 // the backdrop - and the ExperienceStepViewController centered within - providing the scroll
 // container where the hosted SwiftUI content resides. However, this is a more specific and
 // reduced implementation that is decoupled from Experience step content and data.
-@available(iOS 13.0, *)
 internal class DebugModalViewController<Content: View>: UIViewController {
 
     lazy var containerView = DebugModalWrapperView()
@@ -101,7 +100,6 @@ internal class DebugModalViewController<Content: View>: UIViewController {
     }
 }
 
-@available(iOS 13.0, *)
 extension DebugModalViewController {
     internal class DebugModalWrapperView: UIView {
         let backdropView: UIView = {

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/ScreenCapturer.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/ScreenCapturer.swift
@@ -14,7 +14,6 @@ internal enum ScreenCaptureError: Error {
     case failedCaptureEncoding
 }
 
-@available(iOS 13.0, *)
 internal class ScreenCapturer {
     private let config: Appcues.Config
     private let networking: Networking

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/SendCaptureUI.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 /// Namespaced Views used in the screen capture confirmation dialog.
-@available(iOS 13.0, *)
 internal enum SendCaptureUI {
 
     internal enum SendCaptureError: Error {
@@ -131,7 +130,6 @@ internal enum SendCaptureUI {
     }
 }
 
-@available(iOS 13.0, *)
 extension Color {
     // attempted to put colors in asset catalog and use SwiftGen, but the new 6.6.2 version has an
     // open issue with the generated code https://github.com/SwiftGen/SwiftGen/issues/1022 related

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
@@ -125,7 +125,6 @@ internal class UIKitElementSelector: AppcuesElementSelector {
 
 // UIKit implementation of element targeting that captures the UIView hierarchy for the current UIWindow,
 // and identifies applicable views with a UIKitElementSelector.
-@available(iOS 13.0, *)
 internal class UIKitElementTargeting: AppcuesElementTargeting {
     // Inject a window for testing purposes
     var window: UIWindow?

--- a/Sources/AppcuesKit/Presentation/Debugger/Toasts/ToastUIWindow.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/Toasts/ToastUIWindow.swift
@@ -16,7 +16,6 @@ private class OverlayViewController: UIViewController {
 }
 
 /// A transparent UIWindow that displays toast messages and handles the expected toast interactions.
-@available(iOS 13.0, *)
 internal class ToastUIWindow: UIWindow {
 
     private let toastTapRecognizer = UITapGestureRecognizer()

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -10,7 +10,6 @@ import UIKit
 import SwiftUI
 import Combine
 
-@available(iOS 13.0, *)
 internal protocol UIDebugging: AnyObject {
     func verifyInstall(token: String)
     func show(mode: DebugMode)
@@ -44,7 +43,6 @@ internal enum DebugMode {
     case screenCapture(Authorization)     // capture screen image and layout for element targeting
 }
 
-@available(iOS 13.0, *)
 internal class UIDebugger: UIDebugging {
     private var debugWindow: DebugUIWindow?
     private var toastWindow: ToastUIWindow?
@@ -174,7 +172,6 @@ internal class UIDebugger: UIDebugging {
     }
 }
 
-@available(iOS 13.0, *)
 extension UIDebugger: DebugViewDelegate, ScreenCaptureUI {
     func debugView(did event: DebugView.Event) {
         switch event {
@@ -198,7 +195,6 @@ extension UIDebugger: DebugViewDelegate, ScreenCaptureUI {
     }
 }
 
-@available(iOS 13.0, *)
 extension UIDebugger: AnalyticsSubscribing {
     func track(update: TrackingUpdate) {
         guard Thread.isMainThread else {

--- a/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
+++ b/Sources/AppcuesKit/Presentation/DeepLinkHandler.swift
@@ -8,12 +8,10 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal protocol DeepLinkHandling: AnyObject {
     func didHandleURL(_ url: URL) -> Bool
 }
 
-@available(iOS 13.0, *)
 internal class DeepLinkHandler: DeepLinkHandling {
 
     enum Action: Hashable {
@@ -226,7 +224,6 @@ public extension Appcues {
     /// ```swift
     /// guard !<#appcuesInstance#>.filterAndHandle(URLContexts) else { return }
     /// ```
-    @available(iOS 13.0, *)
     @discardableResult
     @objc
     func filterAndHandle(_ URLContexts: Set<UIOpenURLContext>) -> Set<UIOpenURLContext> {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
@@ -10,7 +10,6 @@ import Foundation
 
 extension Dictionary where Key == String, Value == Any {
     /// Map experience model to a general property dictionary.
-    @available(iOS 13.0, *)
     init(
         propertiesFrom experience: ExperienceData,
         stepIndex: Experience.StepIndex? = nil,

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal protocol ExperienceRendering: AnyObject {
     func start(owner: StateMachineOwning, forContext context: RenderContext)
     func processAndShow(qualifiedExperiences: [ExperienceData], reason: ExperienceTrigger)
@@ -50,7 +49,6 @@ internal enum ExperienceRendererError: Error {
     case experimentControl
 }
 
-@available(iOS 13.0, *)
 internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
 
     // Conformance to `StateMachineOwning`.

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+Action.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     indirect enum Action {
         case startExperience(ExperienceData)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+ExperienceError.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     enum ExperienceError: Error {
         case noTransition(currentState: State)
@@ -18,7 +17,6 @@ extension ExperienceStateMachine {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine.ExperienceError: Equatable {
     static func == (lhs: ExperienceStateMachine.ExperienceError, rhs: ExperienceStateMachine.ExperienceError) -> Bool {
         switch (lhs, rhs) {
@@ -36,7 +34,6 @@ extension ExperienceStateMachine.ExperienceError: Equatable {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine.ExperienceError: CustomStringConvertible, CustomDebugStringConvertible {
 
     var description: String {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine+State.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     indirect enum State {
         case idling
@@ -108,7 +107,6 @@ extension ExperienceStateMachine {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine.State: Equatable {
     static func == (lhs: ExperienceStateMachine.State, rhs: ExperienceStateMachine.State) -> Bool {
         switch (lhs, rhs) {
@@ -133,7 +131,6 @@ extension ExperienceStateMachine.State: Equatable {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine.State: CustomStringConvertible {
     var description: String {
         switch self {
@@ -157,7 +154,6 @@ extension ExperienceStateMachine.State: CustomStringConvertible {
 
 // MARK: - Complex Transitions
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine.Transition {
     static func fromIdlingToBeginningExperience(_ experience: ExperienceData) -> Self {
         // handle errors that occurred prior to starting the experience - such as flow deserialization issues

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateMachine.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class ExperienceStateMachine {
 
     private let config: Appcues.Config
@@ -109,7 +108,6 @@ internal class ExperienceStateMachine {
 
 // MARK: - AppcuesExperienceContainerEventHandler
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine: AppcuesExperienceContainerEventHandler {
     // MARK: Step Lifecycle
 
@@ -247,7 +245,6 @@ private extension UIViewController {
 
 // MARK: - State Machine Types
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     struct Transition {
         let toState: State?
@@ -267,7 +264,6 @@ extension ExperienceStateMachine {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     enum SideEffect {
         case continuation(Action)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -8,13 +8,11 @@
 
 import Foundation
 
-@available(iOS 13.0, *)
 internal protocol ExperienceStateObserver: AnyObject {
     typealias StateResult = Result<ExperienceStateMachine.State, ExperienceStateMachine.ExperienceError>
     func evaluateIfSatisfied(result: StateResult) -> Bool
 }
 
-@available(iOS 13.0, *)
 extension Result where Success == ExperienceStateMachine.State, Failure == ExperienceStateMachine.ExperienceError {
 
     /// Check if the result pertains to a specific experience ID.
@@ -39,7 +37,6 @@ extension Result where Success == ExperienceStateMachine.State, Failure == Exper
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceStateMachine {
     typealias Callback = (ExperienceStateObserver.StateResult) -> Bool
 
@@ -206,7 +203,6 @@ extension ExperienceStateMachine {
     }
 }
 
-@available(iOS 13.0, *)
 private extension ExperienceStateObserver.StateResult {
     var shouldPublish: Bool {
         switch self {
@@ -218,7 +214,6 @@ private extension ExperienceStateObserver.StateResult {
     }
 }
 
-@available(iOS 13.0, *)
 private extension ExperienceStateMachine.ExperienceError {
     var shouldPublish: Bool {
         switch self {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class ModalContextManager {
     var presentingWindow: AppcuesUIWindow?
 
@@ -51,7 +50,6 @@ internal class ModalContextManager {
     }
 }
 
-@available(iOS 13.0, *)
 extension ModalContextManager {
     class AppcuesUIWindow: UIWindow {
         override init(windowScene: UIWindowScene) {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StateMachineDirectory.swift
@@ -10,7 +10,6 @@ import Foundation
 
 internal protocol StateMachineOwning: AnyObject {
     var renderContext: RenderContext? { get set }
-    @available(iOS 13.0, *)
     var stateMachine: ExperienceStateMachine? { get set }
 
     /// Should reset the `stateMachine` to `.idling` and clear any rendered experience without triggering experience analytics.
@@ -19,7 +18,6 @@ internal protocol StateMachineOwning: AnyObject {
 
 // This class is intended to work like a `Dictionary<RenderContext, StateMachineOwning?>`,
 // while abstracting away the fact that it weakly references the value.
-@available(iOS 13.0, *)
 internal class StateMachineDirectory {
     private var stateMachines: [RenderContext: WeakStateMachineOwning] = [:]
     private let syncQueue = DispatchQueue(label: "appcues-state-directory")
@@ -79,7 +77,6 @@ internal class StateMachineDirectory {
 
 }
 
-@available(iOS 13.0, *)
 private extension StateMachineDirectory {
     class WeakStateMachineOwning {
         weak var value: StateMachineOwning?

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/StepRecoveryObserver.swift
@@ -13,7 +13,6 @@ import Foundation
 // are observed. It hooks into the AppcuesScrollViewDelegate, which receives
 // scroll updates from the UIScrollView implementations in the app via
 // method swizzling.
-@available(iOS 13.0, *)
 internal class StepRecoveryObserver: ExperienceStateObserver {
 
     private let stateMachine: ExperienceStateMachine

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/Alignment+String.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/Alignment+String.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension Alignment {
 
     /// Init `Alignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/Color+DynamicColor.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/Color+DynamicColor.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension UIColor {
     convenience init?(dynamicColor: ExperienceComponent.Style.DynamicColor?) {
         guard let semanticColor = dynamicColor else { return nil }
@@ -23,7 +22,6 @@ extension UIColor {
     }
 }
 
-@available(iOS 13.0, *)
 extension Color {
     init?(dynamicColor: ExperienceComponent.Style.DynamicColor?) {
         guard let uiColor = UIColor(dynamicColor: dynamicColor) else { return nil }

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/ContentMode+String.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/ContentMode+String.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension ContentMode {
 
     /// Init `ContentMode` from an experience JSON model value.

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/Font+Double.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/Font+Double.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension Font {
 
     /// Init `Font` from an experience JSON model values.
@@ -61,7 +60,6 @@ extension UIFontMetrics {
     }
 }
 
-@available(iOS 13.0, *)
 extension Font.Weight {
 
     /// Init `Font.Weight` from an experience JSON fontName keyword.
@@ -81,7 +79,6 @@ extension Font.Weight {
     }
 }
 
-@available(iOS 13.0, *)
 extension Font.Design {
 
     /// Init `Font.Design` from an experience JSON fontName keyword.
@@ -96,7 +93,6 @@ extension Font.Design {
     }
 }
 
-@available(iOS 13.0, *)
 extension UIFont {
     static func matching(name: String?, size: Double?) -> UIFont? {
         guard let size = CGFloat(size) else { return nil }
@@ -126,7 +122,6 @@ extension UIFont {
     }
 }
 
-@available(iOS 13.0, *)
 extension UIFont.Weight {
 
     /// Init `UIFont.Weight` from an experience JSON fontName keyword.
@@ -146,7 +141,6 @@ extension UIFont.Weight {
     }
 }
 
-@available(iOS 13.0, *)
 extension UIFontDescriptor.SystemDesign {
 
     /// Init `UIFontDescriptor.SystemDesign` from an experience JSON fontName keyword.

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/HorizontalAlignment+String.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/HorizontalAlignment+String.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension HorizontalAlignment {
 
     /// Init `HorizontalAlignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/Image+BlurHash.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/Image+BlurHash.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension Image {
     init?(blurHash: String?, size: CGSize = CGSize(width: 16, height: 16)) {
         guard let blurHash = blurHash, let image = UIImage(blurHash: blurHash, size: size) else {

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/LinearGradient+Init.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/LinearGradient+Init.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension LinearGradient {
 
     /// Init `LinearGradient` from an experience JSON model value.
@@ -25,7 +24,6 @@ extension LinearGradient {
     }
 }
 
-@available(iOS 13.0, *)
 extension UnitPoint {
 
     /// Init `UnitPoint` from an experience JSON model value.

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/NSDirectionalEdgeInsets+Style.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/NSDirectionalEdgeInsets+Style.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 extension NSDirectionalEdgeInsets {
-    @available(iOS 13.0, *)
     init(paddingFrom style: ExperienceComponent.Style?, fallback: CGFloat = 0) {
         self.init(
             top: style?.paddingTop ?? fallback,
@@ -19,7 +18,6 @@ extension NSDirectionalEdgeInsets {
         )
     }
 
-    @available(iOS 13.0, *)
     init(marginFrom style: ExperienceComponent.Style?, fallback: CGFloat = 0) {
         self.init(
             top: style?.marginTop ?? fallback,

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/TextAlignment+String.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/TextAlignment+String.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension TextAlignment {
 
     /// Init `TextAlignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/Presentation/Extensions/Inits/VerticalAlignment+String.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/Inits/VerticalAlignment+String.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension VerticalAlignment {
 
     /// Init `VerticalAlignment` from an experience JSON model value.

--- a/Sources/AppcuesKit/Presentation/Extensions/NSCollectionLayoutSection+Factory.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/NSCollectionLayoutSection+Factory.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 extension NSCollectionLayoutSection {
     static func fullScreenCarousel() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(

--- a/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIApplication+TopViewController.swift
@@ -23,7 +23,6 @@ internal protocol URLOpening {
 
 extension UIApplication: TopControllerGetting {
 
-    @available(iOS 13.0, *)
     private var activeWindowScenes: [UIWindowScene] {
         self.connectedScenes
             .filter { $0.activationState == .foregroundActive }
@@ -31,30 +30,21 @@ extension UIApplication: TopControllerGetting {
     }
 
     // Prefer the active window scene, but in the case where there's no active scene, use the one from the main app window.
-    @available(iOS 13.0, *)
     var mainWindowScene: UIWindowScene? {
         activeWindowScenes.first ?? windows.first(where: { !$0.isAppcuesWindow })?.windowScene
     }
 
     // We expose this property because a unit test cannot init a UIWindowScene for mocking different states.
     var hasActiveWindowScenes: Bool {
-        if #available(iOS 13.0, *) {
-            return !activeWindowScenes.isEmpty
-        } else {
-            return false
-        }
+        !activeWindowScenes.isEmpty
     }
 
     // Note: multitasking with two instances of the same app side by side will have both designated as `.foregroundActive`,
     // and as a result the returned window may not be the one expected.
     private var activeKeyWindow: UIWindow? {
-        if #available(iOS 13.0, *) {
-            return self.activeWindowScenes
-                .flatMap { $0.windows }
-                .first { $0.isKeyWindow }
-        } else {
-            return keyWindow
-        }
+        self.activeWindowScenes
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
     }
 
     func topViewController() -> UIViewController? {

--- a/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
@@ -12,7 +12,6 @@ import UIKit
 // shared instance. The UIScrollView swizzled methods below can then send updates
 // into this class and have them processed and broadcast to a StepRecoverObserver, if
 // any observer is currently in recovery/retry mode (i.e. failed tooltip)
-@available(iOS 13.0, *)
 internal class AppcuesScrollViewDelegate: NSObject, UIScrollViewDelegate {
     static var shared = AppcuesScrollViewDelegate()
 
@@ -73,7 +72,6 @@ internal class AppcuesScrollViewDelegate: NSObject, UIScrollViewDelegate {
     }
 }
 
-@available(iOS 13.0, *)
 extension UIScrollView {
 
     static func swizzleScrollViewGetDelegate() {

--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension View {
     func setupActions(on viewModel: ExperienceStepViewModel, for componentModel: ComponentModel) -> some View {
         let actions = viewModel.actions(for: componentModel.id)
@@ -148,7 +147,6 @@ extension View {
     }
 }
 
-@available(iOS 13.0, *)
 extension Text {
     func applyTextStyle(_ style: AppcuesStyle, model: ExperienceComponent.TextModel) -> some View {
         self

--- a/Sources/AppcuesKit/Presentation/Extensions/View+Conditional.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Conditional.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension View {
 
     // https://www.avanderlee.com/swiftui/conditional-view-modifier/

--- a/Sources/AppcuesKit/Presentation/Public/ElementTargeting/View+AppcuesView.swift
+++ b/Sources/AppcuesKit/Presentation/Public/ElementTargeting/View+AppcuesView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 public extension View {
     /// Associates the view with an identifier for Appcues element targeting.
     /// - Parameter identifier: Unique name identifying the view.

--- a/Sources/AppcuesKit/Presentation/Public/UIWindow+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Public/UIWindow+Appcues.swift
@@ -15,10 +15,6 @@ public extension UIWindow {
     /// Implementations of `AppcuesElementTargeting` may need this value to reliably exclude any Appcues content windows
     /// that are overlaid on top of the application, when capturing screen layout information.
     var isAppcuesWindow: Bool {
-        if #available(iOS 13.0, *) {
-            return self is DebugUIWindow || self is ModalContextManager.AppcuesUIWindow
-        } else {
-            return false
-        }
+        self is DebugUIWindow || self is ModalContextManager.AppcuesUIWindow
     }
 }

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropKeyholeTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesBackdropKeyholeTrait: AppcuesBackdropDecoratingTrait {
     struct Config: Decodable {
         let shape: String?
@@ -202,7 +201,6 @@ internal class AppcuesBackdropKeyholeTrait: AppcuesBackdropDecoratingTrait {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesBackdropKeyholeTrait {
     enum KeyholeShape {
         case rectangle(cornerRadius: CGFloat)

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesBackdropTrait: AppcuesBackdropDecoratingTrait {
     struct Config: Decodable {
         let backgroundColor: ExperienceComponent.Style.DynamicColor

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackgroundContentTrait.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal class AppcuesBackgroundContentTrait: AppcuesStepDecoratingTrait, AppcuesContainerDecoratingTrait {
     struct Config: Decodable {
         let content: ExperienceComponent

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesCarouselTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesCarouselTrait: AppcuesContainerCreatingTrait {
     static let type = "@appcues/carousel"
 
@@ -25,7 +24,6 @@ internal class AppcuesCarouselTrait: AppcuesContainerCreatingTrait {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesCarouselTrait {
 
     class CarouselContainerViewController: AppcuesExperienceContainerViewController, UICollectionViewDataSource, UICollectionViewDelegate {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEmbeddedTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesEmbeddedTrait: AppcuesStepDecoratingTrait, AppcuesContainerDecoratingTrait, AppcuesPresentingTrait {
 
     struct Config: Decodable {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesModalTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
 
     enum Transition: Equatable {
@@ -93,7 +92,6 @@ internal class AppcuesModalTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCrea
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesModalTrait {
     enum PresentationStyle: String, Decodable {
         case full
@@ -125,7 +123,6 @@ extension AppcuesModalTrait {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesModalTrait.Config {
     func toTransition() -> AppcuesModalTrait.Transition {
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesPagingDotsTrait.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesPagingDotsTrait: AppcuesContainerDecoratingTrait {
     struct Config: Decodable {
         let style: ExperienceComponent.Style?

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBackdropDecoratingTrait {
     struct Config: Decodable {
         let buttonAppearance: ButtonAppearance?
@@ -84,7 +83,6 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesSkippableTrait {
     enum ButtonAppearance: String, Decodable {
         case hidden
@@ -93,7 +91,6 @@ extension AppcuesSkippableTrait {
     }
 }
 
-@available(iOS 13.0, *)
 private extension UIViewController {
     @discardableResult
     func addDismissButton(appearance: AppcuesSkippableTrait.ButtonAppearance, style: ExperienceComponent.Style?) -> CloseButton {
@@ -145,7 +142,6 @@ private extension UIViewController {
     }
 }
 
-@available(iOS 13.0, *)
 private extension UIViewController {
     class CloseButton: UIButton {
         private static let defaultSize: Double = 30

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetElementTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesTargetElementTrait: AppcuesBackdropDecoratingTrait {
     struct Config: Decodable {
         let contentPreferredPosition: ContentPosition?

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
     struct Config: Decodable {
         // swiftlint:disable:next discouraged_optional_boolean
@@ -133,7 +132,6 @@ internal class AppcuesTargetInteractionTrait: AppcuesBackdropDecoratingTrait {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesTargetInteractionTrait {
     class TargetView: UIView, UIGestureRecognizerDelegate {
         private weak var appWindow: UIWindow?

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetRectangleTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetRectangleTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesTargetRectangleTrait: AppcuesBackdropDecoratingTrait {
     struct Config: Decodable {
         let contentPreferredPosition: ContentPosition?

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTooltipTrait.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class AppcuesTooltipTrait: AppcuesStepDecoratingTrait, AppcuesWrapperCreatingTrait, AppcuesPresentingTrait {
     struct Config: Decodable {
         // swiftlint:disable:next discouraged_optional_boolean

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperSlideAnimator.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimatedTransitioning {
 
     enum ModalTransitionType {
@@ -90,7 +89,6 @@ internal class ExperienceWrapperSlideAnimator: NSObject, UIViewControllerAnimate
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceWrapperView {
     func slideTransform(edge: AppcuesModalTrait.TransitionEdge, containerBounds: CGRect) {
         var offsetX: CGFloat

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperView.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class ExperienceWrapperView: HitTestingOverrideUIView {
 
     var preferredContentSize: CGSize?

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController+DragDirection.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController+DragDirection.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension ExperienceWrapperViewController {
     struct DragDirection {
         enum Edge {

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/ExperienceWrapperViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal class ExperienceWrapperViewController<BodyView: ExperienceWrapperView>: UIViewController, UIViewControllerTransitioningDelegate {
 
     lazy var bodyView = BodyView()

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/TooltipWrapperView.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/TooltipWrapperView.swift
@@ -15,7 +15,6 @@ internal enum ContentPosition: String, Decodable {
     case right
 }
 
-@available(iOS 13.0, *)
 internal class TooltipWrapperView: ExperienceWrapperView {
 
     private static let defaultMaxWidth: CGFloat = 400

--- a/Sources/AppcuesKit/Presentation/Traits/DefaultContainerViewController.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/DefaultContainerViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class DefaultContainerViewController: AppcuesExperienceContainerViewController {
 
     weak var eventHandler: AppcuesExperienceContainerEventHandler?

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -8,12 +8,10 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal protocol TraitComposing: AnyObject {
     func package(experience: ExperienceData, stepIndex: Experience.StepIndex) throws -> ExperiencePackage
 }
 
-@available(iOS 13.0, *)
 internal class TraitComposer: TraitComposing {
 
     private weak var appcues: Appcues?
@@ -154,7 +152,6 @@ internal class TraitComposer: TraitComposing {
     }
 }
 
-@available(iOS 13.0, *)
 extension TraitComposer {
     class DecomposedTraits {
         private(set) var allTraitInstances: [AppcuesExperienceTrait]

--- a/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitRegistry.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class TraitRegistry {
     private var traits: [String: AppcuesExperienceTrait.Type] = [:]
     private weak var appcues: Appcues?

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrame.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 /// A SwiftUI view that displays an Appcues experience.
-@available(iOS 13.0, *)
 public struct AppcuesFrame: UIViewControllerRepresentable {
     weak var appcues: Appcues?
     let frameID: String
@@ -33,7 +32,6 @@ public struct AppcuesFrame: UIViewControllerRepresentable {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesFrame {
     class AppcuesFrameVC: UIViewController {
         lazy var frameView = AppcuesFrameView()

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesFrameView.swift
@@ -19,18 +19,10 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
     /// The delegate object that manages and observes presentations in this embed frame.
     public weak var presentationDelegate: AppcuesPresentationDelegate? {
         get {
-            if #available(iOS 13.0, *) {
-                return stateMachine?.clientControllerPresentationDelegate
-            } else {
-                return nil
-            }
+            stateMachine?.clientControllerPresentationDelegate
         }
         set {
-            if #available(iOS 13.0, *) {
-                stateMachine?.clientControllerPresentationDelegate = newValue
-            } else {
-                // no-op
-            }
+            stateMachine?.clientControllerPresentationDelegate = newValue
         }
     }
 
@@ -38,7 +30,6 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
     internal var renderContext: RenderContext?
 
     private var _stateMachine: Any?
-    @available(iOS 13.0, *)
     internal var stateMachine: ExperienceStateMachine? {
         get { _stateMachine as? ExperienceStateMachine }
         set { _stateMachine = newValue }
@@ -145,9 +136,7 @@ public class AppcuesFrameView: UIView, StateMachineOwning {
 
     /// Set the Frame back to an unregistered state.
     internal func reset() {
-        if #available(iOS 13.0, *) {
-            stateMachine?.removeAnalyticsObserver()
-            try? stateMachine?.transition(.endExperience(markComplete: false))
-        }
+        stateMachine?.removeAnalyticsObserver()
+        try? stateMachine?.transition(.endExperience(markComplete: false))
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesHostingController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesHostingController.swift
@@ -11,7 +11,6 @@ import SwiftUI
 /// A `UIHostingController` that properly handles content size changes and removes the extra spacing added in iOS 15.
 ///
 /// Reference: https://stackoverflow.com/a/69359296
-@available(iOS 13.0, *)
 internal class AppcuesHostingController<Content: View>: UIHostingController<Content>, DynamicContentSizing {
 
     // By default, changes in preferred content size from this hosting controller should be propagated up

--- a/Sources/AppcuesKit/Presentation/UI/AppcuesStyle.swift
+++ b/Sources/AppcuesKit/Presentation/UI/AppcuesStyle.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesStyle {
     let padding: EdgeInsets
     let margin: EdgeInsets

--- a/Sources/AppcuesKit/Presentation/UI/Components/AnimatedImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AnimatedImage.swift
@@ -12,7 +12,6 @@ internal struct AnimatedImage {
     let animatedImage: FLAnimatedImage
 }
 
-@available(iOS 13.0, *)
 extension AnimatedImage: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UIView {

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesBox.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesBox.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesBox: View {
     let model: ExperienceComponent.BoxModel
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesButton: View {
     let model: ExperienceComponent.ButtonModel
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesCustomComponent.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesCustomComponent.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct CustomComponentRepresentable: UIViewControllerRepresentable {
     private let type: AppcuesCustomComponentViewController.Type
     private let configuration: AppcuesExperiencePluginConfiguration
@@ -31,7 +30,6 @@ internal struct CustomComponentRepresentable: UIViewControllerRepresentable {
     }
 }
 
-@available(iOS 13.0, *)
 internal struct AppcuesCustomComponent: View {
     let model: ExperienceComponent.CustomComponentModel
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesEmbed.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesEmbed.swift
@@ -9,7 +9,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesEmbed: View {
     let model: ExperienceComponent.EmbedModel
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesImage: View {
     let model: ExperienceComponent.ImageModel
     private let transformedURL: URL

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesOptionSelect: View {
     let model: ExperienceComponent.OptionSelectModel
 
@@ -93,7 +92,6 @@ internal struct AppcuesOptionSelect: View {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceComponent.OptionSelectModel.ControlPosition {
     var verticalAlignment: VerticalAlignment? {
         switch self {

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesStack.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesStack: View {
     let model: ExperienceComponent.StackModel
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesText.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesText: View {
     let model: ExperienceComponent.TextModel
 
@@ -29,7 +28,6 @@ internal struct AppcuesText: View {
     }
 }
 
-@available(iOS 13.0, *)
 extension Text {
     init(textModel: ExperienceComponent.TextModel, skipColor: Bool = false, scaled: Bool = false) {
         self.init(verbatim: "")

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesTextInput.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct AppcuesTextInput: View {
     let model: ExperienceComponent.TextInputModel
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/EmbedWebView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EmbedWebView.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 import WebKit
 
-@available(iOS 13.0, *)
 internal struct EmbedWebView: UIViewRepresentable {
     let embed: String
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/EnvironmentValues+ImageCache.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EnvironmentValues+ImageCache.swift
@@ -8,13 +8,11 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct ImageCacheKey: EnvironmentKey {
     // This is mutable so a custom cache can be injected for testing.
     static var defaultValue = SessionImageCache()
 }
 
-@available(iOS 13.0, *)
 extension EnvironmentValues {
     var imageCache: SessionImageCache {
         get { self[ImageCacheKey.self] }

--- a/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EqualWidthStack.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 private struct StackWidthPreferenceKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
 
@@ -17,7 +16,6 @@ private struct StackWidthPreferenceKey: PreferenceKey {
     }
 }
 
-@available(iOS 13.0, *)
 internal struct EqualWidthStack<Content: View>: View {
     @State private var stackWidth: CGFloat = 0
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/ExperienceComponent+View.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension ExperienceComponent {
 
     @ViewBuilder var view: some View {

--- a/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/MultilineTextView.swift
@@ -56,7 +56,6 @@ internal struct TextInputStyle: TextInputStyling {
 // from iOS 13 and up, since SwiftUI TextField has different feature support
 // on later iOS versions, and not all available in 13. This implementation
 // wraps UIKit UITextField for single line, and UIKit UITextView for multi-line.
-@available(iOS 13.0, *)
 internal struct MultilineTextView: UIViewRepresentable {
     @Binding var text: String
     let model: TextInputStyling
@@ -124,7 +123,6 @@ internal struct MultilineTextView: UIViewRepresentable {
     }
 }
 
-@available(iOS 13.0, *)
 extension MultilineTextView {
     class Coordinator: NSObject, UITextViewDelegate, UITextFieldDelegate {
         var parent: MultilineTextView
@@ -226,7 +224,6 @@ extension MultilineTextView {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceComponent.TextInputModel: TextInputStyling {
     var font: UIFont? {
         let fontSize = textFieldStyle?.fontSize ?? UIFont.labelFontSize

--- a/Sources/AppcuesKit/Presentation/UI/Components/NPSView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/NPSView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 // The NPSView is a specialized display format for the AppcuesOptionSelect component.
 // It can be used for single-select models. It splits the given set of options in half
 // and renders in a specific two row display format, for the net promotor score use case.
-@available(iOS 13.0, *)
 internal struct NPSView: View {
     let model: ExperienceComponent.OptionSelectModel
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/RemoteImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/RemoteImage.swift
@@ -12,7 +12,6 @@ import Combine
 // AsyncImage is iOS 15+, so borrow this from
 // https://www.vadimbulavin.com/asynchronous-swiftui-image-loading-from-url-with-combine-and-swift/
 
-@available(iOS 13.0, *)
 internal class ImageLoader: ObservableObject {
     @Published var animatedImage: FLAnimatedImage?
     @Published var image: UIImage?
@@ -69,7 +68,6 @@ internal class ImageLoader: ObservableObject {
     }
 }
 
-@available(iOS 13.0, *)
 internal struct RemoteImage<Placeholder: View>: View {
     @ObservedObject private var loader: ImageLoader
     private let placeholder: Placeholder

--- a/Sources/AppcuesKit/Presentation/UI/Components/SelectToggleView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/SelectToggleView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct SelectToggleView<Content: View>: View {
 
     enum Appearance {
@@ -60,7 +59,6 @@ internal struct SelectToggleView<Content: View>: View {
     }
 }
 
-@available(iOS 13.0, *)
 extension SelectToggleView.Appearance {
     init(_ mode: ExperienceComponent.OptionSelectModel.SelectMode) {
         switch mode {

--- a/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/TintedTextView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct TintedTextView: View {
     let model: ExperienceComponent.TextModel
     let tintColor: Color?

--- a/Sources/AppcuesKit/Presentation/UI/CustomComponentRegistry.swift
+++ b/Sources/AppcuesKit/Presentation/UI/CustomComponentRegistry.swift
@@ -14,7 +14,6 @@ internal struct CustomComponentData {
     let actionController: AppcuesExperienceActions
 }
 
-@available(iOS 13.0, *)
 internal class CustomComponentRegistry {
     private var registeredComponents: [String: AppcuesCustomComponentViewController.Type] = [:]
 

--- a/Sources/AppcuesKit/Presentation/UI/DynamicContentSizing.swift
+++ b/Sources/AppcuesKit/Presentation/UI/DynamicContentSizing.swift
@@ -10,7 +10,6 @@ import UIKit
 
 /// Used to inform a container `UIViewController` whether it should update it's `preferredContentSize` based
 /// on the updated size of this `UIContentContainer`.
-@available(iOS 13.0, *)
 internal protocol DynamicContentSizing: UIContentContainer {
     var updatesPreferredContentSize: Bool { get set }
 }

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 @dynamicMemberLookup
 internal class ExperienceData {
     let model: Experience
@@ -72,7 +71,6 @@ internal class ExperienceData {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceData {
 
     enum Validator: Equatable {
@@ -83,7 +81,6 @@ extension ExperienceData {
         /// At most the specified number of values have been selected.
         case maxSelections(UInt)
 
-        @available(iOS 13.0, *)
         func isSatisfied(value: ExperienceData.FormItem.ValueType) -> Bool {
             switch (self, value) {
             case (.nonEmpty, _), (.minSelections, .single), (.minSelections, .singleLeadingFill):
@@ -264,7 +261,6 @@ extension ExperienceData {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceData.StepState {
     func formattedAsProfileUpdate() -> [String: Any] {
         var update: [String: Any] = [:]
@@ -293,7 +289,6 @@ extension ExperienceData.StepState {
 
 }
 
-@available(iOS 13.0, *)
 extension ExperienceData.StepState: Encodable {
     enum ItemKeys: CodingKey {
         case fieldId, fieldType, fieldRequired, value, label
@@ -313,14 +308,12 @@ extension ExperienceData.StepState: Encodable {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceData.StepState: Equatable {
     static func == (lhs: ExperienceData.StepState, rhs: ExperienceData.StepState) -> Bool {
         lhs.formItems == rhs.formItems
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceComponent.TextInputModel {
     func validators() -> [ExperienceData.Validator] {
         var validators: [ExperienceData.Validator] = []
@@ -333,7 +326,6 @@ extension ExperienceComponent.TextInputModel {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceComponent.OptionSelectModel {
 
     /// The actual minimum number of selections (accounting for the full model state)	.

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepRootView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepRootView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct ExperienceStepRootView<Content: View>: View {
     let rootView: Content
 

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal class ExperienceStepViewController: UIViewController {
 
     let viewModel: ExperienceStepViewModel
@@ -184,7 +183,6 @@ internal class ExperienceStepViewController: UIViewController {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceStepViewController {
     class ExperienceStepView: UIView {
         lazy var scrollView: UIScrollView = {

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewModel.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal class ExperienceStepViewModel: ObservableObject {
 
     enum ActionType: String {
@@ -88,7 +87,6 @@ internal class ExperienceStepViewModel: ObservableObject {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceComponent {
     /// Recursively get all the form components in the `ExperienceContent`.
     var formComponents: [UUID: ExperienceData.FormItem] {

--- a/Sources/AppcuesKit/Push/PushEnvironment.swift
+++ b/Sources/AppcuesKit/Push/PushEnvironment.swift
@@ -107,26 +107,9 @@ extension UIDevice {
         let binaryString = try String(contentsOfFile: path, encoding: .isoLatin1)
 
         let scanner = Scanner(string: binaryString)
-        let plistString: String
 
-        if #available(iOS 13.0, *) {
-            guard scanner.scanUpToString("<plist") != nil,
-                  let targetString = scanner.scanUpToString("</plist>")
-            else {
-                throw ProvisioningProfileError.plistScanFailed
-            }
-            plistString = targetString
-        } else {
-            // swiftlint:disable:next legacy_objc_type
-            var targetString: NSString?
-
-            guard scanner.scanUpTo("<plist", into: nil),
-                  scanner.scanUpTo("</plist>", into: &targetString),
-                  let targetString = targetString
-            else {
-                throw ProvisioningProfileError.plistScanFailed
-            }
-            plistString = targetString as String
+        guard scanner.scanUpToString("<plist") != nil, let plistString = scanner.scanUpToString("</plist>") else {
+            throw ProvisioningProfileError.plistScanFailed
         }
 
         guard let plistData = (plistString + "</plist>").data(using: .isoLatin1) else {

--- a/Sources/AppcuesKit/Push/PushMonitor.swift
+++ b/Sources/AppcuesKit/Push/PushMonitor.swift
@@ -129,10 +129,9 @@ internal class PushMonitor: PushMonitoring {
 
         guard !parsedNotification.isInternal else {
             // This is a synthetic notification response from PushVerifier.
-            if #available(iOS 13.0, *) {
-                let pushVerifier = appcues.container.resolve(PushVerifier.self)
-                pushVerifier.receivedVerification(token: parsedNotification.notificationID)
-            }
+            let pushVerifier = appcues.container.resolve(PushVerifier.self)
+            pushVerifier.receivedVerification(token: parsedNotification.notificationID)
+
             completionHandler()
             return true
         }
@@ -199,26 +198,22 @@ internal class PushMonitor: PushMonitoring {
             ))
         }
 
-        if #available(iOS 13.0, *) {
-            var actions: [AppcuesExperienceAction] = []
+        var actions: [AppcuesExperienceAction] = []
 
-            if let deepLinkURL = parsedNotification.deepLinkURL {
-                actions.append(AppcuesLinkAction(appcues: appcues, url: deepLinkURL))
-            }
-
-            if let experienceID = parsedNotification.experienceID {
-                actions.append(AppcuesLaunchExperienceAction(
-                    appcues: appcues,
-                    experienceID: experienceID,
-                    trigger: .pushNotification(notificationID: parsedNotification.notificationID)
-                ))
-            }
-
-            let actionRegistry = appcues.container.resolve(ActionRegistry.self)
-            actionRegistry.enqueue(actionInstances: actions, completion: completionHandler)
-        } else {
-            completionHandler()
+        if let deepLinkURL = parsedNotification.deepLinkURL {
+            actions.append(AppcuesLinkAction(appcues: appcues, url: deepLinkURL))
         }
+
+        if let experienceID = parsedNotification.experienceID {
+            actions.append(AppcuesLaunchExperienceAction(
+                appcues: appcues,
+                experienceID: experienceID,
+                trigger: .pushNotification(notificationID: parsedNotification.notificationID)
+            ))
+        }
+
+        let actionRegistry = appcues.container.resolve(ActionRegistry.self)
+        actionRegistry.enqueue(actionInstances: actions, completion: completionHandler)
     }
 
     private func getPushEnvironment() {

--- a/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Actions/ActionRegistryTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ActionRegistryTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -192,7 +191,6 @@ class ActionRegistryTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 private extension ActionRegistryTests {
     class TestAction: AppcuesExperienceAction, ExperienceActionQueueTransforming {
         struct Config: Decodable {

--- a/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesCloseActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesCloseActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -80,7 +79,6 @@ class AppcuesCloseActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesCloseAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesContinueActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesContinueActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -93,7 +92,6 @@ class AppcuesContinueActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesContinueAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesDelayActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesDelayActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesDelayActionTests: XCTestCase {
 
     func testInit() throws {
@@ -37,7 +36,6 @@ class AppcuesDelayActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesDelayAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLaunchExperienceActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesLaunchExperienceActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -84,7 +83,6 @@ class AppcuesLaunchExperienceActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesLaunchExperienceAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesLinkActionTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import SafariServices
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesLinkActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -285,7 +284,6 @@ private class MockNavigationDelegate: AppcuesNavigationDelegate {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesLinkActionTests {
     class MockURLOpener: TopControllerGetting, URLOpening {
         var hasActiveWindowScenes: Bool = true
@@ -322,7 +320,6 @@ extension AppcuesLinkActionTests {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesLinkAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesRequestPushActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesRequestPushActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesRequestPushActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -58,7 +57,6 @@ class AppcuesRequestPushActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesRequestPushAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesRequestReviewActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesRequestReviewActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesRequestReviewActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -52,7 +51,6 @@ class AppcuesRequestReviewActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesRequestReviewAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesStepInteractionActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesStepInteractionActionTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesSubmitFormActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesSubmitFormActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -286,7 +285,6 @@ class AppcuesSubmitFormActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesSubmitFormAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesTrackActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesTrackActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -97,7 +96,6 @@ class AppcuesTrackActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesTrackAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
+++ b/Tests/AppcuesKitTests/Actions/AppcuesUpdateProfileActionTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesUpdateProfileActionTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -102,7 +101,6 @@ class AppcuesUpdateProfileActionTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesUpdateProfileAction {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsBroadcasterTests.swift
@@ -89,7 +89,6 @@ class AnalyticsBroadcasterTests: XCTestCase {
         XCTAssertEqual(delegate.lastIsInternal, false)
     }
 
-    @available(iOS 13.0, *) // ExperienceData.StepState is 13+
     func testBroadcastSanitizesStepState() throws {
         // Arrange
         let expectedFormItem = ExperienceData.FormItem(model: ExperienceComponent.TextInputModel(

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -343,7 +343,6 @@ class AnalyticsTrackerTests: XCTestCase {
         wait(for: [minTimeExpectation, onRequestExpectation], timeout: appcues.config.flushAfterDuration + 1, enforceOrder: true)
     }
 
-    @available(iOS 13.0, *)
     func testProcessEmptyResponse() throws {
         let onRenderExpectation = expectation(description: "Experience renderer successfully called")
         let successResponse = QualifyResponse(
@@ -371,7 +370,6 @@ class AnalyticsTrackerTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    @available(iOS 13.0, *)
     func testProcessExperienceResponse() throws {
         let onRenderExpectation = expectation(description: "Experience renderer successfully called")
         let successResponse = QualifyResponse(
@@ -410,22 +408,19 @@ extension Dictionary where Key == String, Value == Any {
         }
         XCTAssertEqual(Set(self.keys), Set(other.keys), file: file, line: line)
         self.keys.forEach { key in
-            // special case since ExperienceData is 13+
-            if #available(iOS 13.0, *), let val1 = self[key] as? ExperienceData.StepState, let val2 = other[key] as? ExperienceData.StepState {
+            switch(self[key], other[key]) {
+            case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
                 XCTAssertEqual(val1, val2, file: file, line: line)
-            } else {
-                switch(self[key], other[key]) {
-                case let (val1 as String, val2 as String):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as NSNumber, val2 as NSNumber):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as [Any], val2 as [Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                case let (val1 as [String: Any], val2 as [String: Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                default:
-                    XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").", file: file, line: line)
-                }
+            case let (val1 as String, val2 as String):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as NSNumber, val2 as NSNumber):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as [Any], val2 as [Any]):
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
+            case let (val1 as [String: Any], val2 as [String: Any]):
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
+            default:
+                XCTFail("\(self[key] ?? "nil") does not match \(other[key] ?? "nil").", file: file, line: line)
             }
         }
     }
@@ -441,21 +436,19 @@ extension Array where Element == Any {
         XCTAssertEqual(self.count, other.count, file: file, line: line)
 
         zip(self, other).forEach { (selfVal, otherVal) in
-            if #available(iOS 13.0, *), let val1 = selfVal as? ExperienceData.StepState, let val2 = otherVal as? ExperienceData.StepState {
+            switch(selfVal, otherVal) {
+            case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
                 XCTAssertEqual(val1, val2, file: file, line: line)
-            } else {
-                switch(selfVal, otherVal) {
-                case let (val1 as String, val2 as String):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as NSNumber, val2 as NSNumber):
-                    XCTAssertEqual(val1, val2, file: file, line: line)
-                case let (val1 as [Any], val2 as [Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                case let (val1 as [String: Any], val2 as [String: Any]):
-                    val1.verifyPropertiesMatch(val2, file: file, line: line)
-                default:
-                    XCTFail("\(selfVal) does not match \(otherVal).", file: file, line: line)
-                }
+            case let (val1 as String, val2 as String):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as NSNumber, val2 as NSNumber):
+                XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (val1 as [Any], val2 as [Any]):
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
+            case let (val1 as [String: Any], val2 as [String: Any]):
+                val1.verifyPropertiesMatch(val2, file: file, line: line)
+            default:
+                XCTFail("\(selfVal) does not match \(otherVal).", file: file, line: line)
             }
         }
     }

--- a/Tests/AppcuesKitTests/AppcuesPresentationDelegateTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesPresentationDelegateTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 final class AppcuesPresentationDelegateTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/AppcuesTests.swift
+++ b/Tests/AppcuesKitTests/AppcuesTests.swift
@@ -326,7 +326,6 @@ class AppcuesTests: XCTestCase {
     }
 
     // Test that all the components are properly deinited when the Appcues instance is
-    @available(iOS 13.0, *)
     func testDeinit() throws {
         // Arrange
         var appcues: Appcues? = Appcues(config: Appcues.Config(accountID: "abc", applicationID: "123"))

--- a/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/APIVerifierTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import Combine
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class APIVerifierTests: XCTestCase {
 
     var apiVerifier: APIVerifier!

--- a/Tests/AppcuesKitTests/Debugger/DebugViewModelTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/DebugViewModelTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import Combine
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class DebugViewModelTests: XCTestCase {
 
     var debugViewModel: DebugViewModel!

--- a/Tests/AppcuesKitTests/Debugger/DeepLinkVerifierTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/DeepLinkVerifierTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import Combine
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class DeepLinkVerifierTests: XCTestCase {
 
     var deepLinkVerifier: MockDeepLinkVerifier!
@@ -170,7 +169,6 @@ class DeepLinkVerifierTests: XCTestCase {
 }
 
 /// Mock DeepLinkVerifier that allows overriding loading the CFBundleURLSchemes values from the Info.plist
-@available(iOS 13.0, *)
 class MockDeepLinkVerifier: DeepLinkVerifier {
     var mockURLTypes: [[String : Any]]?
 

--- a/Tests/AppcuesKitTests/Debugger/LoggedEventTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/LoggedEventTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class LoggedEventTests: XCTestCase {
 
     func testPropertyGrouping() throws {

--- a/Tests/AppcuesKitTests/Debugger/ScreenCapturerTests.swift
+++ b/Tests/AppcuesKitTests/Debugger/ScreenCapturerTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ScreenCapturerTests: XCTestCase {
 
     private var screenCapturer: ScreenCapturer!

--- a/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
+++ b/Tests/AppcuesKitTests/DeepLinkHandlerTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class DeepLinkHandlerTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -254,7 +253,6 @@ class DeepLinkHandlerTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension DeepLinkHandlerTests {
     class MockTopControllerGetting: TopControllerGetting {
         var hasActiveWindowScenes: Bool = true

--- a/Tests/AppcuesKitTests/Experiences/ContentLoaderTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ContentLoaderTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ContentLoaderTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Experiences/EmbedExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/EmbedExperienceRendererTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class EmbedExperienceRendererTests: XCTestCase {
 
     let screenTrigger = ExperienceTrigger.qualification(reason: .screenView)
@@ -240,7 +239,6 @@ extension Experience {
     }
 }
 
-@available(iOS 13.0, *)
 extension ExperienceData {
     static func mockEmbed(frameID: String, trigger: ExperienceTrigger) -> ExperienceData {
         ExperienceData(

--- a/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ExperienceDataTests: XCTestCase {
 
     func testSingleSelectRequired() throws {

--- a/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceRendererTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ExperienceRendererTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -524,9 +523,7 @@ class ExperienceRendererTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 private extension ExperienceData {
-    @available(iOS 13.0, *)
     func packageWithDelay(presentExpectation: XCTestExpectation? = nil, dismissExpectation: XCTestExpectation? = nil) -> ExperiencePackage {
         let pageMonitor = AppcuesExperiencePageMonitor(numberOfPages: 1, currentPage: 0)
         let containerController = Mocks.ContainerViewController(stepControllers: [UIViewController()], pageMonitor: pageMonitor)

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
 
     var appcues: MockAppcues!

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ExperienceStateMachineTests: XCTestCase {
 
     typealias State = ExperienceStateMachine.State
@@ -851,7 +850,6 @@ private class ListingObserver: ExperienceStateObserver {
     }
 }
 
-@available(iOS 13.0, *)
 private extension ExperienceStateMachineTests {
     class TestAction: AppcuesExperienceAction {
         struct Config: Decodable {

--- a/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/StepRefTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class StepRefTests: XCTestCase {
     typealias SI = Experience.StepIndex
 

--- a/Tests/AppcuesKitTests/Experiences/TooltipWrapperViewFrameTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/TooltipWrapperViewFrameTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class TooltipWrapperViewFrameTests: XCTestCase {
 
     private static let iPhone14ProPortraitFrame = CGRect(x: 0, y: 0, width: 393, height: 852)

--- a/Tests/AppcuesKitTests/MockAppcues.swift
+++ b/Tests/AppcuesKitTests/MockAppcues.swift
@@ -31,15 +31,13 @@ class MockAppcues: Appcues {
         container.register(AnalyticsTracking.self, value: analyticsTracker)
         container.register(PushMonitoring.self, value: pushMonitor)
 
-        if #available(iOS 13.0, *) {
-            container.register(DeepLinkHandling.self, value: deepLinkHandler)
-            container.register(UIDebugging.self, value: debugger)
-            container.register(ContentLoading.self, value: contentLoader)
-            container.register(ExperienceRendering.self, value: MockExperienceRenderer())
-            container.registerLazy(TraitRegistry.self, initializer: TraitRegistry.init)
-            container.registerLazy(ActionRegistry.self, initializer: ActionRegistry.init)
-            container.register(TraitComposing.self, value: MockTraitComposer())
-        }
+        container.register(DeepLinkHandling.self, value: deepLinkHandler)
+        container.register(UIDebugging.self, value: debugger)
+        container.register(ContentLoading.self, value: contentLoader)
+        container.register(ExperienceRendering.self, value: experienceRenderer)
+        container.register(TraitComposing.self, value: traitComposer)
+        container.registerLazy(TraitRegistry.self, initializer: TraitRegistry.init)
+        container.registerLazy(ActionRegistry.self, initializer: ActionRegistry.init)
 
         // dependencies that are not mocked
         container.registerLazy(NotificationCenter.self, initializer: NotificationCenter.init)
@@ -65,20 +63,8 @@ class MockAppcues: Appcues {
     var networking = MockNetworking()
     var analyticsTracker = MockAnalyticsTracker()
     var pushMonitor = MockPushMonitor()
-
-    // must wrap in @available since MockExperienceRenderer has a stored property with
-    // type ExperienceData in it, which is 13+
-    @available(iOS 13.0, *)
-    var experienceRenderer: MockExperienceRenderer {
-        return container.resolve(ExperienceRendering.self) as! MockExperienceRenderer
-    }
-
-    // must wrap in @available since MockTraitComposer has a stored property with
-    // type ExperienceData in it, which is 13+
-    @available(iOS 13.0, *)
-    var traitComposer: MockTraitComposer {
-        return container.resolve(TraitComposing.self) as! MockTraitComposer
-    }
+    var experienceRenderer =  MockExperienceRenderer()
+    var traitComposer = MockTraitComposer()
 }
 
 class MockAnalyticsPublisher: AnalyticsPublishing {
@@ -148,7 +134,6 @@ class MockContentLoader: ContentLoading {
     }
 }
 
-@available(iOS 13.0, *) // due to reference to ExperienceData
 class MockExperienceRenderer: ExperienceRendering {
     var onStart: ((StateMachineOwning, RenderContext) -> Void)?
     func start(owner: StateMachineOwning, forContext context: RenderContext) {
@@ -252,7 +237,6 @@ class MockDeepLinkHandler: DeepLinkHandling {
     }
 }
 
-@available(iOS 13.0, *) // due to reference to ExperienceData
 class MockTraitComposer: TraitComposing {
 
     var onPackage: ((ExperienceData, Experience.StepIndex) throws -> ExperiencePackage)?

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -30,7 +30,6 @@ enum Mocks {
         }
     }
 
-    @available(iOS 13.0, *)
     class ContainerViewController: DefaultContainerViewController {
         // ExperienceStateMachine checks these values to avoid unnecessary lifecycle events,
         // and so we need to mock them to trigger the correct events
@@ -197,7 +196,6 @@ extension Experience.Step.Child {
 
 }
 
-@available(iOS 13.0, *)
 extension ExperienceData {
     static var mock: ExperienceData { ExperienceData(.mock, trigger: .showCall) }
     static var singleStepMock: ExperienceData { ExperienceData(.singleStepMock, trigger: .showCall) }

--- a/Tests/AppcuesKitTests/Networking/DynamicCodingKeysTests.swift
+++ b/Tests/AppcuesKitTests/Networking/DynamicCodingKeysTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class DynamicCodingKeysTests: XCTestCase {
 
     var encoder: JSONEncoder = {
@@ -49,7 +48,6 @@ class DynamicCodingKeysTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension DynamicCodingKeysTests {
     struct TestData: Encodable {
         let logger = DebugLogger(previousLogger: nil)

--- a/Tests/AppcuesKitTests/Networking/TraitConfigurationDecodeTests.swift
+++ b/Tests/AppcuesKitTests/Networking/TraitConfigurationDecodeTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class TraitConfigurationDecodeTests: XCTestCase {
 
     func testDecode() throws {

--- a/Tests/AppcuesKitTests/PublicAPITests.swift
+++ b/Tests/AppcuesKitTests/PublicAPITests.swift
@@ -14,9 +14,7 @@ import AppcuesKit
 class PublicAPITests: XCTestCase {
 
     func testAPI() throws {
-        if #available(iOS 13.0, *) {
-            Appcues.elementTargeting = SampleElementTargeting()
-        }
+        Appcues.elementTargeting = SampleElementTargeting()
 
         _ = AppcuesElementSelector().evaluateMatch(for: AppcuesElementSelector())
 
@@ -79,18 +77,13 @@ class PublicAPITests: XCTestCase {
         appcuesInstance.trackScreens()
 
         _ = appcuesInstance.didHandleURL(URL(string: "https://api.appcues.net")!)
-
-        if #available(iOS 13.0, *) {
-            _ = appcuesInstance.filterAndHandle(Set())
-        }
+        _ = appcuesInstance.filterAndHandle(Set())
 
         let frameView = AppcuesFrameView(frame: .zero)
         appcuesInstance.register(frameID: "frame1", for: frameView, on: UIViewController())
         frameView.presentationDelegate = presentationDelegate
 
-        if #available(iOS 13.0, *) {
-            let frame = AppcuesFrame(appcues: appcuesInstance, frameID: "frame1")
-        }
+        let frame = AppcuesFrame(appcues: appcuesInstance, frameID: "frame1")
     }
 }
 

--- a/Tests/AppcuesKitTests/Traits/AppcuesModalTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesModalTraitTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesModalTraitTests: XCTestCase {
 
     func testBackdrop() throws {
@@ -113,7 +112,6 @@ class AppcuesModalTraitTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesModalTrait {
     convenience init?(presentationStyle: PresentationStyle) {
         self.init(
@@ -124,7 +122,6 @@ extension AppcuesModalTrait {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesModalTrait.Config {
     init(
         transition: String,

--- a/Tests/AppcuesKitTests/Traits/AppcuesStepTransitionAnimationTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesStepTransitionAnimationTraitTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesStepTransitionAnimationTraitTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -121,7 +120,6 @@ class AppcuesStepTransitionAnimationTraitTests: XCTestCase {
 
 }
 
-@available(iOS 13.0, *)
 extension AppcuesStepTransitionAnimationTrait {
     convenience init?(appcues: Appcues?) {
         self.init(configuration: AppcuesExperiencePluginConfiguration(nil, appcues: appcues))

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetElementTraitTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesTargetElementTraitTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -334,7 +333,6 @@ extension UIView {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesTargetElementTrait {
     convenience init?(
         appcues: Appcues?,

--- a/Tests/AppcuesKitTests/Traits/AppcuesTargetRectangleTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTargetRectangleTraitTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesTargetRectangleTraitTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -118,7 +117,6 @@ class AppcuesTargetRectangleTraitTests: XCTestCase {
 
 }
 
-@available(iOS 13.0, *)
 extension AppcuesTargetRectangleTrait {
     convenience init?(
         appcues: Appcues?,

--- a/Tests/AppcuesKitTests/Traits/AppcuesTooltipTraitTests.swift
+++ b/Tests/AppcuesKitTests/Traits/AppcuesTooltipTraitTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class AppcuesTooltipTraitTests: XCTestCase {
 
     func testBackdrop() throws {
@@ -29,7 +28,6 @@ class AppcuesTooltipTraitTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 extension AppcuesTooltipTrait {
     convenience init?() {
         self.init(

--- a/Tests/AppcuesKitTests/Traits/ExperienceWrapperSlideAnimatorTests.swift
+++ b/Tests/AppcuesKitTests/Traits/ExperienceWrapperSlideAnimatorTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class ExperienceWrapperSlideAnimatorTests: XCTestCase {
 
     private static let iPhone14ProPortraitFrame = CGRect(x: 0, y: 0, width: 393, height: 852)

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class TraitComposerTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -473,7 +472,6 @@ private extension Experience.Step.Child {
     }
 }
 
-@available(iOS 13.0, *)
 extension TraitComposerTests {
     class Test2Trait: TestTrait {
         override class var type: String { "@test/trait-2" }

--- a/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitRegistryTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 @testable import AppcuesKit
 
-@available(iOS 13.0, *)
 class TraitRegistryTests: XCTestCase {
 
     var appcues: MockAppcues!
@@ -68,7 +67,6 @@ class TraitRegistryTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, *)
 private extension TraitRegistryTests {
     class TestTrait: AppcuesExperienceTrait {
         static let type = "@test/trait"

--- a/project.yml
+++ b/project.yml
@@ -4,7 +4,7 @@ attributes:
 options:
   defaultConfig: Release
   deploymentTarget:
-    iOS: 11.0
+    iOS: 13.0
   groupSortPosition: top
 configs:
   Debug: debug


### PR DESCRIPTION
I created an `sdk5` branch to hold the new major version changes.

First off is updating the deployment target from iOS 11 to iOS 13. Doing this separately to help reduce the diff of the async/await changes. It's mostly removing `@available(iOS 13.0, *)` checks and then updating a handful of `if #available(iOS 13.0, *)` conditions.