### PR TITLE
Concurrency warning fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ orbs:
 executors:
   xcode_15:
     macos:
-      xcode: 15.1.0
+      xcode: 16.1.0
     resource_class: macos.m1.medium.gen1
     working_directory: /Users/distiller/project
     shell: /bin/bash --login -o pipefail

--- a/Sources/AppcuesKit/Appcues.swift
+++ b/Sources/AppcuesKit/Appcues.swift
@@ -20,7 +20,7 @@ public class Appcues: NSObject {
     /// experiences, such as anchored tooltips. By default, the SDK uses a strategy for native iOS UIKit applications.
     public static var elementTargeting: AppcuesElementTargeting = UIKitElementTargeting()
 
-    internal static var customComponentRegistry = CustomComponentRegistry()
+    internal static let customComponentRegistry = CustomComponentRegistry()
 
     let container = DIContainer()
     let config: Appcues.Config

--- a/Sources/AppcuesKit/Data/Analytics/UIKitScreenTracker.swift
+++ b/Sources/AppcuesKit/Data/Analytics/UIKitScreenTracker.swift
@@ -13,7 +13,7 @@ internal class UIKitScreenTracker {
 
     // used to ignore SDK presented screens (experiences we create) for the purpose
     // of automatic screen tracking
-    internal static var untrackedScreenKey: UInt8 = 0
+    nonisolated(unsafe) internal static var untrackedScreenKey: UInt8 = 0
 
     private var lastTrackedScreen: String?
 

--- a/Sources/AppcuesKit/Data/Extensions/NotificationCenter+Custom.swift
+++ b/Sources/AppcuesKit/Data/Extensions/NotificationCenter+Custom.swift
@@ -10,9 +10,9 @@ import Foundation
 
 extension NotificationCenter {
     // Note: this NotificationCenter instance should only be used for SDK-global
-    // notifications - for example, the UIKitScreenTracking implementatation.
+    // notifications - for example, the UIKitScreenTracking implementation.
     // Whenever possible, the preferred usage of notifications is via the DIContainer
     // instance of NotificationCenter, to keep messages scoped to the Appcues instance
     // container.
-    static var appcues = NotificationCenter()
+    static let appcues = NotificationCenter()
 }

--- a/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
+++ b/Sources/AppcuesKit/Data/Extensions/UUID+Custom.swift
@@ -8,15 +8,8 @@
 
 import Foundation
 
-// Allows overriding of UUID creation for deterministic testing.
 extension UUID {
-    static var generator: () -> UUID = UUID.init
-
     var appcuesFormatted: String {
         return uuidString.lowercased()
-    }
-
-    static func create() -> UUID {
-        return UUID.generator()
     }
 }

--- a/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/StepReference.swift
@@ -41,7 +41,7 @@ internal enum StepReference: Equatable {
 
 extension Experience {
     struct StepIndex: Equatable, Comparable, CustomStringConvertible {
-        static var initial = StepIndex(group: 0, item: 0)
+        static let initial = StepIndex(group: 0, item: 0)
 
         var group: Int
         var item: Int

--- a/Sources/AppcuesKit/Data/Models/SdkMetrics.swift
+++ b/Sources/AppcuesKit/Data/Models/SdkMetrics.swift
@@ -12,7 +12,8 @@ internal struct SdkMetrics {
 
     private static let syncQueue = DispatchQueue(label: "appcues-sdk-metrics")
 
-    private static var metrics: [UUID: SdkMetrics] = [:]
+    // Protected by syncQueue
+    nonisolated(unsafe) private static var metrics: [UUID: SdkMetrics] = [:]
 
     // the time when the tracking was first captured by the SDK - the call to `track(event)` for instance
     private var trackedAt: Date?

--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FleetingLogView.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/FleetingLogView.swift
@@ -99,7 +99,8 @@ internal class FleetingLogView: UIView {
             view.transform = .identity
         }
 
-        Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { [weak self] _ in
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(1_000_000_000 * 3))
             self?.removeMessage(view: view)
         }
     }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
@@ -74,7 +74,7 @@ extension Events.Experience {
         let message: String?
         let id: UUID
 
-        init(message: String?, id: UUID = UUID.create()) {
+        init(message: String?, id: UUID = UUID()) {
             self.message = message
             self.id = id
         }
@@ -82,7 +82,7 @@ extension Events.Experience {
         // Conveniently init with `"message"` or `"\(messageVar)"` instead of `Events.Experience.ErrorBody(message: messageVar)`.
         init(stringLiteral value: String) {
             message = value
-            id = UUID.create()
+            id = UUID()
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceStateObserver.swift
@@ -131,7 +131,7 @@ extension ExperienceStateMachine {
             // and the observer is only attached on published flows
             guard experience.recoverableErrorID == nil else { return }
 
-            let errorID = UUID.create()
+            let errorID = UUID()
             if recoverable {
                 experience.recoverableErrorID = errorID
             }
@@ -159,7 +159,7 @@ extension ExperienceStateMachine {
         func trackRecoverableError(experience: ExperienceData, message: String) {
             guard experience.published, experience.recoverableErrorID == nil else { return }
 
-            let errorID = UUID.create()
+            let errorID = UUID()
             experience.recoverableErrorID = errorID
             let errorProperties = Dictionary(
                 propertiesFrom: experience,

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesBackdropTrait.swift
@@ -13,7 +13,7 @@ internal class AppcuesBackdropTrait: AppcuesBackdropDecoratingTrait {
         let backgroundColor: ExperienceComponent.Style.DynamicColor
     }
 
-    static var type: String = "@appcues/backdrop"
+    static let type: String = "@appcues/backdrop"
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEffectsTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesEffectsTrait.swift
@@ -10,7 +10,7 @@ import UIKit
 import QuartzCore
 
 internal class AppcuesEffectsTrait: AppcuesBackdropDecoratingTrait {
-    static var type: String = "@appcues/effects"
+    static let type: String = "@appcues/effects"
 
     var metadataDelegate: AppcuesTraitMetadataDelegate?
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesSkippableTrait.swift
@@ -16,7 +16,7 @@ internal class AppcuesSkippableTrait: AppcuesContainerDecoratingTrait, AppcuesBa
         let buttonStyle: ExperienceComponent.Style?
     }
 
-    static var type: String = "@appcues/skippable"
+    static let type: String = "@appcues/skippable"
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesStepTransitionAnimationTrait.swift
@@ -14,7 +14,7 @@ internal class AppcuesStepTransitionAnimationTrait: AppcuesContainerDecoratingTr
         let easing: Easing?
     }
 
-    static var type: String = "@appcues/step-transition-animation"
+    static let type: String = "@appcues/step-transition-animation"
 
     weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 

--- a/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/TraitComposer.swift
@@ -218,7 +218,7 @@ extension TraitComposer {
     }
 
     class DefaultContainerCreatingTrait: AppcuesContainerCreatingTrait {
-        static var type: String = "_defaultContainerCreatingTrait"
+        static let type: String = "_defaultContainerCreatingTrait"
 
         weak var metadataDelegate: AppcuesTraitMetadataDelegate?
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/EnvironmentValues+ImageCache.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/EnvironmentValues+ImageCache.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 internal struct ImageCacheKey: EnvironmentKey {
     // This is mutable so a custom cache can be injected for testing.
-    static var defaultValue = SessionImageCache()
+    nonisolated(unsafe) static var defaultValue = SessionImageCache()
 }
 
 extension EnvironmentValues {

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceStepViewController.swift
@@ -174,10 +174,10 @@ internal class ExperienceStepViewController: UIViewController {
             switch edge {
             case .top:
                 self?.stickySpacing.top = size.height
-                self?.stepView.scrollView.scrollIndicatorInsets.top = size.height + (self?.padding.top ?? 0)
+                self?.stepView.scrollView.verticalScrollIndicatorInsets.top = size.height + (self?.padding.top ?? 0)
             case .bottom:
                 self?.stickySpacing.bottom = size.height
-                self?.stepView.scrollView.scrollIndicatorInsets.bottom = size.height + (self?.padding.bottom ?? 0)
+                self?.stepView.scrollView.verticalScrollIndicatorInsets.bottom = size.height + (self?.padding.bottom ?? 0)
             }
         }
     }

--- a/Sources/AppcuesKit/Push/UNUserNotificationCenter+AutoConfig.swift
+++ b/Sources/AppcuesKit/Push/UNUserNotificationCenter+AutoConfig.swift
@@ -11,7 +11,7 @@ import UserNotifications
 
 // This is a placeholder delegate implementation in case there's no UNUserNotificationCenter.delegate set in the app
 internal class AppcuesUNUserNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
-    static var shared = AppcuesUNUserNotificationCenterDelegate()
+    static let shared = AppcuesUNUserNotificationCenterDelegate()
 }
 
 extension UNUserNotificationCenter {

--- a/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/AnalyticsTrackerTests.swift
@@ -418,6 +418,9 @@ class AnalyticsTrackerTests: XCTestCase {
     }
 }
 
+/// Empty type to facilitate verifyPropertiesMatch checking with String
+struct SomeUUID {}
+
 // Helpers to test an Activity request body is as expected
 extension Dictionary where Key == String, Value == Any {
 
@@ -431,6 +434,9 @@ extension Dictionary where Key == String, Value == Any {
             switch(self[key], other[key]) {
             case let (val1 as ExperienceData.StepState, val2 as ExperienceData.StepState):
                 XCTAssertEqual(val1, val2, file: file, line: line)
+            case let (_ as SomeUUID, val2 as String):
+                // Ensure val2 is a valid UUID (specific value doesn't matter because it's uniquely generated
+                XCTAssertNotNil(UUID(uuidString: val2), file: file, line: line)
             case let (val1 as String, val2 as String):
                 XCTAssertEqual(val1, val2, file: file, line: line)
             case let (val1 as NSNumber, val2 as NSNumber):

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -26,9 +26,6 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        // Reset fixed UUID
-        UUID.generator = UUID.init
-
         analyticsExpectation = nil
         updates = []
     }
@@ -311,7 +308,6 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         // Arrange
         analyticsExpectation = expectation(description: "analytics updated")
         let experience = ExperienceData.mock
-        UUID.generator = { UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181")! }
 
         // Act
         observer.stateChanged(to: .failure(.experience(experience, "error")))
@@ -331,9 +327,11 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "localeName": "English",
             "localeId": "en",
             "message": "error",
-            "errorId": "a6d6e248-faff-4789-a03c-bd7f520c1181"
+            "errorId": SomeUUID()
         ].verifyPropertiesMatch(lastUpdate.properties)
 
+        // Pull the error ID from the update being tested because it's uniquely generated
+        let errorID = try XCTUnwrap(UUID(uuidString: lastUpdate.properties?["errorId"] as? String ?? ""))
         XCTAssertEqual(
             try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
             StructuredLifecycleProperties(
@@ -341,7 +339,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 experienceID: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
                 experienceName: "Mock Experience: Group with 3 steps, Single step",
                 experienceInstanceID: experience.instanceID,
-                errorID: UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181"),
+                errorID: errorID,
                 message: "error"
             ),
             "can successfully remap the property dict"
@@ -352,7 +350,6 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         // Arrange
         analyticsExpectation = expectation(description: "analytics updated")
         let experience = ExperienceData.mock
-        UUID.generator = { UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181")! }
 
         // Act
         observer.stateChanged(to: .failure(.step(experience, .initial, "error")))
@@ -375,9 +372,11 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "stepId": "e03ae132-91b7-4cb0-9474-7d4a0e308a07",
             "stepIndex": "0,0",
             "message": "error",
-            "errorId": "a6d6e248-faff-4789-a03c-bd7f520c1181"
+            "errorId": SomeUUID()
         ].verifyPropertiesMatch(lastUpdate.properties)
 
+        // Pull the error ID from the update being tested because it's uniquely generated
+        let errorID = try XCTUnwrap(UUID(uuidString: lastUpdate.properties?["errorId"] as? String ?? ""))
         XCTAssertEqual(
             try XCTUnwrap(StructuredLifecycleProperties(update: lastUpdate)),
             StructuredLifecycleProperties(
@@ -387,7 +386,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
                 experienceInstanceID: experience.instanceID,
                 stepID: UUID(uuidString: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
                 stepIndex: Experience.StepIndex(group: 0, item: 0),
-                errorID: UUID(uuidString: "A6D6E248-FAFF-4789-A03C-BD7F520C1181"),
+                errorID: errorID,
                 message: "error"
             ),
             "can successfully remap the property dict"
@@ -398,7 +397,6 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         // Arrange
         analyticsExpectation = expectation(description: "analytics updated")
         analyticsExpectation.expectedFulfillmentCount = 2
-        UUID.generator = { UUID(uuidString: "2e044aa2-130f-4260-80c2-a36092a88aff")! }
 
         let experienceData = ExperienceData.mock
 
@@ -422,7 +420,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "trigger": "show_call",
             "localeName": "English",
             "localeId": "en",
-            "errorId": "2e044aa2-130f-4260-80c2-a36092a88aff",
+            "errorId": SomeUUID(),
             "message": "oh no"
         ].verifyPropertiesMatch(errorUpdate.properties)
 
@@ -436,14 +434,12 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "trigger": "show_call",
             "localeName": "English",
             "localeId": "en",
-            "errorId": "2e044aa2-130f-4260-80c2-a36092a88aff"
+            "errorId": SomeUUID()
         ].verifyPropertiesMatch(recoveryUpdate.properties)
     }
 
     func testUnpublishedExperienceErrorAndRecovery() async throws {
         // Arrange
-        UUID.generator = { UUID(uuidString: "2e044aa2-130f-4260-80c2-a36092a88aff")! }
-
         let experienceData = ExperienceData(.mock, trigger: .showCall, published: false)
 
         // Act
@@ -459,7 +455,6 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         analyticsExpectation = expectation(description: "analytics updated")
         analyticsExpectation.expectedFulfillmentCount = 4
 
-        UUID.generator = { UUID(uuidString: "aa47c304-7a42-40e4-8cbf-6d7d8f46c31c")! }
         let experience = ExperienceData.mock
         let package = await experience.package()
 
@@ -493,7 +488,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "stepId": "e03ae132-91b7-4cb0-9474-7d4a0e308a07",
             "stepIndex": "0,0",
             "message": "recoverable step error",
-            "errorId": "aa47c304-7a42-40e4-8cbf-6d7d8f46c31c"
+            "errorId": SomeUUID()
         ].verifyPropertiesMatch(stepError.properties)
         [
             "experienceName": "Mock Experience: Group with 3 steps, Single step",
@@ -507,7 +502,7 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
             "stepType": "modal",
             "stepId": "e03ae132-91b7-4cb0-9474-7d4a0e308a07",
             "stepIndex": "0,0",
-            "errorId": "aa47c304-7a42-40e4-8cbf-6d7d8f46c31c"
+            "errorId": SomeUUID()
         ].verifyPropertiesMatch(stepRecovered.properties)
     }
 


### PR DESCRIPTION
This is tackling some of the low hanging fruit of warnings on the road to Swift 6.

1. `scrollIndicatorInsets` was deprecated.
2. Using a `Timer` causes isolation warnings, so I replaced those with Tasks that sleep. Good article here: https://wadetregaskis.com/performing-a-delayed-and-or-repeating-operation-in-a-swift-actor/
3. Fixed the easy isolated global variable warnings by changing `static var` to static let` and adding `nonisolated(unsafe)` where it makes sense. There are still other instances of this warning that will be a bit more work to resolve.