### PR TITLE
Address potential crashes in AnalyticsPublisher

### DIFF
--- a/Sources/AppcuesKit/Data/Analytics/AnalyticsPublisher.swift
+++ b/Sources/AppcuesKit/Data/Analytics/AnalyticsPublisher.swift
@@ -101,10 +101,8 @@ internal class AnalyticsPublisher: AnalyticsPublishing {
     private func decorate(_ update: TrackingUpdate) -> TrackingUpdate {
         var update = update
 
-        // Apply decorations, removing any decorators that have been released from memory.
-        decorators.removeAll {
+        decorators.forEach {
             update = $0.value?.decorate(update) ?? update
-            return $0.value == nil
         }
 
         return update
@@ -112,10 +110,8 @@ internal class AnalyticsPublisher: AnalyticsPublishing {
 
     private func notifySubscribers(_ update: TrackingUpdate) {
 
-        // Call subscribers, removing any subscribers that have been released from memory.
-        subscribers.removeAll {
+        subscribers.forEach {
             $0.value?.track(update: update)
-            return $0.value == nil
         }
     }
 }


### PR DESCRIPTION
`AnalyticsPublisher` has some thread safety issues. Our sdk5 work should address the root of these, but for now, we need some patches. This PR does two things:

1. Updates PushMonitor to track new status on main thread. I believe the cause of new thread safety issues is the device updated event coming through at startup on an arbitrary thread.
2. Removing the `removeAll` in `AnalyticsPublisher` to avoid mutating the array in an unsafe way. This was here to clean up any `WeakAnalytic*` instances whose weak references has been de-inited. However, in practice this doesn't need to happen since there's a single decorator (`AutoPropertyDecorator`) and 3 subscribers (`AnalyticsTracker`, `AnalyticsBroadcaster` and `UIDebugger`). The weak references are still necessary for the SDK to be able to fully de-init.