### PR TITLE
Fix infinit loop in swizzler

### DIFF
--- a/Tests/AppcuesKitTests/SwizzlerTests.swift
+++ b/Tests/AppcuesKitTests/SwizzlerTests.swift
@@ -1,0 +1,44 @@
+//
+//  SwizzlerTests.swift
+//  AppcuesKitTests
+//
+//  Created by Matt on 2025-01-24.
+//  Copyright © 2025 Appcues. All rights reserved.
+//
+
+import XCTest
+@testable import AppcuesKit
+
+final class SwizzlerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @available(iOS 13.0, *)
+    func testDelegateSubclassSwizzlingInfiniteLoop() throws {
+        // Arrange
+        let scrollView = UIScrollView()
+        let delegate1 = ScrollViewDelegate1()
+        let delegate2 = ScrollViewDelegate2()
+
+        // Act
+        UIScrollView.swizzleScrollViewGetDelegate()
+        scrollView.delegate = delegate1
+        scrollView.delegate = delegate2
+
+        // Assert
+        let swizzledDelegateMethod = try XCTUnwrap(scrollView.delegate?.scrollViewWillBeginDragging)
+        // This shouldn't loop forever!
+        swizzledDelegateMethod(scrollView)
+    }
+}
+
+private extension SwizzlerTests {
+    class ScrollViewDelegate1: NSObject, UIScrollViewDelegate {}
+    class ScrollViewDelegate2: ScrollViewDelegate1 {}
+}


### PR DESCRIPTION
I discovered that one (but perhaps not the only?) way to cause the swizzling to infinite loop is with inheritance. The test case in this PR shows it, but what could happen is:

```
1. swizzle Delegate1 scrollViewDidEndDragging
    a. add placeholder impl
    b. add actual impl
    c. swap placeholder and actual
2. swizzle Delegate2 scrollViewDidEndDragging
    a. add actual impl
    b. swap with "original", which is actually itself (from 1.b) 
```

Checking that the actual implementations that we intend to swap are different is the key here.

In my investigation and testing, I also notice we were trying to swizzle the same class multiple times. The guard checks in the `Swizzler` prevent anything bad from happening, but it's still unnecessary, so I added a `Set` to track what's been swizzled to prevent repeat attempts that could potentially cause something to break.

And for the case where a scroll view has a `nil` delegate, we can just assign it `AppcuesScrollViewDelegate.shared` with the implementation we need instead of also swizzling the `AppcuesScrollViewDelegate.shared` since we own its implementation. This just saves us from more swizzling in this one case, making things a bit safer overall.

This should fix #582 