### PR TITLE
Screen capture flow improvements

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/Capture.swift
@@ -95,22 +95,17 @@ extension Capture: Encodable {
 
 extension UIImage {
     func annotate(with targetRects: [CGRect]) -> UIImage {
-        let imageSize = self.size
-        UIGraphicsBeginImageContextWithOptions(imageSize, false, 0)
-        defer {
-            UIGraphicsEndImageContext()
+        let renderer = UIGraphicsImageRenderer(size: self.size)
+        
+        return renderer.image { context in
+            self.draw(at: CGPoint.zero)
+
+            context.cgContext.setFillColor(UIColor(red: 227 / 255, green: 242 / 255, blue: 255 / 255, alpha: 0.5).cgColor)
+            context.cgContext.setStrokeColor(UIColor(red: 20 / 255, green: 146 / 255, blue: 255 / 255, alpha: 1).cgColor)
+
+            context.cgContext.addRects(targetRects)
+            context.cgContext.drawPath(using: .fillStroke)
         }
-        guard let context = UIGraphicsGetCurrentContext() else { return self }
-
-        self.draw(at: CGPoint.zero)
-
-        context.setFillColor(UIColor(red: 227 / 255, green: 242 / 255, blue: 255 / 255, alpha: 0.5).cgColor)
-        context.setStrokeColor(UIColor(red: 20 / 255, green: 146 / 255, blue: 255 / 255, alpha: 1).cgColor)
-
-        context.addRects(targetRects)
-        context.drawPath(using: .fillStroke)
-
-        return UIGraphicsGetImageFromCurrentImageContext() ?? self
     }
 }
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
@@ -131,7 +131,7 @@ internal class UIKitElementTargeting: AppcuesElementTargeting {
     var window: UIWindow?
 
     func captureLayout() -> AppcuesViewElement? {
-        let captureWindow = (window ?? UIApplication.shared.windows.first { !$0.isAppcuesWindow })
+        let captureWindow = window ?? UIApplication.shared.mainAppWindow
         return captureWindow?.asViewElement()
     }
 

--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIView+Capture.swift
@@ -38,13 +38,11 @@ internal extension UIView {
     }
 
     func screenshot() -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(frame.size, false, 1)
-        defer {
-            UIGraphicsEndImageContext()
+        guard frame.size != .zero else { return nil }
+
+        let renderer = UIGraphicsImageRenderer(size: frame.size)
+        return renderer.image { context in
+            drawHierarchy(in: self.bounds, afterScreenUpdates: false)
         }
-
-        drawHierarchy(in: self.bounds, afterScreenUpdates: false)
-
-        return UIGraphicsGetImageFromCurrentImageContext()
     }
 }

--- a/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/UIDebugger.swift
@@ -184,7 +184,7 @@ extension UIDebugger: DebugViewDelegate, ScreenCaptureUI {
             debugViewController?.apiVerifier.verifyAPI()
         case let .screenCapture(authorization):
             screenCapturer.captureScreen(
-                window: UIApplication.shared.windows.first(where: { !$0.isAppcuesWindow }),
+                window: UIApplication.shared.mainAppWindow,
                 authorization: authorization,
                 captureUI: self
             )

--- a/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
+++ b/Sources/AppcuesKit/Presentation/Traits/Appcues/AppcuesTargetInteractionTrait.swift
@@ -159,7 +159,7 @@ extension AppcuesTargetInteractionTrait {
             super.init(frame: .zero)
 
             if trait.enablePassThrough {
-                self.appWindow = UIApplication.shared.windows.first { !$0.isAppcuesWindow }
+                self.appWindow = UIApplication.shared.mainAppWindow
             } else {
                 self.addGestureRecognizer(tapRecognizer)
                 self.addGestureRecognizer(longPressRecognizer)


### PR DESCRIPTION
1. I've modernized the screen capture and annotation to use `UIGraphicsImageRenderer`. I've also added a check for a zero-sized capture, so now we show an error toast instead of crashing or having a confusing blank confirm screen.
2. To try and avoid getting the zero-sized capture failure, I've reworked and consolidated the scene/window logic to avoid a window with a zero-frame. I'm still not sure how it's possible, but if it is, we'll ignore a window like that in preference of another one.
    We had a couple different ways of finding the "main" window:
    1. The `topViewController()` implementation would try and find the `keyWindow`, with a fallback in case the `keyWindow` was an appcues window.
    2. Everything else (screen capture, element targeting) would look through all windows and take the first non-appcues window, which was probably too simplistic
    
   I've combined these approaches in the new `mainAppWindow` property that ignores all appcues windows and then takes the `keyWindow` or the best looking other window if the `keyWindow` is an appcues window.

This ends up being an all-around good refactor and simplification while also being more robust.