### PR TITLE
Exclude UITextView from step recovery UIScrollView swizzling

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/UIScrollView+ScrollObserver.swift
@@ -92,7 +92,7 @@ internal class AppcuesScrollViewDelegate: NSObject, UIScrollViewDelegate {
 
 @available(iOS 13.0, *)
 extension UIScrollView {
-    
+
     // this set includes `AppcuesScrollViewDelegate.shared` by default since it doesn't need to be swizzled
     private static var swizzledClasses: Set<String> = ["\(type(of: AppcuesScrollViewDelegate.shared))"]
 
@@ -114,6 +114,11 @@ extension UIScrollView {
     // this is our custom getter logic for the UIScrollView.delegate
     @objc
     private func appcues__getScrollViewDelegate() -> UIScrollViewDelegate? {
+        // exclude UITextView type from our custom getter
+        guard !(self is UITextView) else {
+            return appcues__getScrollViewDelegate()
+        }
+
         let delegate: UIScrollViewDelegate
 
         // this call looks recursive, but it is not, it is calling the swapped implementation

--- a/Tests/AppcuesKitTests/SwizzlerTests.swift
+++ b/Tests/AppcuesKitTests/SwizzlerTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import AppcuesKit
 
+@available(iOS 13.0, *)
 final class SwizzlerTests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -16,10 +17,10 @@ final class SwizzlerTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        // Reverse swizzle
+        UIScrollView.swizzleScrollViewGetDelegate()
     }
 
-    @available(iOS 13.0, *)
     func testDelegateSubclassSwizzlingInfiniteLoop() throws {
         // Arrange
         let scrollView = UIScrollView()
@@ -36,8 +37,22 @@ final class SwizzlerTests: XCTestCase {
         // This shouldn't loop forever!
         swizzledDelegateMethod(scrollView)
     }
+
+    func testIgnoredViewTypes() throws {
+        // Arrange
+        let scrollView = UIScrollView()
+        let textView = UITextView()
+
+        // Act
+        UIScrollView.swizzleScrollViewGetDelegate()
+
+        // Assert
+        XCTAssertTrue(scrollView.delegate is AppcuesScrollViewDelegate)
+        XCTAssertNil(textView.delegate)
+    }
 }
 
+@available(iOS 13.0, *)
 private extension SwizzlerTests {
     class ScrollViewDelegate1: NSObject, UIScrollViewDelegate {}
     class ScrollViewDelegate2: ScrollViewDelegate1 {}


### PR DESCRIPTION
We discovered that scroll view swizzling can interfere with React Native multiline `TextInput` components (that use `UITextView` under the hood). The delegate setter for `RCTUITextView` checks to ensure the current delegate is `nil` before setting the delegate value which is needed to handle the input events ([ref](https://github.com/facebook/react-native/blob/f53d066d26352e6abfdf2f727ea06425ea163039/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm#L69-L71)). The `StepRecoveryObserver` scroll view swizzling meant that the delegate value was an `AppcuesScrollViewDelegate` instead of `nil`.

There's no reason for us to care about scrolling in a `UITextView`, since there's not going to be a "below the fold" target element inside a text view, so we can return early the original delegate value.