### PR TITLE
Ensure new UIWindows match the userInterfaceStyle of the main app window

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/FloatingView/DebugUIWindow.swift
@@ -17,6 +17,10 @@ internal class DebugUIWindow: UIWindow {
         self.rootViewController = rootViewController
         windowLevel = .statusBar
         isHidden = false
+
+        if let appUIStyle = UIApplication.shared.mainAppWindow?.traitCollection.userInterfaceStyle {
+            overrideUserInterfaceStyle = appUIStyle
+        }
     }
 
     @available(*, unavailable)

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ModalContextManager.swift
@@ -59,6 +59,10 @@ extension ModalContextManager {
 
             rootViewController = AppcuesWindowRootViewController()
             isHidden = false
+
+            if let appUIStyle = UIApplication.shared.mainAppWindow?.traitCollection.userInterfaceStyle {
+                overrideUserInterfaceStyle = appUIStyle
+            }
         }
 
         @available(*, unavailable)


### PR DESCRIPTION
Handles both the modal context window (modals and tooltips) as well as the debugger window (which isn't crucial, but provides an easy way to check if the SDK is picking up the current style properly.

Note this only checks on the window's creation, so if you launch the debugger in dark mode and then toggle to light, the debugger will stay in dark until fully dismissed and re-launched. Same for a modal: if the setting changes between modals, we'll catch the update, but if it somehow changes while the modal is showing, it's not going to catch that (seems fine since  the modal will usually be covering any UI controls that would change the appearance).