### PR TITLE
Update clause decoding behavior

### DIFF
--- a/Tests/AppcuesKitTests/Experiences/ClauseTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ClauseTests.swift
@@ -647,12 +647,18 @@ class ClauseTests: XCTestCase {
         """
 
         let data = json.data(using: .utf8)!
+        let clause = try JSONDecoder().decode(Clause.self, from: data)
 
-        // This should throw a decoding error due to invalid UUID
-        XCTAssertThrowsError(try JSONDecoder().decode(Clause.self, from: data))
+        switch clause {
+        case .unknown:
+            // This is expected behavior - invalid survey clause (bad UUID) should decode to .unknown
+            break
+        default:
+            XCTFail("Expected unknown clause")
+        }
     }
 
-    func testDecodeInvalidOperator() throws {
+    func testDecodeInvalidSurveyOperator() throws {
         let json = """
         {
             "survey": {
@@ -664,12 +670,18 @@ class ClauseTests: XCTestCase {
         """
 
         let data = json.data(using: .utf8)!
+        let clause = try JSONDecoder().decode(Clause.self, from: data)
 
-        // This should throw a decoding error due to invalid operator
-        XCTAssertThrowsError(try JSONDecoder().decode(Clause.self, from: data))
+        switch clause {
+        case .unknown:
+            // This is expected behavior - invalid survey clause (bad operator) should decode to .unknown
+            break
+        default:
+            XCTFail("Expected unknown clause")
+        }
     }
 
-    func testDecodeUnknownOperator() throws {
+    func testDecodeInvalidTokenOperator() throws {
         let json = """
         {
             "token": {
@@ -681,9 +693,15 @@ class ClauseTests: XCTestCase {
         """
 
         let data = json.data(using: .utf8)!
+        let clause = try JSONDecoder().decode(Clause.self, from: data)
 
-        // This should throw a decoding error due to unknown operator
-        XCTAssertThrowsError(try JSONDecoder().decode(Clause.self, from: data))
+        switch clause {
+        case .unknown:
+            // This is expected behavior - invalid token clause (bad operator) should decode to .unknown
+            break
+        default:
+            XCTFail("Expected unknown clause")
+        }
     }
 
     // MARK: - Integration Tests


### PR DESCRIPTION
We've redefined the expected behavior of for incomplete/malformed clauses. Previously we'd fallback to `unknown` for unknown clause types, but now we also do if a known clause is malformed.

The reason for this is that it's possible to have an incomplete state in the mobile builder and we want to handle that as graciously as possible (imagine 4 valid checks and one incomplete one at the end: we can now properly handle the first 4 cases instead of failing entirely to decode the config).

We do still want to throw errors for very wrong data (ie we don't want any random JSON to decode to `unknown` since that's not helpful at all), so the key count still throws as does decoding clause groups since we'll have stricter control over how those are structured.