### PR TITLE
Add randomize option for select surveys

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience/ExperienceComponent.swift
@@ -277,6 +277,8 @@ extension ExperienceComponent {
         let attributeName: String?
         // swiftlint:disable:next discouraged_optional_boolean
         let leadingFill: Bool?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let randomizeOptionOrder: Bool?
 
         let style: Style?
 

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesOptionSelect.swift
@@ -53,7 +53,7 @@ internal struct AppcuesOptionSelect: View {
         switch (model.selectMode, model.displayFormat) {
         case (.single, .picker):
             Picker(model.label.text, selection: stepState.formBinding(for: model.id)) {
-                ForEach(model.options) { option in
+                ForEach(stepState.formOptions(for: model.id)) { option in
                     option.content.view
                         .tag(option.value)
                 }
@@ -76,7 +76,7 @@ internal struct AppcuesOptionSelect: View {
     @ViewBuilder private var items: some View {
         let primaryColor = stepState.shouldShowError(for: model.id) ? Color(dynamicColor: model.errorLabel?.style?.foregroundColor) : nil
 
-        ForEach(model.options) { option in
+        ForEach(stepState.formOptions(for: model.id)) { option in
             let binding = stepState.formBinding(for: model.id, value: option.value)
             SelectToggleView(
                 selected: binding,

--- a/Sources/AppcuesKit/Presentation/UI/Components/NPSView.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/NPSView.swift
@@ -23,7 +23,8 @@ internal struct NPSView: View {
             // A bit more flexibility here though to just split the given options
             // in half, taking the ceiling of an odd numbered set - which
             // gives 6 on the first row and 5 on the second row, in the normal display
-            let rows = model.options.chunked(into: (model.options.count + 1) / 2)
+            let options = stepState.formOptions(for: model.id)
+            let rows = options.chunked(into: (options.count + 1) / 2)
             ForEach(rows.indices, id: \.self) { rowIndex in
                 // Each row lays out items horizontally, with spacing defined within the model
                 HStack(spacing: 0) {

--- a/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceDataTests.swift
@@ -237,6 +237,7 @@ extension ExperienceComponent.OptionSelectModel {
             pickerStyle: nil,
             attributeName: nil,
             leadingFill: leadingFill,
+            randomizeOptionOrder: nil,
             style: nil
         )
     }


### PR DESCRIPTION
Randomize survey options if `randomizeOptionOrder == true`. We store the randomized order in the `FormState` because 1) we want the order to remain the same even if you navigate from one step group to another and back, and 2) we want to access the order to include in analytics.

Note that we do support randomization in the NPS display format. It's obviously never going to be used for number ratings, but I've added it for the sake of consistency within the data model.