### PR TITLE
Update SwiftLint version

### DIFF
--- a/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperCocoapodsExample/AppcuesCocoapodsExample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0384A2A89074FC193A107EE5 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663BEDD1883CC408AA4A302 /* SignInViewController.swift */; };
 		04F09F9C75FB66578541D199 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */; };
+		13F56EB1B502BF170F4854C3 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36EE0A948DE300FAF14B362E /* Pods_AppcuesCocoapodsExample.framework */; };
 		160BF92965F22C6957DEB27C /* Mulish-Italic-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */; };
 		31B667E890BBB65B74BD7B75 /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 98AA47DD8A38D313178BD4DA /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3EADA9762D050C3E2ED69514 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */; };
@@ -21,7 +22,6 @@
 		8F7329B0046118A1DFA8B58D /* EmbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */; };
 		9E6FF9F4B22B8874E5AA6544 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93D50517BBE18B336D130E13 /* LaunchScreen.storyboard */; };
 		A245C61F75A6DAA8985A6772 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C713E67205D9507CE2DC80 /* AppDelegate.swift */; };
-		A4BF980858732EB54FF38FB1 /* Pods_NotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB9983E50F5D358EC3C6178B /* Pods_NotificationServiceExtension.framework */; };
 		A5CE7AE8513C052690838416 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */; };
 		B246D604B3AA669DFA5E25FB /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34615287562F7C453579B60 /* NotificationService.swift */; };
 		B62E50722A74862AEBD2DE44 /* ScrollingTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F518475589397A213D89DA /* ScrollingTableViewController.swift */; };
@@ -30,7 +30,7 @@
 		DBE453F2B40A01B4818CB84E /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */; };
 		E92BC1A5B0C87A1E9A3E08EE /* AppDelegate+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD624398B79925BABBF277E4 /* AppDelegate+Push.swift */; };
 		EC6747EFCF3EDE3DE6E45EF3 /* EventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D26E6136C6539597C9E50A9 /* EventsViewController.swift */; };
-		ED805C9F2CBE992452FC169E /* Pods_AppcuesCocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F81774B6BC00A8730C88346 /* Pods_AppcuesCocoapodsExample.framework */; };
+		F8003C4D053A7AF14D53C705 /* Pods_NotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78740E9F391AEA73878B1E11 /* Pods_NotificationServiceExtension.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,32 +58,33 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		029790ECC9D98D238CDFD23B /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		10C713E67205D9507CE2DC80 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1330BC6CE40DF0AEA0B5D802 /* Mulish-Italic-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-Italic-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		25B8CDCE5B93FC3FE0FEB574 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		2E1BE92E4A34AD818AD21FDC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		2F81774B6BC00A8730C88346 /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		33558EA87F74CF18DDF92F09 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		36EE0A948DE300FAF14B362E /* Pods_AppcuesCocoapodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppcuesCocoapodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		384497BA35A275E793B475C1 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		3D589CCB0B728CB0A41B9783 /* LiveStreamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStreamViewController.swift; sourceTree = "<group>"; };
-		3E4CA6A0C4D6277939EAD8D1 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		4978E4D08E607FD148F38FB9 /* EmbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedViewController.swift; sourceTree = "<group>"; };
+		4E804ECB3C4FDEFA9426DC3B /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		547A647EB6D311E97F592C7C /* Lato-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Black.ttf"; sourceTree = "<group>"; };
 		5548F50894583A174A85628C /* DeepLinkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkNavigator.swift; sourceTree = "<group>"; };
+		5AF28BDB52063013D760B4C8 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
+		5D13704635747E5FDB013328 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.debug.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		5DC2B62290580560D162A8E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		65CCE5B36353D68AD83C0E01 /* Pods-AppcuesCocoapodsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppcuesCocoapodsExample.release.xcconfig"; path = "Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample.release.xcconfig"; sourceTree = "<group>"; };
+		78740E9F391AEA73878B1E11 /* Pods_NotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82DED1437C1DA54F0C231566 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8663BEDD1883CC408AA4A302 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		97E1B4A2DAE2893B3A919749 /* EmbedTestHarnessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedTestHarnessViewController.swift; sourceTree = "<group>"; };
 		98AA47DD8A38D313178BD4DA /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		9CB61619365785F4544ED13D /* GroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupViewController.swift; sourceTree = "<group>"; };
 		9D26E6136C6539597C9E50A9 /* EventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewController.swift; sourceTree = "<group>"; };
+		9E1E31D8BB217BC68AA77628 /* Pods-NotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		A05A73A257DA52CCE18DDC73 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Main.strings"; sourceTree = "<group>"; };
 		A3F518475589397A213D89DA /* ScrollingTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingTableViewController.swift; sourceTree = "<group>"; };
 		AA113FA372FB904082730474 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		AAD7ED9DCA5972361B3F5E67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		B1731CCE3498957F0C7DE396 /* Pods-NotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		C47ABB97FE784624C32E96D7 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
 		CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Mulish-VariableFont_wght.ttf"; sourceTree = "<group>"; };
 		CFDBB85EB221CD35EEEFA497 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
@@ -92,23 +93,22 @@
 		D3C0F23F9CDE7740C2E2DBF7 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
 		D6FA0A31EF53A9C9A764BE5C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
 		DD624398B79925BABBF277E4 /* AppDelegate+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Push.swift"; sourceTree = "<group>"; };
-		EB9983E50F5D358EC3C6178B /* Pods_NotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		4CFB118A34AE82D2E83A4A5B /* Frameworks */ = {
+		7CBDA917E97E9B13963B9FF8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED805C9F2CBE992452FC169E /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
+				13F56EB1B502BF170F4854C3 /* Pods_AppcuesCocoapodsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7D3A57ABD94AC5117DF2C852 /* Frameworks */ = {
+		8464DC8D2E13E5AE2B7A2C42 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A4BF980858732EB54FF38FB1 /* Pods_NotificationServiceExtension.framework in Frameworks */,
+				F8003C4D053A7AF14D53C705 /* Pods_NotificationServiceExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -124,6 +124,15 @@
 			path = NotificationServiceExtension;
 			sourceTree = "<group>";
 		};
+		271A886D5411AAA83EBE7CB1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				36EE0A948DE300FAF14B362E /* Pods_AppcuesCocoapodsExample.framework */,
+				78740E9F391AEA73878B1E11 /* Pods_NotificationServiceExtension.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		3271BCB89D21367EC1AA9069 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -134,15 +143,6 @@
 				CF3444B81C1A2ED10CA985F2 /* Mulish-VariableFont_wght.ttf */,
 			);
 			path = Fonts;
-			sourceTree = "<group>";
-		};
-		61898C30950B1C6762B5CA97 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				2F81774B6BC00A8730C88346 /* Pods_AppcuesCocoapodsExample.framework */,
-				EB9983E50F5D358EC3C6178B /* Pods_NotificationServiceExtension.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */ = {
@@ -169,13 +169,13 @@
 			path = CocoapodsExample;
 			sourceTree = "<group>";
 		};
-		9F6A3FC3337DE753DF7B19F7 /* Pods */ = {
+		A530CB18A4D0FDFFE79C20E3 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3E4CA6A0C4D6277939EAD8D1 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
-				65CCE5B36353D68AD83C0E01 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
-				B1731CCE3498957F0C7DE396 /* Pods-NotificationServiceExtension.debug.xcconfig */,
-				029790ECC9D98D238CDFD23B /* Pods-NotificationServiceExtension.release.xcconfig */,
+				5D13704635747E5FDB013328 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */,
+				5AF28BDB52063013D760B4C8 /* Pods-AppcuesCocoapodsExample.release.xcconfig */,
+				9E1E31D8BB217BC68AA77628 /* Pods-NotificationServiceExtension.debug.xcconfig */,
+				4E804ECB3C4FDEFA9426DC3B /* Pods-NotificationServiceExtension.release.xcconfig */,
 			);
 			name = Pods;
 			path = Pods;
@@ -196,8 +196,8 @@
 				8E16BA0B4697D91DBE3389A7 /* CocoapodsExample */,
 				1FE3F3C97CB4A18213B00765 /* NotificationServiceExtension */,
 				C743E51709EACC21B03B3A23 /* Products */,
-				9F6A3FC3337DE753DF7B19F7 /* Pods */,
-				61898C30950B1C6762B5CA97 /* Frameworks */,
+				A530CB18A4D0FDFFE79C20E3 /* Pods */,
+				271A886D5411AAA83EBE7CB1 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -208,9 +208,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA0D3F7775224770E811557C /* Build configuration list for PBXNativeTarget "NotificationServiceExtension" */;
 			buildPhases = (
-				4C0635F2A55F9F9A05F42167 /* [CP] Check Pods Manifest.lock */,
+				41CD13AF9C4688AD3413A2B1 /* [CP] Check Pods Manifest.lock */,
 				0C533839B37BFF02997B30E6 /* Sources */,
-				7D3A57ABD94AC5117DF2C852 /* Frameworks */,
+				8464DC8D2E13E5AE2B7A2C42 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -225,13 +225,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7200554C7EB6F6E4E0D35C70 /* Build configuration list for PBXNativeTarget "AppcuesCocoapodsExample" */;
 			buildPhases = (
-				E7C7E7A678818B22E251ED7D /* [CP] Check Pods Manifest.lock */,
+				A91A06C83F1D2E6C0762EBBB /* [CP] Check Pods Manifest.lock */,
 				39C4F25C30C2C38F00378FED /* Sources */,
 				4B41B1A9E3D52747D92B7344 /* Resources */,
 				7F6C967FB8B2DE55E93EC3B1 /* Embed Foundation Extensions */,
 				6D4DB9FBC4445D937FD94125 /* SwiftLint */,
-				4CFB118A34AE82D2E83A4A5B /* Frameworks */,
-				D4BE109CCA308AA67377BAA7 /* [CP] Embed Pods Frameworks */,
+				7CBDA917E97E9B13963B9FF8 /* Frameworks */,
+				5FD695E0AC9FC97EC65C77BF /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -299,7 +299,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4C0635F2A55F9F9A05F42167 /* [CP] Check Pods Manifest.lock */ = {
+		41CD13AF9C4688AD3413A2B1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -321,25 +321,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6D4DB9FBC4445D937FD94125 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.50.3\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
-		};
-		D4BE109CCA308AA67377BAA7 /* [CP] Embed Pods Frameworks */ = {
+		5FD695E0AC9FC97EC65C77BF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -356,7 +338,25 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppcuesCocoapodsExample/Pods-AppcuesCocoapodsExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E7C7E7A678818B22E251ED7D /* [CP] Check Pods Manifest.lock */ = {
+		6D4DB9FBC4445D937FD94125 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.62.2\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
+		};
+		A91A06C83F1D2E6C0762EBBB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -444,7 +444,7 @@
 /* Begin XCBuildConfiguration section */
 		015038143918E0C7F9D7E873 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3E4CA6A0C4D6277939EAD8D1 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
+			baseConfigurationReference = 5D13704635747E5FDB013328 /* Pods-AppcuesCocoapodsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -527,7 +527,7 @@
 		};
 		266E5C088CC8701B4117B193 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 65CCE5B36353D68AD83C0E01 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
+			baseConfigurationReference = 5AF28BDB52063013D760B4C8 /* Pods-AppcuesCocoapodsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -546,7 +546,7 @@
 		};
 		4F94E6007A88D980CC63B06F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B1731CCE3498957F0C7DE396 /* Pods-NotificationServiceExtension.debug.xcconfig */;
+			baseConfigurationReference = 9E1E31D8BB217BC68AA77628 /* Pods-NotificationServiceExtension.debug.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -562,7 +562,7 @@
 		};
 		B77C4DA932BE4B036BA18244 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 029790ECC9D98D238CDFD23B /* Pods-NotificationServiceExtension.release.xcconfig */;
+			baseConfigurationReference = 4E804ECB3C4FDEFA9426DC3B /* Pods-NotificationServiceExtension.release.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Examples/DeveloperCocoapodsExample/Podfile.lock
+++ b/Examples/DeveloperCocoapodsExample/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Appcues (5.0.0-beta.1)
-  - AppcuesNotificationService (5.0.0-beta.1)
+  - Appcues (5.0.0)
+  - AppcuesNotificationService (5.0.0)
 
 DEPENDENCIES:
   - Appcues (from `../../Appcues.podspec`)
@@ -13,8 +13,8 @@ EXTERNAL SOURCES:
     :path: "../../AppcuesNotificationService.podspec"
 
 SPEC CHECKSUMS:
-  Appcues: 9dce4c0e09ca08afb69e8c8499fa04be0e28cfd9
-  AppcuesNotificationService: 9421d1acdc5beddc37ecfc2e59c23507eb7cc950
+  Appcues: d04033bf9e6a6f9803a2f6e466f0a433010a1a87
+  AppcuesNotificationService: 84358bc93e1c12a67592cbcd73d0fa1599d51b57
 
 PODFILE CHECKSUM: 24c643e3c9c013c74f5d561608aa37768cb0c43e
 

--- a/Examples/DeveloperCocoapodsExample/project.yml
+++ b/Examples/DeveloperCocoapodsExample/project.yml
@@ -34,7 +34,7 @@ targets:
     - name: SwiftLint
       script: 'if which mint >/dev/null; then
 
-            xcrun --sdk macosx mint run swiftlint@0.50.3
+            xcrun --sdk macosx mint run swiftlint@0.62.2
 
         else
 

--- a/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
+++ b/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -162,8 +162,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 3307568C9084A060E694F2E4 /* Build configuration list for PBXProject "AppcuesSPMExample" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -176,9 +174,11 @@
 				"pt-BR",
 			);
 			mainGroup = 00D57936BE4D8040097BA252;
+			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				F95E3E563418244E3D063AA9 /* XCLocalSwiftPackageReference "../.." */,
 			);
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -222,7 +222,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.50.3\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
+			shellScript = "if which mint >/dev/null; then\nxcrun --sdk macosx mint run swiftlint@0.62.2\nelse\necho \"warning: Mint not installed, install from https://github.com/yonaskolb/Mint\"\nfi ";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/xcshareddata/xcschemes/AppcuesSPMExample.xcscheme
+++ b/Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/xcshareddata/xcschemes/AppcuesSPMExample.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ACC350A3330EAA63211500A0"
+               BuildableName = "AppcuesSPMExample.app"
+               BlueprintName = "AppcuesSPMExample"
+               ReferencedContainer = "container:AppcuesSPMExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ACC350A3330EAA63211500A0"
+            BuildableName = "AppcuesSPMExample.app"
+            BlueprintName = "AppcuesSPMExample"
+            ReferencedContainer = "container:AppcuesSPMExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ACC350A3330EAA63211500A0"
+            BuildableName = "AppcuesSPMExample.app"
+            BlueprintName = "AppcuesSPMExample"
+            ReferencedContainer = "container:AppcuesSPMExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ACC350A3330EAA63211500A0"
+            BuildableName = "AppcuesSPMExample.app"
+            BlueprintName = "AppcuesSPMExample"
+            ReferencedContainer = "container:AppcuesSPMExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DeveloperSPMExample/project.yml
+++ b/Examples/DeveloperSPMExample/project.yml
@@ -30,7 +30,7 @@ targets:
     - name: SwiftLint
       script: 'if which mint >/dev/null; then
 
-            xcrun --sdk macosx mint run swiftlint@0.50.3
+            xcrun --sdk macosx mint run swiftlint@0.62.2
 
         else
 

--- a/Mintfile
+++ b/Mintfile
@@ -1,3 +1,3 @@
 yonaskolb/xcodegen@2.44.1
-realm/swiftlint@0.50.3
+realm/swiftlint@0.62.2
 SwiftGen/SwiftGen@6.6.3


### PR DESCRIPTION
While testing Xcode 26.2, found that our older version of SwiftLint was no longer compatible. This upgrade to the latest 0.62.2 resolves it.

Other changes are just from regenerating the project files with xcodegen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade SwiftLint to 0.62.2 across examples, add a shared SPM scheme, and refresh Xcode project settings/references.
> 
> - **Tooling**:
>   - Bump SwiftLint to `0.62.2` in `Mintfile`, `project.yml` scripts, and Xcode SwiftLint build phases for both `DeveloperCocoapodsExample` and `DeveloperSPMExample`.
> - **SPM Example**:
>   - Add shared scheme `Examples/DeveloperSPMExample/AppcuesSPMExample.xcodeproj/xcshareddata/xcschemes/AppcuesSPMExample.xcscheme`.
> - **Xcode projects**:
>   - Update project settings/object versions and regenerate CocoaPods framework references in `*.xcodeproj/project.pbxproj` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b57da59b666b9f56e7dfc47ad244bedd2e03a66a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->