### PR TITLE
Add enums for standard event names

### DIFF
--- a/Sources/AppcuesKit/Data/Events.swift
+++ b/Sources/AppcuesKit/Data/Events.swift
@@ -22,6 +22,14 @@ internal enum Events {
         case pushOpened = "appcues:push_opened"
     }
 
+    enum Screen: String {
+        case screenView = "appcues:screen_view"
+    }
+
+    enum Experiment: String {
+        case experimentEntered = "appcues:experiment_entered"
+    }
+
     enum Experience: String {
         case stepSeen = "appcues:v2:step_seen"
         case stepInteraction = "appcues:v2:step_interaction"

--- a/Sources/AppcuesKit/Data/Models/Event.swift
+++ b/Sources/AppcuesKit/Data/Models/Event.swift
@@ -33,7 +33,7 @@ internal struct Event {
     }
 
     init(screen screenTitle: String, attributes: [String: Any]? = nil, context: [String: Any]? = nil, logger: Logging = OSLog.disabled) {
-        name = "appcues:screen_view"
+        name = Events.Screen.screenView.rawValue
         timestamp = Date()
 
         var extendedAttributes = attributes ?? [:]

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceRenderer.swift
@@ -378,7 +378,7 @@ internal class ExperienceRenderer: ExperienceRendering, StateMachineOwning {
         }
 
         analyticsPublisher.publish(TrackingUpdate(
-            type: .event(name: "appcues:experiment_entered", interactive: false),
+            type: .event(name: Events.Experiment.experimentEntered.rawValue, interactive: false),
             properties: [
                 "experimentId": experiment.experimentID.appcuesFormatted,
                 "experimentGroup": experiment.group,


### PR DESCRIPTION
We occasionally get asked for a list of all the appcues events that the sdk generates. The `Events` enum was an almost complete list so I've made it complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes event name usage via enums for consistency and type safety.
> 
> - Adds `Events.Screen` and `Events.Experiment` enums with `screenView` and `experimentEntered`
> - Refactors `Event.init(screen:)` to use `Events.Screen.screenView`
> - Refactors experiment tracking in `ExperienceRenderer` to use `Events.Experiment.experimentEntered`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bacfe0167a1bc384a5a5297afb69dd9bb127e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->