### PR TITLE
Add docs for configuring hosting environment

### DIFF
--- a/Sources/AppcuesKit/AppcuesKit.docc/GettingStarted.md
+++ b/Sources/AppcuesKit/AppcuesKit.docc/GettingStarted.md
@@ -49,3 +49,16 @@ Add ``AppcuesFrameView`` instances in your application layouts to support embedd
 
 See <doc:URLSchemeConfiguring> for setup instructions and then refer to <doc:Debugging> for usage details.
 
+## Configuring Hosting Environment
+
+By default, the Appcues SDK will send data to the United States (US) hosting environment, and no additional configuration is required. To specify a different hosting environment, use ``Appcues/Config/apiHost(_:)`` and ``Appcues/Config/settingsHost(_:)``.
+
+### EU Hosting Environment Configuration
+
+To send data to the European Union (EU) hosting environment, use the following configuration when initializing the SDK:
+
+```swift
+let appcuesConfig = Appcues.Config(accountID: <#APPCUES_ACCOUNT_ID#>, applicationID: <#APPCUES_APPLICATION_ID#>)
+    .apiHost(URL(string: "https://api.eu.appcues.net")!)
+    .settingsHost(URL(string: "https://fast.eu.appcues.com")!)
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new "Configuring Hosting Environment" section to `GettingStarted.md`.
> 
> - Documents default US routing and how to override via `Appcues/Config.apiHost(_:)` and `Appcues/Config.settingsHost(_:)`
> - Provides a Swift snippet for configuring the EU environment (`https://api.eu.appcues.net` and `https://fast.eu.appcues.com`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d8aaf8f48bd6f71883430784d8bb9732076be74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->