### PR TITLE
Update view styling ViewModifiers

### DIFF
--- a/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
+++ b/Sources/AppcuesKit/Presentation/Extensions/View+Appcues.swift
@@ -29,8 +29,17 @@ extension View {
             }
     }
 
-    func applyForegroundStyle(_ style: AppcuesStyle) -> some View {
-        self
+    func applyAllAppcues(_ style: AppcuesStyle) -> some View {
+        modifier(AppcuesAllStylesModifier(style: style))
+    }
+}
+
+@available(iOS 13.0, *)
+internal struct AppcuesForegroundStyleModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
+        content
             .ifLet(style.font) { view, val in
                 view.font(val)
             }
@@ -41,9 +50,14 @@ extension View {
                 view.foregroundColor(val)
             }
     }
+}
 
-    func applyInternalLayout(_ style: AppcuesStyle) -> some View {
-        self
+@available(iOS 13.0, *)
+internal struct AppcuesInternalLayoutModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
+        content
             .padding(style.padding)
             .frame(width: style.width, height: style.height)
             .if(style.fillWidth) { view in
@@ -54,9 +68,14 @@ extension View {
             // sized frame is being used
             .padding(style.borderInset * -1)
     }
+}
 
-    func applyBackgroundStyle(_ style: AppcuesStyle) -> some View {
-        self
+@available(iOS 13.0, *)
+internal struct AppcuesBackgroundStyleModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
+        content
             // Order for the backgrounds matters. Images > Gradients > Color.
             .ifLet(style.backgroundImage) { view, val in
                 let model = ExperienceComponent.ImageModel(from: val)
@@ -87,9 +106,14 @@ extension View {
                 }
             }
     }
+}
 
-    func applyBorderStyle(_ style: AppcuesStyle) -> some View {
-        self
+@available(iOS 13.0, *)
+internal struct AppcuesBorderStyleModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
+        content
             .ifLet(style.borderColor, style.borderWidth) { view, color, width in
                 view
                     // The border should account for space in the layout, not just be an overlay.
@@ -105,19 +129,29 @@ extension View {
                             // half of the width is outside the view bounds. Add padding for that to
                             // ensure the border never gets half cropped out.
                             .padding(width / 2)
-                )
+                    )
             }
     }
+}
 
-    func applyCornerRadius(_ style: AppcuesStyle) -> some View {
-        self
+@available(iOS 13.0, *)
+internal struct AppcuesCornerRadiusModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
+        content
             .ifLet(style.cornerRadius) { view, val in
                 view.cornerRadius(val)
             }
     }
+}
 
-    func applyShadow(_ style: AppcuesStyle) -> some View {
-        self
+@available(iOS 13.0, *)
+internal struct AppcuesShadowModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
+        content
             .ifLet(style.shadow) { view, val in
                 view.shadow(
                     color: Color(dynamicColor: val.color) ?? Color(.sRGBLinear, white: 0, opacity: 0.33),
@@ -127,23 +161,33 @@ extension View {
                 )
             }
     }
+}
 
-    func applyExternalLayout(_ style: AppcuesStyle) -> some View {
-        self
+@available(iOS 13.0, *)
+internal struct AppcuesExternalLayoutModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
+        content
             .padding(style.margin)
     }
+}
 
-    func applyAllAppcues(_ style: AppcuesStyle) -> some View {
+@available(iOS 13.0, *)
+internal struct AppcuesAllStylesModifier: ViewModifier {
+    let style: AppcuesStyle
+
+    func body(content: Content) -> some View {
         // Using `AnyView` here drastically improves memory and CPU usage
         AnyView(
-            self
-                .applyForegroundStyle(style)
-                .applyInternalLayout(style)
-                .applyBorderStyle(style)
-                .applyBackgroundStyle(style)
-                .applyCornerRadius(style) // needs to be after border and background
-                .applyShadow(style)
-                .applyExternalLayout(style)
+            content
+                .modifier(AppcuesForegroundStyleModifier(style: style))
+                .modifier(AppcuesInternalLayoutModifier(style: style))
+                .modifier(AppcuesBorderStyleModifier(style: style))
+                .modifier(AppcuesBackgroundStyleModifier(style: style))
+                .modifier(AppcuesCornerRadiusModifier(style: style)) // needs to be after border and background
+                .modifier(AppcuesShadowModifier(style: style))
+                .modifier(AppcuesExternalLayoutModifier(style: style))
         )
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesButton.swift
@@ -35,14 +35,14 @@ internal struct AppcuesButton: View {
                 }
                 // Applying the Button padding and frame to the label ensures the proper button highlight effect
                 // on touchDown everywhere within the button frame.
-                .applyInternalLayout(style)
+                .modifier(AppcuesInternalLayoutModifier(style: style))
         }
-        .applyForegroundStyle(style)
-        .applyBorderStyle(style)
-        .applyBackgroundStyle(style)
-        .applyCornerRadius(style)
-        .applyShadow(style)
-        .applyExternalLayout(style)
+        .modifier(AppcuesForegroundStyleModifier(style: style))
+        .modifier(AppcuesBorderStyleModifier(style: style))
+        .modifier(AppcuesBackgroundStyleModifier(style: style))
+        .modifier(AppcuesCornerRadiusModifier(style: style))
+        .modifier(AppcuesShadowModifier(style: style))
+        .modifier(AppcuesExternalLayoutModifier(style: style))
         .setupActions(on: viewModel, for: model)
     }
 }

--- a/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
+++ b/Sources/AppcuesKit/Presentation/UI/Components/AppcuesImage.swift
@@ -30,20 +30,20 @@ internal struct AppcuesImage: View {
             // allocate space for any border that will be applied below
             .padding(style.borderInset)
             .setupActions(on: viewModel, for: model)
-            .applyForegroundStyle(style)
+            .modifier(AppcuesForegroundStyleModifier(style: style))
             // set the aspect ratio before applying frame sizing
             .ifLet(ContentMode(string: model.contentMode)) { view, val in
                 view.aspectRatio(model.intrinsicSize?.aspectRatio, contentMode: val)
             }
-            .applyInternalLayout(style)
+            .modifier(AppcuesInternalLayoutModifier(style: style))
 
             // clip before adding shadows
             .clipped()
-            .applyBorderStyle(style)
-            .applyBackgroundStyle(style)
-            .applyCornerRadius(style)
-            .applyShadow(style)
-            .applyExternalLayout(style)
+            .modifier(AppcuesBorderStyleModifier(style: style))
+            .modifier(AppcuesBackgroundStyleModifier(style: style))
+            .modifier(AppcuesCornerRadiusModifier(style: style))
+            .modifier(AppcuesShadowModifier(style: style))
+            .modifier(AppcuesExternalLayoutModifier(style: style))
     }
 
     internal init(model: ExperienceComponent.ImageModel) {


### PR DESCRIPTION
As #615 notes, Xcode 26.4 (RC) has a build error specifically when creating a build archive. Building and running works fine. Also, removing `AppcuesButton` from the equation results in a (much) longer compile error:

```
Abort: function substOpaqueTypesWithUnderlyingTypes at SubstitutionMap.cpp:651
Possible non-terminating type substitution detected
...
```

Debugging showed the issue was with the quantity of our view extensions. Converting just one to a ViewModifier was enough to fix the error. I've converted all to ViewModifiers for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a SwiftUI refactor, but it changes how core style concerns (layout/background/border/shadow) are applied across components, so subtle visual/layout regressions are possible.
> 
> **Overview**
> Refactors Appcues SwiftUI styling from chained `View` extension helpers into dedicated `ViewModifier`s (foreground, internal/external layout, background, border, corner radius, shadow) and updates `applyAllAppcues` to apply them via a single `AppcuesAllStylesModifier`.
> 
> Updates `AppcuesButton` and `AppcuesImage` to use the new modifiers directly, aiming to reduce compiler/type-substitution complexity (notably for archive builds) while keeping the same modifier ordering semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 241a55dddb1a1a22605c9118696a3c13fd89bbef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->