### PR TITLE
Specify openSSL version to fix build issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source "https://rubygems.org"
 gem "fastlane", "2.232.1"
 gem "cocoapods", "1.16.2"
 gem "slather", "2.8.5"
+
+# https://github.com/fastlane/fastlane/issues/29710
+gem "openssl", ">= 3.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
+    openssl (4.0.1)
     optparse (0.8.1)
     os (1.1.4)
     ostruct (0.6.3)
@@ -326,6 +327,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.16.2)
   fastlane (= 2.232.1)
+  openssl (>= 3.3.1)
   slather (= 2.8.5)
 
 BUNDLED WITH


### PR DESCRIPTION
Was [hitting](https://app.circleci.com/pipelines/github/appcues/appcues-ios-sdk/2923/workflows/53e2b271-e3a5-4a8c-aa13-076652e0c9aa/jobs/4332/parallel-runs/0/steps/0-110) a build failure on the example app deploy. Turns out it's openSSL related.

```
ERROR [2026-03-25 13:12:31.67]: SSL_connect returned=1 errno=0 peeraddr=xx.xx.xxx.xxx:xxx state=error: certificate verify failed (unable to get certificate CRL)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Ruby tooling dependencies by explicitly requiring a newer `openssl` gem; no app/runtime code changes. Main risk is CI/build environment incompatibility if the new OpenSSL gem version behaves differently on some platforms.
> 
> **Overview**
> Adds an explicit `openssl` dependency (`>= 3.3.1`) to the `Gemfile` (with a reference to fastlane issue #29710) to address SSL/certificate verification failures in CI.
> 
> Updates `Gemfile.lock` to include `openssl` (resolved to `4.0.1`) and list it under `DEPENDENCIES` so bundler consistently installs the newer OpenSSL gem.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61baa288445bb698ff459eb668a8a8498d169161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->