### PR TITLE
Fix tab bar auto tag

### DIFF
--- a/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
+++ b/Sources/AppcuesKit/Presentation/Debugger/ScreenCapturing/UIKitElementTargeting.swift
@@ -196,7 +196,8 @@ internal extension UIView {
                 // discard hidden views and subviews within
                 guard !subview.isHidden else { return nil }
                 var childTabIndex: Int?
-                if subview.displayType == "UITabBarButton" {
+                // iOS 26.1+ uses duplicated _UITabButton in the same coordinates, so we filter down to one
+                if subview.displayType == "UITabBarButton" || (subview.displayType == "_UITabButton" && self.displayType != "SelectedContentView") {
                     tabCount += 1
                     childTabIndex = tabCount - 1
                 }


### PR DESCRIPTION
iOS 26.1 changed the structure so we need to look for `_UITabButton` now too. And it has duplicate `_UITabButton` for the selected and unselected states, so we need to skip one. It doesn't really matter since the frames are the same, so I chose to skip the Selected.

For reference, the structure is:

```json
{
  "type": "UITabBar",
  "height": 49,
  "width": 402,
  "x": 0,
  "y": 791,
  "children": [
    {
      "type": "_UITabBarPlatterView",
      "height": 49,
      "width": 360,
      "x": 21,
      "y": 791,
      "children": [
        {
          "type": "SelectedContentView",
          "height": 49,
          "width": 360,
          "x": 21,
          "y": 791,
          "children": [
            {
              "type": "_UITabButton",
              "displayName": "tab[0]",
              "selector": {
                "autoTag": "tab[0]"
              },
              "height": 45,
              "width": 95,
              "x": 25,
              "y": 795,
              "children": [...]
            },
            // more tabs
          ]
        },
        {...},
        {
          "type": "ContentView",
          "height": 49,
          "width": 360,
          "x": 21,
          "y": 791,
          "children": [
            {
              "type": "_UITabButton",
              "displayName": "tab[0]",
              "selector": {
                "autoTag": "tab[0]"
              },
              "height": 45,
              "width": 95,
              "x": 25,
              "y": 795,
              "children": [...]
            },
            // more tabs
          ]
        },
        ...
      ]
    }
  ]
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, narrowly scoped to tab bar view traversal for generating `autoTag`s; main risk is mis-numbering tabs on iOS 26.1+ if the filtering heuristic misses an edge case.
> 
> **Overview**
> Fixes tab bar `autoTag` generation on iOS 26.1+ by treating `_UITabButton` as a tab button type and **filtering out the duplicated selected-state button** (skipping those under `SelectedContentView`) so tab indices don’t double-count during UIView hierarchy capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0fdbfeb243a0c15fed7d32484a6bcdc910cbc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->