### PR TITLE
Add campaign and tactic details to experience analytics

### DIFF
--- a/Sources/AppcuesKit/Data/Models/Experience.swift
+++ b/Sources/AppcuesKit/Data/Models/Experience.swift
@@ -35,6 +35,8 @@ internal struct FailedExperience: Decodable {
     let type: String?
     let publishedAt: Int?
     let context: Experience.Context?
+    let campaignId: String?
+    let tacticId: String?
     var error: String?
 
     // This is a synthetically generated Experience from the known values of the FailedExperience that
@@ -47,6 +49,8 @@ internal struct FailedExperience: Decodable {
             type: type ?? "",
             publishedAt: publishedAt,
             context: context,
+            campaignId: campaignId,
+            tacticId: tacticId,
             traits: [],
             steps: [],
             redirectURL: nil,
@@ -146,6 +150,8 @@ internal struct Experience {
     // a millisecond timestamp
     let publishedAt: Int?
     let context: Context?
+    let campaignId: String?
+    let tacticId: String?
     // tags, theme, actions
     // TODO: Handle experience-level actions
     let traits: [Trait]
@@ -168,6 +174,8 @@ extension Experience: Decodable {
         case type
         case publishedAt
         case context
+        case campaignId
+        case tacticId
         case traits
         case steps
         case redirectURL = "redirectUrl"
@@ -181,6 +189,8 @@ extension Experience: Decodable {
         type = try container.decode(String.self, forKey: .type)
         publishedAt = try? container.decode(Int.self, forKey: .publishedAt)
         context = try? container.decodeIfPresent(Context.self, forKey: .context)
+        campaignId = try? container.decodeIfPresent(String.self, forKey: .campaignId)
+        tacticId = try? container.decodeIfPresent(String.self, forKey: .tacticId)
         traits = try container.decode(TraitCollection.self, forKey: .traits).traits
         steps = try container.decode([Step].self, forKey: .steps)
         redirectURL = try? container.decode(URL.self, forKey: .redirectURL)
@@ -194,30 +204,6 @@ extension Experience: Decodable {
             renderContext = .embed(frameID: config.frameID)
         } else {
             renderContext = .modal
-        }
-    }
-}
-
-extension Experience {
-    /// Returns a function that creates the post experience actions given an ``Appcues`` instance.
-    @available(iOS 13.0, *)
-    var postExperienceActionFactory: ((Appcues?) -> [AppcuesExperienceAction]) {
-        return { appcues in
-            var actions: [AppcuesExperienceAction] = []
-
-            if let redirectURL = redirectURL {
-                actions.append(AppcuesLinkAction(appcues: appcues, url: redirectURL))
-            }
-
-            if let nextContentID = nextContentID {
-                actions.append(AppcuesLaunchExperienceAction(
-                    appcues: appcues,
-                    experienceID: nextContentID,
-                    trigger: .experienceCompletionAction(fromExperienceID: self.id)
-                ))
-            }
-
-            return actions
         }
     }
 }

--- a/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
+++ b/Sources/AppcuesKit/Presentation/Actions/Appcues/AppcuesLaunchExperienceAction.swift
@@ -27,11 +27,14 @@ internal class AppcuesLaunchExperienceAction: AppcuesExperienceAction {
         guard let config = configuration.decode(Config.self) else { return nil }
         self.experienceID = config.experienceID
 
-        // Trigger is the current experienceID
         let renderContext = configuration.renderContext
         let experienceRendering = appcues?.container.resolve(ExperienceRendering.self)
-        let currentExperienceID = experienceRendering?.experienceData(forContext: renderContext)?.id
-        self.trigger = .launchExperienceAction(fromExperienceID: currentExperienceID)
+        let currentExperience = experienceRendering?.experienceData(forContext: renderContext)
+        self.trigger = .launchExperienceAction(
+            fromExperienceID: currentExperience?.id,
+            campaignId: currentExperience?.campaignId,
+            tacticId: currentExperience?.tacticId
+        )
     }
 
     init(appcues: Appcues?, experienceID: String, trigger: ExperienceTrigger) {

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/Dictionary+ExperienceProperties.swift
@@ -28,8 +28,8 @@ extension Dictionary where Key == String, Value == Any {
         }
 
         switch experience.trigger {
-        case let .launchExperienceAction(experienceID),
-            let .experienceCompletionAction(experienceID):
+        case .launchExperienceAction(let experienceID, _, _),
+             .experienceCompletionAction(let experienceID, _, _):
             properties["fromExperienceId"] = experienceID?.appcuesFormatted
         case let .pushNotification(notificationID):
             properties["pushNotificationId"] = notificationID
@@ -51,6 +51,14 @@ extension Dictionary where Key == String, Value == Any {
 
         if let workflowTaskId = experience.context?.workflowTaskId {
             properties["workflowTaskId"] = workflowTaskId
+        }
+
+        if let campaignId = experience.campaignId {
+            properties["campaignId"] = campaignId
+        }
+
+        if let tacticId = experience.tacticId {
+            properties["tacticId"] = tacticId
         }
 
         // frameID is added primarily for use by the debugger

--- a/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
+++ b/Sources/AppcuesKit/Presentation/ExperienceRendering/ExperienceTrigger.swift
@@ -10,8 +10,8 @@ import Foundation
 
 internal enum ExperienceTrigger: Equatable {
     case qualification(reason: QualifyResponse.QualificationReason?)
-    case experienceCompletionAction(fromExperienceID: UUID?)
-    case launchExperienceAction(fromExperienceID: UUID?)
+    case experienceCompletionAction(fromExperienceID: UUID?, campaignId: String? = nil, tacticId: String? = nil)
+    case launchExperienceAction(fromExperienceID: UUID?, campaignId: String? = nil, tacticId: String? = nil)
     case pushNotification(notificationID: String)
     case showCall
     case deepLink

--- a/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
+++ b/Sources/AppcuesKit/Presentation/UI/ExperienceData.swift
@@ -75,6 +75,57 @@ internal class ExperienceData {
         )
     }
 
+    var campaignId: String? {
+        switch trigger {
+        case .launchExperienceAction(_, let campaignId, _),
+             .experienceCompletionAction(_, let campaignId, _):
+            return campaignId
+        default:
+            return model.campaignId
+        }
+    }
+
+    var tacticId: String? {
+        switch trigger {
+        case .launchExperienceAction(_, _, let tacticId),
+             .experienceCompletionAction(_, _, let tacticId):
+            return tacticId
+        default:
+            return model.tacticId
+        }
+    }
+
+    @available(iOS 13.0, *)
+    var postExperienceActionFactory: ((Appcues?) -> [AppcuesExperienceAction]) {
+        let effectiveCampaignId = campaignId
+        let effectiveTacticId = tacticId
+        let experienceId = model.id
+        let redirectURL = model.redirectURL
+        let nextContentID = model.nextContentID
+
+        return { appcues in
+            var actions: [AppcuesExperienceAction] = []
+
+            if let redirectURL = redirectURL {
+                actions.append(AppcuesLinkAction(appcues: appcues, url: redirectURL))
+            }
+
+            if let nextContentID = nextContentID {
+                actions.append(AppcuesLaunchExperienceAction(
+                    appcues: appcues,
+                    experienceID: nextContentID,
+                    trigger: .experienceCompletionAction(
+                        fromExperienceID: experienceId,
+                        campaignId: effectiveCampaignId,
+                        tacticId: effectiveTacticId
+                    )
+                ))
+            }
+
+            return actions
+        }
+    }
+
     subscript<T>(dynamicMember keyPath: KeyPath<Experience, T>) -> T {
         return model[keyPath: keyPath]
     }

--- a/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
+++ b/Tests/AppcuesKitTests/Analytics/ActivityProcessorTests.swift
@@ -371,7 +371,7 @@ class ActivityProcessorTests: XCTestCase {
         )
     }
 
-    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, context: nil, traits: [], steps: [], redirectURL: nil, nextContentID: nil, renderContext: .modal)
+    private let mockExperience = Experience(id: UUID(), name: "test_experience", type: "mobile", publishedAt: 1632142800000, context: nil, campaignId: nil, tacticId: nil, traits: [], steps: [], redirectURL: nil, nextContentID: nil, renderContext: .modal)
 
 }
 

--- a/Tests/AppcuesKitTests/Experiences/EmbedExperienceRendererTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/EmbedExperienceRendererTests.swift
@@ -255,6 +255,8 @@ extension Experience {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [],
             steps: [
                 Experience.Step(

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachine+AnalyticsObserverTests.swift
@@ -127,6 +127,78 @@ class ExperienceStateMachine_AnalyticsObserverTests: XCTestCase {
         ].verifyPropertiesMatch(lastUpdate.properties)
     }
 
+    func testEvaluateRenderingFirstStepStateFromCampaign() throws {
+        // Act
+        let experience = ExperienceData(.mockFromCampaign, trigger: .showCall)
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(experience, .initial, experience.package(), isFirst: true)))
+
+        // Assert
+        XCTAssertFalse(isCompleted)
+        XCTAssertEqual(updates.count, 2)
+        let lastUpdate = try XCTUnwrap(updates.last)
+        XCTAssertEqual(lastUpdate.type, .event(name: "appcues:v2:step_seen", interactive: false))
+        [
+            "experienceName": "Single step experience",
+            "experienceId": "54b7ec71-cdaf-4697-affa-f3abd672b3cf",
+            "experienceInstanceId": experience.instanceID.appcuesFormatted,
+            "version": 1632142800000,
+            "experienceType": "mobile",
+            "trigger": "show_call",
+            "localeName": "English",
+            "localeId": "en",
+            "campaignId": "campaign-123",
+            "tacticId": "tactic-456",
+            "stepType": "modal",
+            "stepId": "e03ae132-91b7-4cb0-9474-7d4a0e308a07",
+            "stepIndex": "0,0"
+        ].verifyPropertiesMatch(lastUpdate.properties)
+    }
+
+    func testEvaluateRenderingFirstStepStatePropagatesCampaignFromParent() throws {
+        // A child experience triggered by a parent should inherit the parent's campaign/tactic IDs,
+        // ignoring any values from the child's own API response.
+        let experience = ExperienceData(
+            .mock,
+            trigger: .launchExperienceAction(
+                fromExperienceID: UUID(),
+                campaignId: "parent-campaign",
+                tacticId: "parent-tactic"
+            )
+        )
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(experience, .initial, experience.package(), isFirst: true)))
+
+        // Assert
+        XCTAssertFalse(isCompleted)
+        XCTAssertEqual(updates.count, 2)
+        let lastUpdate = try XCTUnwrap(updates.last)
+
+        // Campaign IDs from the trigger (parent) should be used
+        XCTAssertEqual(lastUpdate.properties?["campaignId"] as? String, "parent-campaign")
+        XCTAssertEqual(lastUpdate.properties?["tacticId"] as? String, "parent-tactic")
+    }
+
+    func testEvaluateRenderingFirstStepStateNoCampaignWhenParentHasNone() throws {
+        // When the parent has no campaign IDs, the child should not report any either,
+        // even if the child's API response included them.
+        let experience = ExperienceData(
+            .mockFromCampaign, // has campaignId/tacticId on the model
+            trigger: .launchExperienceAction(
+                fromExperienceID: UUID(),
+                campaignId: nil,
+                tacticId: nil
+            )
+        )
+        let isCompleted = observer.evaluateIfSatisfied(result: .success(.renderingStep(experience, .initial, experience.package(), isFirst: true)))
+
+        // Assert
+        XCTAssertFalse(isCompleted)
+        let lastUpdate = try XCTUnwrap(updates.last)
+
+        // Campaign IDs should be absent (parent had none)
+        XCTAssertNil(lastUpdate.properties?["campaignId"])
+        XCTAssertNil(lastUpdate.properties?["tacticId"])
+    }
+
     func testEvaluateRenderingStepState() throws {
         // Act
         let experience = ExperienceData.mock

--- a/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
+++ b/Tests/AppcuesKitTests/Experiences/ExperienceStateMachineTests.swift
@@ -511,7 +511,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsIdling_whenStartExperienceWithNoSteps_noTransition() throws {
         // Arrange
-        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, context: nil, traits: [], steps: [], redirectURL: nil, nextContentID: nil, renderContext: .modal)
+        let experience = Experience(id: UUID(), name: "Empty experience", type: "mobile", publishedAt: 1632142800000, context: nil, campaignId: nil, tacticId: nil, traits: [], steps: [], redirectURL: nil, nextContentID: nil, renderContext: .modal)
         let initialState: State = .idling
         let action: Action = .startExperience(ExperienceData(experience, trigger: .showCall))
         let stateMachine = givenState(is: initialState)
@@ -525,7 +525,7 @@ class ExperienceStateMachineTests: XCTestCase {
 
     func test_stateIsIdling_whenStartFailedExperience_noTransition() throws {
         // Arrange
-        let failedExperience = FailedExperience(id: UUID(), name: "Invalid experience", type: "mobile", publishedAt: 1632142800000, context: nil, error: "could not decode")
+        let failedExperience = FailedExperience(id: UUID(), name: "Invalid experience", type: "mobile", publishedAt: 1632142800000, context: nil, campaignId: nil, tacticId: nil, error: "could not decode")
         let initialState: State = .idling
         let experienceData = ExperienceData(failedExperience.skeletonExperience, trigger: .showCall, error: failedExperience.error)
         let action: Action = .startExperience(experienceData)

--- a/Tests/AppcuesKitTests/Mocks.swift
+++ b/Tests/AppcuesKitTests/Mocks.swift
@@ -60,6 +60,8 @@ extension Experience {
                 workflowId: nil,
                 workflowTaskId: nil
             ),
+            campaignId: nil,
+            tacticId: nil,
             traits: [],
             steps: [
                 Experience.Step(
@@ -91,6 +93,36 @@ extension Experience {
                 workflowId: "c2e376fb-f7ba-4d0c-bf87-1c7cfd1f5a94",
                 workflowTaskId: "b16d3d86-9299-4bcd-9a04-e2a18d9c9a33"
             ),
+            campaignId: nil,
+            tacticId: nil,
+            traits: [],
+            steps: [
+                Experience.Step(
+                    fixedID: "fb529214-3c78-4d6d-ba93-b55d22497ca1",
+                    children: [
+                        Step.Child(fixedID: "e03ae132-91b7-4cb0-9474-7d4a0e308a07"),
+                    ]
+                )
+            ],
+            redirectURL: nil,
+            nextContentID: nil,
+            renderContext: .modal)
+    }
+
+    static var mockFromCampaign: Experience {
+        Experience(
+            id: UUID(uuidString: "54b7ec71-cdaf-4697-affa-f3abd672b3cf")!,
+            name: "Single step experience",
+            type: "mobile",
+            publishedAt: 1632142800000,
+            context: Context(
+                localeId: "en",
+                localeName: "English",
+                workflowId: nil,
+                workflowTaskId: nil
+            ),
+            campaignId: "campaign-123",
+            tacticId: "tactic-456",
             traits: [],
             steps: [
                 Experience.Step(
@@ -112,6 +144,8 @@ extension Experience {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [],
             steps: [
                 Experience.Step(
@@ -133,6 +167,8 @@ extension Experience {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [],
             steps: [
                 Experience.Step(
@@ -154,6 +190,8 @@ extension Experience {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [],
             steps: [
                 Experience.Step(

--- a/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
+++ b/Tests/AppcuesKitTests/Traits/TraitComposerTests.swift
@@ -40,6 +40,8 @@ class TraitComposerTests: XCTestCase {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [
                 Experience.Trait(
                     type: "@test/presenting",
@@ -197,6 +199,8 @@ class TraitComposerTests: XCTestCase {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [
                 Experience.Trait(
                     type: "@test/presenting",
@@ -301,6 +305,8 @@ class TraitComposerTests: XCTestCase {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [
                 Experience.Trait(
                     type: "@test/presenting",
@@ -342,6 +348,8 @@ class TraitComposerTests: XCTestCase {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [],
             steps: [
                 .group(Experience.Step.Group(
@@ -449,6 +457,8 @@ class TraitComposerTests: XCTestCase {
             type: "mobile",
             publishedAt: 1632142800000,
             context: nil,
+            campaignId: nil,
+            tacticId: nil,
             traits: [],
             steps: [
                 .group(Experience.Step.Group(


### PR DESCRIPTION
Read `campaignId` and `tacticId` from the experience API response and include them on all analytics events fired for that experience.

When one experience triggers another via `@appcues/launch-experience` or a completion action, the parent experience's campaign/tactic IDs propagate to the child, overriding any IDs from the child's API response. This propagation carries through the full chain of triggered experiences.

### Changes:

- Added `campaignId` and `tacticId` properties to `Experience`
- Added computed `campaignId`/`tacticId` on `ExperienceData` that resolve effective IDs from the trigger (for chained experiences) or fall back to the model
- Updated `ExperienceTrigger` to carry campaign/tactic IDs on `.launchExperienceAction` and `.experienceCompletionAction`
- Updated `AppcuesLaunchExperienceAction` to forward the parent's effective IDs
- Included `campaignId`/`tacticId` in analytics event properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experiences now track and preserve campaign and tactic identifiers throughout the experience flow
  * Analytics events include campaign and tactic context information

* **Improvements**
  * Campaign and tactic information is now properly carried when launching experiences from other experiences, improving attribution tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->